### PR TITLE
Consolidate test-harness fixes: rounds 7-19 (13 PRs, 16 commits)

### DIFF
--- a/plugin/commands/translate-id.md
+++ b/plugin/commands/translate-id.md
@@ -37,7 +37,7 @@ or pick gene by default and note the assumption.
 ### 2. Pick the resolver
 
 For genes/proteins:
-- HGNC symbol → all → `tu run mygene_query_genes '{"q":"<symbol>","species":"human"}'`
+- HGNC symbol → all → `tu run MyGene_query_genes '{"query":"<symbol>","species":"human"}'`
   (returns Ensembl, UniProt, RefSeq, NCBI Gene, MGI in one call)
 - Ensembl ID → all → `tu run ensembl_lookup_gene '{"gene_id":"<id>"}'`
 - UniProt → gene/Ensembl → `tu run UniProt_search '{"query":"<accession>","limit":1}'`

--- a/src/tooluniverse/aging_cohort_tool.py
+++ b/src/tooluniverse/aging_cohort_tool.py
@@ -8,6 +8,7 @@ No external API calls -- uses an internal curated database. Cohort metadata
 changes rarely (study design, variables, and access methods are stable).
 """
 
+import math
 from typing import Dict, Any, List
 from .base_tool import BaseTool
 from .tool_registry import register_tool
@@ -1258,6 +1259,24 @@ def _token_match_count(text: str, tokens: list[str]) -> int:
     return sum(1 for tok in tokens if tok in lower)
 
 
+# Words that carry little discriminating signal for this registry: nearly
+# every cohort's text contains "study" (it's in most full_names) and
+# "biomarkers" (it's a listed variable category for most cohorts), so
+# counting them toward the match threshold makes almost any multi-word
+# query -- including nonsense ones -- match nearly the whole registry.
+_LOW_SIGNAL_TOKENS = {
+    "a", "an", "the", "of", "in", "on", "and", "or", "with", "for", "to",
+    "by", "at", "study", "studies", "data", "cohort", "cohorts", "research",
+    "biomarker", "biomarkers",
+}
+
+
+def _meaningful_tokens(tokens: list[str]) -> list[str]:
+    """Drop low-signal tokens unless doing so would empty the query."""
+    filtered = [t for t in tokens if t not in _LOW_SIGNAL_TOKENS and len(t) > 2]
+    return filtered or tokens
+
+
 def _cohort_searchable_text(c: Dict[str, Any]) -> str:
     """Build a single searchable string from all cohort fields."""
     parts = [
@@ -1299,14 +1318,21 @@ class AgingCohortSearchTool(BaseTool):
                 "retryable": False,
             }
 
-        # Tokenize query -- match at least one token, rank by coverage
+        # Tokenize query and drop low-signal tokens (e.g. "study",
+        # "biomarker") that appear in nearly every cohort's text and would
+        # otherwise make almost any query -- including a nonsense one --
+        # match most of the registry. Require a majority of the remaining
+        # tokens to hit, not just one, so relevance actually tracks the
+        # query instead of any single common word.
         tokens = query.lower().split()
+        match_tokens = _meaningful_tokens(tokens)
+        min_hits = max(1, math.ceil(len(match_tokens) * 0.6))
         scored: list[tuple[int, Dict[str, Any]]] = []
 
         for cohort in _COHORTS:
             searchable = _cohort_searchable_text(cohort)
-            hits = _token_match_count(searchable, tokens)
-            if hits == 0:
+            hits = _token_match_count(searchable, match_tokens)
+            if hits < min_hits:
                 continue
 
             # --- Optional filters ---

--- a/src/tooluniverse/base_tool.py
+++ b/src/tooluniverse/base_tool.py
@@ -233,6 +233,34 @@ class BaseTool:
         )
         return norm_to_key[match[0]] if match else None
 
+    @classmethod
+    def _best_property_match(
+        cls, supplied_key: str, unset_props: list
+    ) -> Optional[str]:
+        """The inverse of ``_find_misspelled_key``: given one supplied key
+        that isn't a schema property, find which *unset* property it was
+        probably meant to be. Used when there are few unknown keys but many
+        optional schema properties (a filter-heavy search endpoint), so the
+        fuzzy match runs once per supplied key instead of once per schema
+        property."""
+        if not unset_props:
+            return None
+        target = supplied_key.lower()
+        for prop in unset_props:
+            if prop.lower() == target:
+                return prop
+        target_norm = cls._normalize_key(supplied_key)
+        for prop in unset_props:
+            if cls._normalize_key(prop) == target_norm:
+                return prop
+        import difflib
+
+        norm_to_prop = {cls._normalize_key(p): p for p in unset_props}
+        match = difflib.get_close_matches(
+            target_norm, list(norm_to_prop), n=1, cutoff=0.8
+        )
+        return norm_to_prop[match[0]] if match else None
+
     def validate_parameters(self, arguments: Dict[str, Any]) -> Optional[ToolError]:
         """
         Validate parameters against tool schema.
@@ -268,6 +296,71 @@ class BaseTool:
             }
 
             jsonschema.validate(filtered_arguments, schema)
+
+            # Feature-14A-01 / Feature-14B-01: jsonschema only rejects an
+            # unknown key when it causes a *required* property to end up
+            # missing. A tool whose schema has no required properties (a
+            # common "all filters optional" search endpoint) silently drops
+            # a misnamed parameter and falls back to its unfiltered default
+            # result -- which still looks like a relevant "success"
+            # response. Confirmed live two ways:
+            #  - ChEMBL_search_drugs({"drug_name": "baricitinib"}) returned
+            #    status=success with 20 unrelated drugs (its default page)
+            #    because the schema's only search parameter is "query", not
+            #    "drug_name" -- every supplied key was unrecognized.
+            #  - OpenTargets_get_evidence_by_datasource({"efoId": ...,
+            #    "ensemblId": ..., "datasourceId": "bogus"}) silently
+            #    ignored the singular "datasourceId" (real param is plural
+            #    "datasourceIds") and returned unfiltered evidence rows,
+            #    even though efoId/ensemblId were valid and recognized.
+            # Two checks, in order of confidence:
+            #  1. A near-miss of an *unset* schema property (same fuzzy
+            #     logic as the required-property "did you mean?" hint below)
+            #     is flagged regardless of what else was supplied -- it's a
+            #     typo, not intentional extra context.
+            #  2. If nothing was recognized at all, the whole parameter set
+            #     is almost certainly wrong even without a fuzzy near-miss.
+            # A caller mixing one valid key with an unrelated extra key
+            # (no near-miss, not a total mismatch) is left alone -- lower
+            # risk of being a genuine mistake, and flagging it risks
+            # rejecting legitimate pass-through/forward-compatible callers.
+            properties = schema.get("properties", {})
+            if properties and filtered_arguments:
+                unknown = self._unknown_keys(filtered_arguments, properties)
+                if unknown:
+                    unset_props = [p for p in properties if p not in filtered_arguments]
+                    # Match each *unknown supplied key* (typically 1-2) against
+                    # the unset schema properties (can be 30+ for a
+                    # filter-heavy endpoint), rather than the reverse -- same
+                    # result, but O(unknown) fuzzy-match calls instead of
+                    # O(unset schema properties).
+                    hints = [
+                        (key, match)
+                        for key in unknown
+                        if (match := self._best_property_match(key, unset_props))
+                        is not None
+                    ]
+                    if hints:
+                        hint_text = "; ".join(
+                            f"'{k}' — did you mean '{p}'?" for k, p in hints
+                        )
+                        return ToolValidationError(
+                            f"Unrecognized parameter(s): {hint_text}",
+                            details={
+                                "unknown_parameters": unknown,
+                                "valid_parameters": sorted(properties),
+                            },
+                        )
+                    if len(unknown) == len(filtered_arguments):
+                        return ToolValidationError(
+                            f"Unrecognized parameter(s): "
+                            f"{', '.join(repr(k) for k in unknown)}. "
+                            f"This tool accepts: {', '.join(sorted(properties))}.",
+                            details={
+                                "unknown_parameters": unknown,
+                                "valid_parameters": sorted(properties),
+                            },
+                        )
             return None
         except jsonschema.ValidationError as e:
             # Create a more agent-friendly error message
@@ -320,6 +413,49 @@ class BaseTool:
                                 f" (unrecognized parameter(s): "
                                 f"{', '.join(repr(k) for k in unknown)})"
                             )
+
+            # Feature-14B-02: a "oneOf: [{required: [a]}, {required: [b]}, ...]"
+            # schema (pick exactly one of several alternative search
+            # parameters) produces a bare, unhelpful "is not valid under any
+            # of the given schemas" when none of the alternatives are
+            # present -- unlike a plain "required" failure, e.path is empty
+            # and e.message names no specific property, so the typo-hint
+            # logic above never runs. Confirmed live:
+            # gwas_get_associations_for_trait({"trait": "narcolepsy"}) (the
+            # schema's alternatives are disease_trait/efo_uri/efo_id/
+            # efo_trait, not "trait") gave only "{'trait': 'narcolepsy'} is
+            # not valid under any of the given schemas" with no hint that
+            # "trait" isn't even a real parameter, let alone which
+            # alternative it was probably meant to be. Collect the
+            # alternative-required property names from the oneOf branches
+            # and reuse the same fuzzy "did you mean?" match.
+            if e.validator == "oneOf" and isinstance(filtered_arguments, dict):
+                alt_props = []
+                for branch in e.validator_value or []:
+                    alt_props.extend(branch.get("required", []))
+                for alt_prop in dict.fromkeys(alt_props):  # de-dup, keep order
+                    if alt_prop in filtered_arguments:
+                        continue
+                    wrong_key = self._find_misspelled_key(
+                        alt_prop,
+                        filtered_arguments,
+                        properties=schema.get("properties", {}),
+                    )
+                    if wrong_key is not None:
+                        error_msg += (
+                            f" (you passed '{wrong_key}' — did you mean '{alt_prop}'?)"
+                        )
+                        break
+                else:
+                    unknown = self._unknown_keys(
+                        filtered_arguments, schema.get("properties", {})
+                    )
+                    if unknown:
+                        error_msg += (
+                            f" (unrecognized parameter(s): "
+                            f"{', '.join(repr(k) for k in unknown)}; "
+                            f"provide one of: {', '.join(alt_props)})"
+                        )
 
             return ToolValidationError(
                 error_msg,

--- a/src/tooluniverse/bvbrc_tool.py
+++ b/src/tooluniverse/bvbrc_tool.py
@@ -405,7 +405,17 @@ class BVBRCTool(BaseTool):
 
         limit = min(arguments.get("limit") or 25, 100)
 
+        # Fix-11C-1: BV-BRC's surveillance collection commonly holds multiple
+        # distinct records (e.g. separate lab submissions/panels) that share
+        # identical sample_identifier/collection_date/subtype values. Without
+        # a unique identifier in the response, these genuinely distinct
+        # records looked like a duplication bug (same visible fields
+        # repeated). Including sample_accession (human-readable submission
+        # accession) and id (the record's unique key) lets callers tell
+        # distinct records apart instead of appearing to be verbatim dupes.
         select_fields = [
+            "sample_accession",
+            "id",
             "sample_identifier",
             "collection_date",
             "geographic_group",

--- a/src/tooluniverse/clinvar_tool.py
+++ b/src/tooluniverse/clinvar_tool.py
@@ -259,6 +259,7 @@ class ClinVarSearchVariants(ClinVarRESTTool):
                 gene_hyphen_variant = gene.replace("-", "")
             query_parts.append(f"{gene}[gene]")
 
+        condition_dis_index = None
         if "condition" in arguments:
             # Feature-70B-005: [disease/phenotype] is not a valid ClinVar eSearch field.
             # Use [dis] (disease/phenotype) field tag for condition searches.
@@ -266,6 +267,7 @@ class ClinVarSearchVariants(ClinVarRESTTool):
             condition = arguments["condition"].strip()
             if " " in condition and not condition.startswith('"'):
                 condition = f'"{condition}"'
+            condition_dis_index = len(query_parts)
             query_parts.append(f"{condition}[dis]")
 
         if arguments.get("rsid"):
@@ -478,6 +480,36 @@ class ClinVarSearchVariants(ClinVarRESTTool):
                     result = resolved_result
                     data = result["data"]
 
+        # Fix-R9B-1: the [dis] field only matches ClinVar's own indexed
+        # disease/phenotype name for a record, which frequently differs from
+        # the name clinicians actually use -- confirmed live that
+        # "MECP2 duplication syndrome"[dis] (arguably the most natural way to
+        # refer to this exact condition) returns 0 even though ClinVar has
+        # 101+ MECP2 records that reference that phrase in free text (under
+        # its indexed name "Xq28 duplication syndrome" instead). Retry once
+        # with the condition term unrestricted to any field ([All Fields])
+        # when the [dis]-restricted search comes back empty -- this can only
+        # add matches the strict query missed, never drop ones it found.
+        if (
+            condition_dis_index is not None
+            and int(data["esearchresult"].get("count", 0)) == 0
+        ):
+            freetext_query_parts = list(query_parts)
+            # The stored term is "<condition>[dis]" -- drop the field tag to
+            # search it unrestricted instead.
+            freetext_query_parts[condition_dis_index] = query_parts[
+                condition_dis_index
+            ][: -len("[dis]")]
+            freetext_params = dict(params, term=" AND ".join(freetext_query_parts))
+            freetext_result = self._make_request(self.endpoint, freetext_params)
+            if (
+                freetext_result.get("status") == "success"
+                and "esearchresult" in freetext_result.get("data", {})
+                and int(freetext_result["data"]["esearchresult"].get("count", 0)) > 0
+            ):
+                result = freetext_result
+                data = result["data"]
+
         esearch = data["esearchresult"]
         ids = esearch.get("idlist", [])
         count = int(esearch.get("count", 0))
@@ -516,6 +548,28 @@ class ClinVarSearchVariants(ClinVarRESTTool):
         }
         if unrecognized:
             response_data["ignored_parameters"] = unrecognized
+        if count == 0 and "gene" in arguments:
+            # Fix-R9B-2: a 0-count response for a `gene` filter is
+            # indistinguishable from "this gene truly has no ClinVar
+            # entries" whether the symbol was a typo (e.g. "MEPC2"), a
+            # protein/full name instead of the HGNC gene symbol (e.g.
+            # "dystrophin" instead of "DMD"), or a species mismatch --
+            # confirmed live that ClinVar's [gene] index only matches an
+            # exact current HGNC symbol and has no fuzzy/synonym fallback of
+            # its own. Automatically retrying with an unrestricted free-text
+            # search was tried and rejected: "dystrophin[All Fields]"
+            # matches 12,000+ unrelated ClinVar records that merely mention
+            # the word, which would silently swap a false-empty for a
+            # false-positive result set -- worse than reporting nothing.
+            # Surface the ambiguity instead of guessing.
+            response_data["zero_result_hint"] = (
+                f"No ClinVar records matched gene '{arguments['gene']}'. "
+                "ClinVar's gene index only recognizes the current official "
+                "HGNC symbol (e.g. 'DMD', not the protein name 'dystrophin' "
+                "or an outdated/misspelled symbol) -- verify the symbol "
+                "(e.g. via HGNC_search_genes or NCBIDatasets_get_gene) "
+                "before concluding this gene has no reported variants."
+            )
         if compound_clnsig:
             response_data["clinical_significance_note"] = (
                 "The '/' in the requested clinical_significance was treated as OR: "

--- a/src/tooluniverse/compose_scripts/biomarker_discovery.py
+++ b/src/tooluniverse/compose_scripts/biomarker_discovery.py
@@ -4,6 +4,28 @@ Discover and validate biomarkers for a specific disease condition using compose 
 """
 
 
+def _extract_genes(tool_result):
+    """Pull a gene list out of an HPA_search_genes_by_query result.
+
+    call_tool() returns the tool's raw envelope (e.g.
+    {"status": "success", "data": {"genes": [...]}}), not the unwrapped
+    payload -- this previously checked for "genes" at the top level only,
+    which never matched, so every disease query silently fell through to
+    (formerly) a hardcoded fallback / (now) an honest "no genes found".
+    Check the nested location first, then the top level and bare list, for
+    resilience to either response shape.
+    """
+    if isinstance(tool_result, dict):
+        data = tool_result.get("data")
+        if isinstance(data, dict) and isinstance(data.get("genes"), list):
+            return data["genes"]
+        if isinstance(tool_result.get("genes"), list):
+            return tool_result["genes"]
+    elif isinstance(tool_result, list):
+        return tool_result
+    return []
+
+
 def compose(arguments, tooluniverse, call_tool):
     """Discover and validate biomarkers for a specific disease condition"""
 
@@ -41,16 +63,11 @@ def compose(arguments, tooluniverse, call_tool):
             hpa_result = call_tool(
                 "HPA_search_genes_by_query", {"search_query": disease_condition}
             )
-            if hpa_result and isinstance(hpa_result, dict) and "genes" in hpa_result:
-                genes = hpa_result["genes"]
+            genes = _extract_genes(hpa_result)
+            if genes:
                 gene_search_results.extend(genes)
                 print(
                     f"✅ HPA search found {len(genes)} genes for '{disease_condition}'"
-                )
-            elif hpa_result and isinstance(hpa_result, list):
-                gene_search_results.extend(hpa_result)
-                print(
-                    f"✅ HPA search found {len(hpa_result)} genes for '{disease_condition}'"
                 )
         except Exception as e:
             print(f"⚠️ HPA search failed: {e}")
@@ -64,59 +81,31 @@ def compose(arguments, tooluniverse, call_tool):
                     hpa_result = call_tool(
                         "HPA_search_genes_by_query", {"search_query": search_term}
                     )
-                    if (
-                        hpa_result
-                        and isinstance(hpa_result, dict)
-                        and "genes" in hpa_result
-                    ):
-                        genes = hpa_result["genes"]
+                    genes = _extract_genes(hpa_result)
+                    if genes:
                         gene_search_results.extend(genes)
                         print(
                             f"✅ HPA search found {len(genes)} genes for '{search_term}'"
                         )
                         break
-                    elif hpa_result and isinstance(hpa_result, list):
-                        gene_search_results.extend(hpa_result)
-                        print(
-                            f"✅ HPA search found {len(hpa_result)} genes for '{search_term}'"
-                        )
-                        break
                 except Exception as e:
                     print(f"⚠️ HPA search failed for '{search_term}': {e}")
 
-        # Strategy 3: Use alternative search if no results
+        # NOTE: this used to silently substitute a hardcoded list of
+        # generic cancer genes (BRCA1/BRCA2/TP53/EGFR/MYC) here and print a
+        # "✅" success line whenever HPA search found nothing -- for a
+        # disease with no matches (e.g. "healthy aging", which isn't a
+        # disease HPA indexes genes against), that meant every downstream
+        # step silently analyzed unrelated cancer genes while every log
+        # line still claimed success. Report the miss honestly instead so
+        # callers can tell "no data for this query" apart from "found
+        # data."
         if not gene_search_results:
-            print("⚠️ No genes found with HPA search strategies")
-            # Create a fallback result with common cancer genes
-            fallback_genes = [
-                {
-                    "gene_name": "BRCA1",
-                    "ensembl_id": "ENSG00000012048",
-                    "description": "Breast cancer type 1 susceptibility protein",
-                },
-                {
-                    "gene_name": "BRCA2",
-                    "ensembl_id": "ENSG00000139618",
-                    "description": "Breast cancer type 2 susceptibility protein",
-                },
-                {
-                    "gene_name": "TP53",
-                    "ensembl_id": "ENSG00000141510",
-                    "description": "Tumor protein p53",
-                },
-                {
-                    "gene_name": "EGFR",
-                    "ensembl_id": "ENSG00000146648",
-                    "description": "Epidermal growth factor receptor",
-                },
-                {
-                    "gene_name": "MYC",
-                    "ensembl_id": "ENSG00000136997",
-                    "description": "MYC proto-oncogene protein",
-                },
-            ]
-            gene_search_results.extend(fallback_genes)
-            print(f"✅ Using fallback cancer genes: {len(fallback_genes)} genes")
+            print(
+                "⚠️ No genes found with HPA search strategies for "
+                f"'{disease_condition}' -- skipping expression/pathway "
+                "steps that depend on a specific gene."
+            )
 
         if gene_search_results:
             # Get details for the first gene found

--- a/src/tooluniverse/compound_disease_tool.py
+++ b/src/tooluniverse/compound_disease_tool.py
@@ -11,6 +11,20 @@ from .base_tool import BaseTool
 from .tool_registry import register_tool
 
 
+def _truncate_msg(msg: str, limit: int = 240) -> str:
+    """Truncate an error message on a word boundary, never mid-word.
+
+    Sub-tool error messages are the only actionable guidance a caller gets
+    on a failed source; cutting them off mid-word at a fixed character
+    count silently drops that guidance (e.g. DisGeNET's "...resolve first
+    (e.g. umls_search_concepts)..." hint used to get cut to "umls_search_").
+    """
+    if len(msg) <= limit:
+        return msg
+    head = msg[:limit].rsplit(" ", 1)[0]
+    return head + "..."
+
+
 @register_tool("CompoundDiseaseProfileTool")
 class CompoundDiseaseProfileTool(BaseTool):
     """Gather a comprehensive disease profile from Orphanet, OMIM, DisGeNET, OpenTargets, and OLS."""
@@ -35,10 +49,12 @@ class CompoundDiseaseProfileTool(BaseTool):
             try:
                 r = tu.run_one_function({"name": tool_name, "arguments": args})
                 if isinstance(r, dict) and r.get("status") == "error":
-                    sources_failed.append(f"{source_name}: {r.get('error', '')[:100]}")
+                    sources_failed.append(
+                        f"{source_name}: {_truncate_msg(r.get('error', ''))}"
+                    )
                 return r
             except Exception as e:
-                sources_failed.append(f"{source_name}: {str(e)[:100]}")
+                sources_failed.append(f"{source_name}: {_truncate_msg(str(e))}")
                 return {"status": "error"}
 
         # 1. Orphanet

--- a/src/tooluniverse/compound_gene_disease_tool.py
+++ b/src/tooluniverse/compound_gene_disease_tool.py
@@ -10,6 +10,20 @@ from .base_tool import BaseTool
 from .tool_registry import register_tool
 
 
+def _truncate_msg(msg: str, limit: int = 240) -> str:
+    """Truncate an error message on a word boundary, never mid-word.
+
+    Sub-tool error messages (e.g. DisGeNET's "...resolve first (e.g.
+    umls_search_concepts), then pass disease='C0152200'.") are the only
+    actionable guidance a caller gets on a failed source; cutting them off
+    mid-word at a fixed character count silently drops that guidance.
+    """
+    if len(msg) <= limit:
+        return msg
+    head = msg[:limit].rsplit(" ", 1)[0]
+    return head + "..."
+
+
 @register_tool("CompoundGeneDiseaseAssociationTool")
 class CompoundGeneDiseaseAssociationTool(BaseTool):
     """Query multiple gene-disease databases in a single call."""
@@ -42,12 +56,12 @@ class CompoundGeneDiseaseAssociationTool(BaseTool):
                 r = tu.run_one_function({"name": tool_name, "arguments": args})
                 if isinstance(r, dict) and r.get("status") == "error":
                     sources_failed.append(
-                        f"{source_name}: {r.get('error', 'unknown error')[:100]}"
+                        f"{source_name}: {_truncate_msg(r.get('error', 'unknown error'))}"
                     )
                     return r
                 return r
             except Exception as e:
-                sources_failed.append(f"{source_name}: {str(e)[:100]}")
+                sources_failed.append(f"{source_name}: {_truncate_msg(str(e))}")
                 return {"status": "error", "error": str(e)}
 
         # 1. DisGeNET
@@ -191,11 +205,11 @@ class CompoundGeneDiseaseAssociationTool(BaseTool):
             )
             if isinstance(result, dict) and result.get("status") == "error":
                 sources_failed.append(
-                    f"OpenTargets: {result.get('error', 'unknown error')[:100]}"
+                    f"OpenTargets: {_truncate_msg(result.get('error', 'unknown error'))}"
                 )
             return result
         except Exception as e:
-            sources_failed.append(f"OpenTargets: {str(e)[:100]}")
+            sources_failed.append(f"OpenTargets: {_truncate_msg(str(e))}")
             return {"status": "error", "error": str(e)}
 
     def _opentargets_disease_genes(
@@ -230,11 +244,11 @@ class CompoundGeneDiseaseAssociationTool(BaseTool):
             )
             if isinstance(result, dict) and result.get("status") == "error":
                 sources_failed.append(
-                    f"OpenTargets: {result.get('error', 'unknown error')[:100]}"
+                    f"OpenTargets: {_truncate_msg(result.get('error', 'unknown error'))}"
                 )
             return result
         except Exception as e:
-            sources_failed.append(f"OpenTargets: {str(e)[:100]}")
+            sources_failed.append(f"OpenTargets: {_truncate_msg(str(e))}")
             return {"status": "error", "error": str(e)}
 
     def _extract_genes_or_diseases(
@@ -328,6 +342,24 @@ class CompoundGeneDiseaseAssociationTool(BaseTool):
                                 items.append(
                                     {"name": str(g), "score": None, "source": source}
                                 )
+            return items
+
+        # OMIM_search: each row is {"entry": {"titles": {"preferredTitle": ...},
+        # "mimNumber": ...}} -- the identifying text is nested one level under
+        # "entry", not a top-level gene/disease field, so the generic
+        # extraction below (which only looks at top-level keys) always found
+        # nothing and silently produced zero items for every OMIM query.
+        # OMIM titles conflate gene and disorder names in one string (e.g.
+        # "VON HIPPEL-LINDAU TUMOR SUPPRESSOR; VHL"), so there's no clean
+        # gene-only/disease-only split to make here -- surface the title as-is
+        # for both query directions, same as ClinVar's disease->gene branch
+        # falls back to what the source actually gives us.
+        if isinstance(data, dict) and "entries" in data:
+            for row in (data.get("entries") or [])[:30]:
+                entry = (row or {}).get("entry") or {}
+                title = (entry.get("titles") or {}).get("preferredTitle", "")
+                if title:
+                    items.append({"name": str(title), "score": None, "source": source})
             return items
 
         # Generic list: prefer the field the caller is asking for -- gene fields

--- a/src/tooluniverse/compound_variant_tool.py
+++ b/src/tooluniverse/compound_variant_tool.py
@@ -308,7 +308,34 @@ class CompoundVariantAnnotationTool(BaseTool):
                 if error:
                     sources_failed.append(f"UniProt: {error[:100]}")
                 else:
-                    annotations["uniprot"] = self._parse_uniprot(r, gene_for_gnomad)
+                    parsed = self._parse_uniprot(r, gene_for_gnomad)
+                    # Fix-11B-1: UniProt_search's entries never carry a
+                    # "function" field (confirmed live -- only accession,
+                    # id, protein_name, gene_names, organism, length), so
+                    # _parse_uniprot's function lookup silently always
+                    # returned "". Look up the real function comment with a
+                    # follow-up call keyed on the accession we just picked.
+                    accession = parsed.get("accession")
+                    if accession:
+                        try:
+                            fr = tu.run_one_function(
+                                {
+                                    "name": "UniProt_get_function_by_accession",
+                                    "arguments": {"accession": accession},
+                                }
+                            )
+                            fn_error = self._sub_call_error(fr)
+                            # run_one_function returns this tool's raw
+                            # result -- a bare list of function-comment
+                            # strings -- not wrapped in a dict.
+                            fn_list = fr if isinstance(fr, list) else None
+                            if fn_list is None and isinstance(fr, dict):
+                                fn_list = fr.get("result")
+                            if not fn_error and fn_list:
+                                parsed["function"] = str(fn_list[0])[:300]
+                        except Exception:
+                            pass  # keep parsed["function"] == "" (no data)
+                    annotations["uniprot"] = parsed
             except Exception as e:
                 sources_failed.append(f"UniProt: {str(e)[:100]}")
 

--- a/src/tooluniverse/compound_variant_tool.py
+++ b/src/tooluniverse/compound_variant_tool.py
@@ -50,6 +50,19 @@ _AA_3TO1 = {v.upper(): k for k, v in _AA_1TO3.items()}
 _MATURE_PROTEIN_OFFSET_GENES = {"HBB"}
 
 
+def _truncate_msg(msg: str, limit: int = 240) -> str:
+    """Truncate an error message on a word boundary, never mid-word.
+
+    Sub-tool error messages are the only actionable guidance a caller gets
+    on a failed source; cutting them off mid-word at a fixed character
+    count silently drops that guidance.
+    """
+    if len(msg) <= limit:
+        return msg
+    head = msg[:limit].rsplit(" ", 1)[0]
+    return head + "..."
+
+
 # ClinVar clinical-significance terms ranked most→least clinically significant.
 # Used to pick the headline classification when a query matches several ClinVar
 # variants (e.g. a multi-allelic rsid whose alleles carry different
@@ -245,13 +258,13 @@ class CompoundVariantAnnotationTool(BaseTool):
                     r, error = None, None
 
                 if error:
-                    sources_failed.append(f"ClinVar: {error[:100]}")
+                    sources_failed.append(f"ClinVar: {_truncate_msg(error)}")
                 elif parsed is not None:
                     annotations["clinvar"] = parsed
                 else:
                     annotations["clinvar"] = self._parse_clinvar(r, variant_token)
             except Exception as e:
-                sources_failed.append(f"ClinVar: {str(e)[:100]}")
+                sources_failed.append(f"ClinVar: {_truncate_msg(str(e))}")
 
         # 2. gnomAD
         if gene_for_gnomad:
@@ -264,11 +277,11 @@ class CompoundVariantAnnotationTool(BaseTool):
                 )
                 error = self._sub_call_error(r)
                 if error:
-                    sources_failed.append(f"gnomAD: {error[:100]}")
+                    sources_failed.append(f"gnomAD: {_truncate_msg(error)}")
                 else:
                     annotations["gnomad"] = self._parse_gnomad(r)
             except Exception as e:
-                sources_failed.append(f"gnomAD: {str(e)[:100]}")
+                sources_failed.append(f"gnomAD: {_truncate_msg(str(e))}")
 
         # 3. CIViC
         if gene_for_gnomad:
@@ -281,11 +294,11 @@ class CompoundVariantAnnotationTool(BaseTool):
                 )
                 error = self._sub_call_error(r)
                 if error:
-                    sources_failed.append(f"CIViC: {error[:100]}")
+                    sources_failed.append(f"CIViC: {_truncate_msg(error)}")
                 else:
                     annotations["civic"] = self._parse_civic(r, variant_token)
             except Exception as e:
-                sources_failed.append(f"CIViC: {str(e)[:100]}")
+                sources_failed.append(f"CIViC: {_truncate_msg(str(e))}")
 
         # 4. UniProt
         if gene_for_gnomad:
@@ -306,7 +319,7 @@ class CompoundVariantAnnotationTool(BaseTool):
                 )
                 error = self._sub_call_error(r)
                 if error:
-                    sources_failed.append(f"UniProt: {error[:100]}")
+                    sources_failed.append(f"UniProt: {_truncate_msg(error)}")
                 else:
                     parsed = self._parse_uniprot(r, gene_for_gnomad)
                     # Fix-11B-1: UniProt_search's entries never carry a
@@ -337,7 +350,7 @@ class CompoundVariantAnnotationTool(BaseTool):
                             pass  # keep parsed["function"] == "" (no data)
                     annotations["uniprot"] = parsed
             except Exception as e:
-                sources_failed.append(f"UniProt: {str(e)[:100]}")
+                sources_failed.append(f"UniProt: {_truncate_msg(str(e))}")
 
         # Build summary
         summary = self._build_summary(annotations, variant, gene_for_gnomad, rsid)
@@ -393,7 +406,7 @@ class CompoundVariantAnnotationTool(BaseTool):
             )
             error = self._sub_call_error(r)
             if error:
-                sources_failed.append(f"dbSNP (rsid->gene): {error[:100]}")
+                sources_failed.append(f"dbSNP (rsid->gene): {_truncate_msg(error)}")
                 return None, None
             hgvs = str((r.get("data") or {}).get("hgvs_notation", ""))
             m = re.search(r"GENE=([A-Za-z0-9\-]+):", hgvs)
@@ -413,7 +426,7 @@ class CompoundVariantAnnotationTool(BaseTool):
             variant_tokens = _offset_protein_tokens(variant_tokens, gene)
             return gene, (variant_tokens or None)
         except Exception as e:
-            sources_failed.append(f"dbSNP (rsid->gene): {str(e)[:100]}")
+            sources_failed.append(f"dbSNP (rsid->gene): {_truncate_msg(str(e))}")
             return None, None
 
     def _parse_clinvar(self, result: Any, variant_token: str = None) -> Dict[str, Any]:

--- a/src/tooluniverse/ctd_tool.py
+++ b/src/tooluniverse/ctd_tool.py
@@ -149,9 +149,11 @@ class CTDTool(BaseTool):
                     "direction)."
                 ),
                 "suggestion": (
-                    "Use OpenTargets_get_associated_diseases (live, more "
-                    "sources) or DGIdb_search_interactions for gene-disease "
-                    "associations."
+                    "Use gather_gene_disease_associations (queries DisGeNET, "
+                    "OMIM, OpenTargets, GenCC, and ClinVar in one call and "
+                    "cross-references them) or "
+                    "OpenTargets_get_diseases_phenotypes_by_target_ensembl "
+                    "for gene-disease associations."
                 ),
                 "metadata": metadata,
             }

--- a/src/tooluniverse/ctg_tool.py
+++ b/src/tooluniverse/ctg_tool.py
@@ -24,6 +24,28 @@ def _phrase_quote_if_plain(value: str) -> str:
     return value
 
 
+def _restrict_to_area(value: str, area: str) -> str:
+    """Fix-R13B-1: CTG API v2's Essie search engine treats a bare
+    query.intr/query.spons value as a match against the whole study
+    record (brief summaries, arm descriptions, eligibility text, etc.)
+    rather than restricting to the actual intervention-name or
+    lead-sponsor-name field, so a specific query like 'vedolizumab' or
+    'Takeda' surfaces completely unrelated trials -- confirmed live: an
+    oncology trial with no vedolizumab intervention ranked in the
+    query.intr top 5 (215 unrestricted hits vs. 134 once restricted, all
+    correctly containing the drug), and a Neurocrine/Shire-sponsored
+    trial ranked in the query.spons top 5 for 'Takeda' (1977 unrestricted
+    hits vs. 1022 once restricted, all correctly Takeda-sponsored).
+    Wrapping the value in Essie's AREA[<area>] operator (and
+    phrase-quoting multi-word values, same as _phrase_quote_if_plain)
+    fixes this -- but only for a plain value with no existing Essie
+    syntax, since advanced users may already supply their own
+    AREA/boolean operators."""
+    if _ESSIE_OPERATOR_RE.search(value):
+        return value
+    return f"AREA[{area}]{_phrase_quote_if_plain(value)}"
+
+
 @register_tool("ClinicalTrialsTool")
 class ClinicalTrialsTool(RESTfulTool):
     _BASE_URL = "https://clinicaltrials.gov/api/v2"
@@ -160,6 +182,13 @@ class ClinicalTrialsTool(RESTfulTool):
             return {"status": "success", **result}
         return result
 
+    # Essie fields that get restricted via AREA[<name>] rather than a plain
+    # value match (see _restrict_to_area). Keyed by the mapped API param name.
+    _AREA_RESTRICTED_FIELDS = {
+        "query.intr": "InterventionName",
+        "query.spons": "LeadSponsorName",
+    }
+
     def _run_search(self, arguments):
         """Handle search operations (search_studies, search_by_intervention, search_by_sponsor)."""
         import requests
@@ -211,10 +240,14 @@ class ClinicalTrialsTool(RESTfulTool):
                 advanced_clauses.append(study_type_clause)
             elif key in _SEARCH_PARAM_MAP:
                 mapped_key = _SEARCH_PARAM_MAP[key]
-                if mapped_key in ("query.cond", "query.intr") and isinstance(
+                if mapped_key == "query.cond" and isinstance(value, str):
+                    value = _phrase_quote_if_plain(value)
+                elif mapped_key in self._AREA_RESTRICTED_FIELDS and isinstance(
                     value, str
                 ):
-                    value = _phrase_quote_if_plain(value)
+                    value = _restrict_to_area(
+                        value, self._AREA_RESTRICTED_FIELDS[mapped_key]
+                    )
                 params[mapped_key] = value
 
         if advanced_clauses:

--- a/src/tooluniverse/ctg_tool.py
+++ b/src/tooluniverse/ctg_tool.py
@@ -568,6 +568,27 @@ class ClinicalTrialsSearchTool(ClinicalTrialsTool):
             endpoint_url=formatted_endpoint_url, variables=api_params
         )
 
+        # Feature-14C-02: this tool always applies a hardcoded phase>=2
+        # filter (see default_params_not_shown above), which silently
+        # excludes every NA-phase/observational study -- the exact bucket
+        # most genetics/epidemiology trials fall into. Confirmed live:
+        # condition="orofacial cleft" returns total_count=0 here, but the
+        # same query against the raw ClinicalTrials.gov v2 API (no phase
+        # filter) surfaces real matches such as NCT03065686 ("Genetic
+        # Factors Implicated in Orofacial Cleft"), which is phase "NA".
+        # A bare total_count=0 is indistinguishable from "no matching
+        # trials exist at all", so note the filter whenever it produced
+        # zero results.
+        phase_filter_applied = "PHASE2" in str(api_params.get("filter.advanced", ""))
+        phase_filter_note = (
+            "This search excludes phase-1-only, phase-NA, and observational "
+            "studies by default (see tool description). If you expected "
+            "results (e.g. for a genetics/epidemiology trial), the true "
+            "match count on ClinicalTrials.gov may be higher than 0 -- "
+            "consider searching https://clinicaltrials.gov/ directly for "
+            "NA-phase/observational studies."
+        )
+
         # Fix-Round3-002: a well-formed query that legitimately matches zero
         # trials (empty `studies` list) is a success, not the error below --
         # `execute_RESTful_query` already returns False for genuine failures
@@ -575,15 +596,24 @@ class ClinicalTrialsSearchTool(ClinicalTrialsTool):
         # a response missing "studies" entirely) is a real error.
         # _simplify_output handles an empty list fine on its own.
         if response is not None and response and "studies" in response.keys():
+            metadata = {"source": "ClinicalTrials.gov API v2"}
+            if phase_filter_applied and not response.get("studies"):
+                metadata["note"] = phase_filter_note
             return {
                 "status": "success",
                 "data": self._simplify_output(response),
-                "metadata": {"source": "ClinicalTrials.gov API v2"},
+                "metadata": metadata,
             }
 
+        error_msg = (
+            "No studies found for the given query parameters. "
+            "Please examine your input and try different parameters."
+        )
+        if phase_filter_applied:
+            error_msg += " " + phase_filter_note
         return {
             "status": "error",
-            "error": "No studies found for the given query parameters. Please examine your input and try different parameters.",
+            "error": error_msg,
         }
 
     def _simplify_output(self, response):

--- a/src/tooluniverse/data/biothings_tools.json
+++ b/src/tooluniverse/data/biothings_tools.json
@@ -677,7 +677,7 @@
         "fields": {
           "type": "string",
           "description": "Fields to return (pre-configured for pathogenicity scores)",
-          "default": "dbnsfp.revel.score,dbnsfp.cadd.phred,dbnsfp.alphamissense.score,dbnsfp.alphamissense.pred,dbnsfp.sift.score,dbnsfp.sift.pred,dbnsfp.polyphen2_hdiv.score,dbnsfp.polyphen2_hdiv.pred,dbnsfp.metarnn.score,dbnsfp.metarnn.pred,dbnsfp.gerp_rs,dbnsfp.phylop100way_vertebrate.rankscore,dbnsfp.phastcons100way_vertebrate.rankscore,dbnsfp.vest4.score,dbnsfp.mutationtaster.pred,clinvar.rcv.clinical_significance,dbsnp.rsid"
+          "default": "dbnsfp.revel.score,cadd.phred,dbnsfp.alphamissense.score,dbnsfp.alphamissense.pred,dbnsfp.sift.score,dbnsfp.sift.pred,dbnsfp.polyphen2.hdiv.score,dbnsfp.polyphen2.hdiv.pred,dbnsfp.metarnn.score,dbnsfp.metarnn.pred,cadd.gerp.rs,dbnsfp.phylop.100way_vertebrate.rankscore,dbnsfp.phastcons.100way_vertebrate.rankscore,dbnsfp.vest4.score,dbnsfp.mutationtaster.pred,clinvar.rcv.clinical_significance,dbsnp.rsid"
         }
       },
       "required": [

--- a/src/tooluniverse/data/bvbrc_tools.json
+++ b/src/tooluniverse/data/bvbrc_tools.json
@@ -688,6 +688,20 @@
           "items": {
             "type": "object",
             "properties": {
+              "sample_accession": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Human-readable submission accession (e.g. 'IRD_ROC000000507'). Multiple records can share the same sample_accession/sample_identifier when a sample was tested/submitted more than once -- use 'id' to distinguish them."
+              },
+              "id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Unique BV-BRC record identifier for this surveillance entry."
+              },
               "sample_identifier": {
                 "type": [
                   "string",

--- a/src/tooluniverse/data/bvbrc_tools.json
+++ b/src/tooluniverse/data/bvbrc_tools.json
@@ -213,7 +213,7 @@
   },
   {
     "name": "BVBRC_search_amr",
-    "description": "Search for antimicrobial resistance (AMR) phenotype data in BV-BRC. Returns resistance/susceptibility data for pathogens against specific antibiotics, including MIC values, testing methods, and evidence. Essential for AMR surveillance research. Filter by 'antibiotic' (e.g. 'methicillin'), 'resistant_phenotype', and/or a specific BV-BRC 'genome_id'. There is no organism/species parameter: to scope results to one organism, first obtain its genome_id(s) (e.g. via BVBRC_search_genome_features / BVBRC_search_specialty_genes with taxon_id) and pass genome_id here.",
+    "description": "Search for ANTIBACTERIAL resistance (AMR) phenotype data in BV-BRC -- bacteria tested against antibiotics (e.g. 'methicillin', 'ciprofloxacin'), NOT antiviral drug-resistance mutations (for influenza/viral antiviral resistance, use Pathoplexus_get_mutations or literature search instead). Returns resistance/susceptibility data for pathogens against specific antibiotics, including MIC values, testing methods, and evidence. Essential for bacterial AMR surveillance research. Filter by 'antibiotic' (e.g. 'methicillin'), 'resistant_phenotype', and/or a specific BV-BRC 'genome_id'. There is no organism/species parameter: to scope results to one organism, first obtain its genome_id(s) (e.g. via BVBRC_search_genome_features / BVBRC_search_specialty_genes with taxon_id) and pass genome_id here.",
     "parameter": {
       "type": "object",
       "properties": {

--- a/src/tooluniverse/data/cbioportal_tools.json
+++ b/src/tooluniverse/data/cbioportal_tools.json
@@ -475,7 +475,7 @@
   {
     "type": "CBioPortalRESTTool",
     "name": "cBioPortal_get_gene_info",
-    "description": "Get detailed information about a specific gene by Entrez Gene ID. Returns gene symbol, aliases, type, and chromosome location.",
+    "description": "Get basic information about a specific gene by Entrez Gene ID. Returns the HUGO gene symbol and gene type (e.g., 'protein-coding'); does not return aliases -- use HGNC_fetch_gene_by_symbol or NCBIGene_get_summary for gene aliases/chromosome location.",
     "parameter": {
       "type": "object",
       "properties": {

--- a/src/tooluniverse/data/clinicaltrials_gov_tools.json
+++ b/src/tooluniverse/data/clinicaltrials_gov_tools.json
@@ -927,6 +927,14 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "operation": {
+          "type": "string",
+          "enum": [
+            "search"
+          ],
+          "description": "Operation (optional; defaults to 'search' for this tool).",
+          "default": "search"
+        },
         "query_cond": {
           "type": [
             "string",

--- a/src/tooluniverse/data/cpic_tools.json
+++ b/src/tooluniverse/data/cpic_tools.json
@@ -844,7 +844,7 @@
       "additionalProperties": false
     },
     "fields": {
-      "endpoint": "https://api.cpicpgx.org/v1/pair?select=genesymbol,drugid,cpiclevel,guidelineid,usedforrecommendation,clinpgxlevel,pgxtesting"
+      "endpoint": "https://api.cpicpgx.org/v1/pair?select=genesymbol,drugid,cpiclevel,guidelineid,usedforrecommendation,clinpgxlevel,pgxtesting,drug(name)"
     },
     "type": "CPICSearchPairsTool",
     "test_examples": [
@@ -894,6 +894,18 @@
                   "null",
                   "string"
                 ]
+              },
+              "drug": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "The drug's generic name, embedded via CPIC's PostgREST resource-embedding join on drugid (e.g. {\"name\": \"codeine\"}) so callers don't need a separate RxNorm lookup just to identify which drug a row is about.",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                }
               }
             }
           }

--- a/src/tooluniverse/data/dna_tools.json
+++ b/src/tooluniverse/data/dna_tools.json
@@ -986,55 +986,56 @@
         {
           "type": "object",
           "properties": {
-            "status": {
+            "enzyme": {
               "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "enzyme": {
-                  "type": "string"
-                },
-                "product_length": {
-                  "type": "integer",
-                  "description": "Length of the assembled circular product in bp."
-                },
-                "num_fragments_assembled": {
-                  "type": "integer"
-                },
-                "assembly_order": {
-                  "type": "array",
-                  "description": "Fragments in assembly order, each with source, length and its two overhangs."
-                },
-                "unused_fragments": {
-                  "type": "array",
-                  "description": "Site-free fragments that did not enter the circular product."
-                },
-                "product_sequence": {
-                  "type": "string"
-                }
-              }
+            "product_length": {
+              "type": "integer",
+              "description": "Length of the assembled circular product in bp."
+            },
+            "num_fragments_assembled": {
+              "type": "integer"
+            },
+            "assembly_order": {
+              "type": "array",
+              "description": "Fragments in assembly order, each with source, length and its two overhangs."
+            },
+            "unused_fragments": {
+              "type": "array",
+              "description": "Site-free fragments that did not enter the circular product."
+            },
+            "product_sequence": {
+              "type": "string"
             }
-          }
+          },
+          "required": [
+            "enzyme",
+            "product_length",
+            "num_fragments_assembled",
+            "assembly_order",
+            "product_sequence"
+          ]
         },
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
       {
         "fragments": [
-          "GGTCTCAAGGTGGGGCCCCGGGGCCCCAAAACATCAGAGACCACGTACGTACGTACGTACGTACGTAC",
-          "GGTCTCACATCCCCCGGGGCCCCGGGGTTTTAGGTAGAGACCTGCATGCATGCATGCATGCATGCATG"
+          "GGTCTCAAAACATGGAGGAGCCGCAGTCAGATCCTAGCGTTGAATTCGGATCCCTTTTGAGACC",
+          "GGTCTCAAAAGGGATCCAAGCTTACGTACGTATGGAGGAGCCGCAGTCAGATATTTTGAGACC",
+          "GGTCTCAAAATCCTAGCGTTGAATTCGGATCCAAGCTTACGTACGTATGGAGCGTTTGAGACC",
+          "GGTCTCAAACGATCGATCGATCGATCGATCGGTTTTGAGACC"
         ],
         "enzyme": "BsaI",
         "circular": true

--- a/src/tooluniverse/data/ensembl_tools.json
+++ b/src/tooluniverse/data/ensembl_tools.json
@@ -179,10 +179,11 @@
             "genomic",
             "cds",
             "cdna",
+            "protein",
             "peptide"
           ],
           "default": "genomic",
-          "description": "Sequence type: 'genomic' (genomic DNA), 'cds' (coding sequence), 'cdna' (cDNA), 'peptide' (protein sequence)"
+          "description": "Sequence type: 'genomic' (genomic DNA), 'cds' (coding sequence), 'cdna' (cDNA), 'protein' (protein/peptide sequence -- 'peptide' is also accepted and mapped to 'protein', the name Ensembl's own REST API actually expects)"
         },
         "species": {
           "type": "string",

--- a/src/tooluniverse/data/fda_drug_adverse_event_detail_tools.json
+++ b/src/tooluniverse/data/fda_drug_adverse_event_detail_tools.json
@@ -263,7 +263,7 @@
         },
         "reactionmeddrapt": {
           "type": "string",
-          "description": "MedDRA preferred term for the adverse reaction (required). Example: 'INFUSION RELATED REACTION', 'DYSPNOEA'."
+          "description": "MedDRA preferred term for the adverse reaction (required). Example: 'INFUSION RELATED REACTION', 'DYSPNOEA'. Must be the exact MedDRA Preferred Term FAERS uses, not a clinical description or synonym -- e.g. 'NEPHROTOXICITY' matches nothing, the real terms are 'ACUTE KIDNEY INJURY' or 'RENAL IMPAIRMENT'. A non-matching term returns an empty result (not an error), which looks identical to a genuine zero-report finding. If unsure of the exact term, call FAERS_count_reactions_by_drug_event first (with just medicinalproduct) to list the actual MedDRA terms reported for that drug."
         },
         "limit": {
           "type": "integer",

--- a/src/tooluniverse/data/fda_drug_adverse_event_tools.json
+++ b/src/tooluniverse/data/fda_drug_adverse_event_tools.json
@@ -1300,7 +1300,7 @@
   {
     "type": "FDACountAdditiveReactionsTool",
     "name": "FAERS_count_additive_adverse_reactions",
-    "description": "Aggregate adverse reaction counts across specified medicinal products. Only medicinalproducts is required; all other filters (patientsex, patientagegroup, occurcountry, serious, seriousnessdeath) are optional. Use filters sparingly to avoid overly restrictive searches that return no results. Data source: FDA Adverse Event Reporting System (FAERS).",
+    "description": "Aggregate adverse reaction counts across specified medicinal products. Note: 'medicinalproducts' is combined with OR (union) -- counts are reports mentioning ANY listed product, not reports where all of them co-occur, so results for a multi-drug list can look nearly identical to the single most-reported drug's own counts. For co-occurrence/combination-risk analysis (e.g. checking two specific drugs taken together), use FAERS_search_reports_by_drug_combination (AND) or FAERS_calculate_disproportionality instead. Only medicinalproducts is required; all other filters (patientsex, patientagegroup, occurcountry, serious, seriousnessdeath) are optional. Use filters sparingly to avoid overly restrictive searches that return no results. Data source: FDA Adverse Event Reporting System (FAERS).",
     "parameter": {
       "type": "object",
       "properties": {

--- a/src/tooluniverse/data/fda_drug_labeling_tools.json
+++ b/src/tooluniverse/data/fda_drug_labeling_tools.json
@@ -5619,13 +5619,13 @@
   },
   {
     "name": "FDA_get_drug_names_by_food_safety_warnings",
-    "description": "Retrieve drug names based on specific food safety warnings.",
+    "description": "Retrieve drug names whose label discusses a food-drug interaction or food safety warning (e.g. 'grapefruit', 'alcohol', 'dairy'). Searches across the label's food-interaction-relevant sections: 'food_safety_warning' (a real but very rarely populated openFDA section -- only a handful of labels use it), plus the much more commonly populated 'drug_interactions', 'precautions', and 'warnings_and_precautions' sections where food/beverage interactions are usually actually documented. Matching a single word like 'alcohol' can return many results since these are broad safety sections, not a dedicated food-warning field.",
     "parameter": {
       "type": "object",
       "properties": {
         "field_info": {
           "type": "string",
-          "description": "Information related to food safety warnings."
+          "description": "Food/beverage or interaction keyword to search for, e.g. 'grapefruit', 'alcohol', 'dairy', 'tyramine'."
         },
         "indication": {
           "type": "string",
@@ -5647,7 +5647,10 @@
     "fields": {
       "search_fields": {
         "field_info": [
-          "food_safety_warning"
+          "food_safety_warning",
+          "drug_interactions",
+          "precautions",
+          "warnings_and_precautions"
         ],
         "indication": [
           "indications_and_usage"
@@ -5666,8 +5669,7 @@
     ],
     "test_examples": [
       {
-        "field_info": "Instructions",
-        "indication": "Hypertension",
+        "field_info": "grapefruit",
         "limit": 1,
         "skip": 0
       }
@@ -5695,7 +5697,40 @@
             "type": "object",
             "properties": {
               "food_safety_warning": {
-                "type": "null"
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": "string"
+                }
+              },
+              "drug_interactions": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": "string"
+                }
+              },
+              "precautions": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": "string"
+                }
+              },
+              "warnings_and_precautions": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": "string"
+                }
               },
               "indications_and_usage": {
                 "type": [

--- a/src/tooluniverse/data/fda_drug_labeling_tools.json
+++ b/src/tooluniverse/data/fda_drug_labeling_tools.json
@@ -8737,7 +8737,7 @@
       "properties": {
         "mechanism_info": {
           "type": "string",
-          "description": "Information related to the desired mechanism of action."
+          "description": "Free-text mechanism-of-action keyword to search for in the drug label's 'Mechanism of Action' section (e.g., 'angiotensin', 'beta blocker', 'IL-4 receptor'). Not a diagnosis/ICD code -- this searches the label's mechanism text, not indication codes."
         },
         "indication": {
           "type": "string",
@@ -8779,8 +8779,8 @@
     ],
     "test_examples": [
       {
-        "mechanism_info": "E11.9",
-        "indication": "Hypertension",
+        "mechanism_info": "angiotensin",
+        "indication": "hypertension",
         "limit": 5,
         "skip": 0
       }

--- a/src/tooluniverse/data/hpo_tools.json
+++ b/src/tooluniverse/data/hpo_tools.json
@@ -24,6 +24,9 @@
       },
       {
         "term_id": "HP:0001263"
+      },
+      {
+        "term_id": "HP:0006887"
       }
     ],
     "return_schema": {

--- a/src/tooluniverse/data/hpo_tools.json
+++ b/src/tooluniverse/data/hpo_tools.json
@@ -276,7 +276,7 @@
   },
   {
     "name": "HPO_get_genes_by_phenotype",
-    "description": "Get the genes associated with an HPO phenotype term (genes in which variants cause this phenotype), from the JAX HPO network annotations. Returns NCBI gene IDs and symbols. Example: HP:0001250 (Seizure) is linked to genes such as RELN, SCN1A, and ~2000 others. Use to go from an observed patient phenotype to candidate disease genes for variant prioritization.",
+    "description": "Get the genes associated with an HPO phenotype term (genes in which variants cause this phenotype), from the JAX HPO network annotations. Returns NCBI gene IDs and symbols. Example: HP:0001250 (Seizure) is linked to genes such as RELN, SCN1A, and ~2000 others. Use to go from an observed patient phenotype to candidate disease genes for variant prioritization. A phenotype term can be linked to thousands of genes but 'limit' caps a single response at 500 -- check metadata.has_more in the response and pass 'offset' to page through the rest; a well-known gene for a common phenotype may not appear in the first page.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -290,6 +290,13 @@
             "null"
           ],
           "description": "Maximum number of results to return (1-500, default 50). Phenotype terms can be linked to thousands of genes."
+        },
+        "offset": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Number of results to skip before returning 'limit' results (default 0). Use with the response's metadata.has_more/metadata.total to page through phenotypes with more genes than fit in one call."
         }
       },
       "required": [
@@ -351,7 +358,7 @@
   },
   {
     "name": "HPO_get_diseases_by_phenotype",
-    "description": "Get the diseases that present with an HPO phenotype term, from the JAX HPO network annotations. Returns disease IDs (ORPHA/OMIM/DECIPHER), names, and the cross-referenced MONDO ID. Example: HP:0001250 (Seizure) is a feature of thousands of diseases. Use to build a differential diagnosis from a set of observed phenotypes.",
+    "description": "Get the diseases that present with an HPO phenotype term, from the JAX HPO network annotations. Returns disease IDs (ORPHA/OMIM/DECIPHER), names, and the cross-referenced MONDO ID. Example: HP:0001250 (Seizure) is a feature of thousands of diseases. Use to build a differential diagnosis from a set of observed phenotypes. A phenotype term can be linked to thousands of diseases but 'limit' caps a single response at 500 -- check metadata.has_more in the response and pass 'offset' to page through the rest; a well-known disease for a common phenotype may not appear in the first page.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -365,6 +372,13 @@
             "null"
           ],
           "description": "Maximum number of results to return (1-500, default 50). Phenotype terms can be linked to thousands of diseases."
+        },
+        "offset": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Number of results to skip before returning 'limit' results (default 0). Use with the response's metadata.has_more/metadata.total to page through phenotypes with more diseases than fit in one call."
         }
       },
       "required": [

--- a/src/tooluniverse/data/idmap_tools.json
+++ b/src/tooluniverse/data/idmap_tools.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "OpenTargets_get_disease_ids_by_name",
-    "description": "Given a disease or phenotype name, find all cross-referenced external IDs (e.g., OMIM, MONDO, MeSH, ICD10, UMLS, MedDRA, NCIt, Orphanet) using Open Targets GraphQL API.",
+    "description": "Given a disease or phenotype name, find candidate diseases and their cross-referenced external IDs (e.g., OMIM, MONDO, MeSH, ICD10, UMLS, MedDRA, NCIt, Orphanet) using Open Targets GraphQL full-text search. Returns up to 5 ranked candidates, not a single guaranteed match -- OpenTargets' relevance ranking can surface an unrelated top hit for multi-word or qualified phrasing (e.g. 'localized prostate cancer' or 'high-risk prostate cancer' rank an unrelated disease/trait above 'prostate cancer' itself). Always check each hit's 'name' against the disease you intended before using its dbXRefs; prefer a plain, unqualified disease name (e.g. 'prostate cancer' rather than 'localized prostate cancer') if the top hit's name looks wrong.",
     "label": [
       "Disease",
       "Phenotype",
@@ -22,7 +22,7 @@
         "name"
       ]
     },
-    "query_schema": "query getDiseaseDbXRefsByName($name: String!) {\n  search(queryString: $name, entityNames: [\"disease\"], page: { index: 0, size: 1 }) {\n    hits {\n      id\n      name\n      object {\n        ... on Disease {\n          id\n          name\n          dbXRefs\n        }\n      }\n    }\n  }\n}",
+    "query_schema": "query getDiseaseDbXRefsByName($name: String!) {\n  search(queryString: $name, entityNames: [\"disease\"], page: { index: 0, size: 5 }) {\n    hits {\n      id\n      name\n      score\n      object {\n        ... on Disease {\n          id\n          name\n          dbXRefs\n        }\n      }\n    }\n  }\n}",
     "type": "OpenTarget",
     "test_examples": [
       {
@@ -48,6 +48,10 @@
                       },
                       "name": {
                         "type": "string"
+                      },
+                      "score": {
+                        "type": "number",
+                        "description": "Open Targets' own relevance score for this candidate, in the order it was ranked. Not comparable across different queries -- use it only to judge whether the top hit clearly dominates the rest, not as an absolute confidence value."
                       },
                       "object": {
                         "type": "object",

--- a/src/tooluniverse/data/kegg_disease_drug_tools.json
+++ b/src/tooluniverse/data/kegg_disease_drug_tools.json
@@ -348,7 +348,7 @@
   {
     "name": "KEGG_get_drug_targets",
     "type": "KEGGExtTool",
-    "description": "Get human gene targets linked to a KEGG drug. Returns KEGG gene IDs (hsa:XXXXX format) for known drug targets. Example: D01441 (imatinib) returns hsa:25 (ABL1), hsa:3815 (KIT), hsa:5159 (PDGFRB). Useful for drug-target interaction analysis and pharmacogenomics. Limited to human targets by default.",
+    "description": "Get human gene targets linked to a KEGG drug. Returns raw KEGG gene IDs only (hsa:XXXXX format), not gene symbols -- resolve symbols separately if you need them. Example: D01441 (imatinib) returns hsa:25 (ABL1), hsa:3815 (KIT), hsa:5156 (PDGFRA). Useful for drug-target interaction analysis and pharmacogenomics. Limited to human targets by default.",
     "parameter": {
       "type": "object",
       "properties": {

--- a/src/tooluniverse/data/kegg_network_variant_tools.json
+++ b/src/tooluniverse/data/kegg_network_variant_tools.json
@@ -41,7 +41,7 @@
   {
     "name": "KEGG_get_network",
     "type": "KEGGExtTool",
-    "description": "Get detailed KEGG network information including signaling pathway definition (e.g., EGF -> EGFR -> RAS -> RAF -> MEK -> ERK), associated disease classes, linked diseases, drug targets, and pathway elements. KEGG networks model specific molecular interaction cascades perturbed in disease. Example: N00001 returns EGF-EGFR-RAS-ERK signaling pathway linked to colorectal cancer, melanoma, breast cancer, and 7+ other cancer types.",
+    "description": "Get detailed KEGG network information including signaling pathway definition (e.g., EGF -> EGFR -> RAS -> RAF -> MEK -> ERK), associated disease classes, linked diseases, drug targets, and pathway elements. KEGG networks model specific molecular interaction cascades perturbed in disease. Example: N00001 returns EGF-EGFR-RAS-ERK signaling pathway linked to colorectal cancer, melanoma, breast cancer, and 7+ other cancer types. For N#####-style perturbed-network IDs, `genes` gives the gene symbols (with Entrez IDs and descriptions) that map the numeric IDs in `expanded`, and `pathways` cross-references the canonical KEGG PATHWAY map(s) (e.g. hsa04668) the network belongs to. For nt######-style disease/map-class network IDs, `elements` instead lists the child N##### networks that compose it (`genes`/`pathways` are empty for that ID family).",
     "parameter": {
       "type": "object",
       "properties": {
@@ -65,7 +65,30 @@
         "classes": {"type": "array", "items": {"type": "string"}},
         "diseases": {"type": "array", "items": {"type": "string"}},
         "drugs": {"type": "array", "items": {"type": "string"}},
-        "elements": {"type": "array", "items": {"type": "string"}}
+        "elements": {"type": "array", "items": {"type": "string"}},
+        "genes": {
+          "type": "array",
+          "description": "Gene symbols driving an N#####-style network, with Entrez IDs and descriptions. Empty for nt######-style (Map-class) network IDs.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "entrez_id": {"type": "string"},
+              "symbol": {"type": "string"},
+              "description": {"type": "string"}
+            }
+          }
+        },
+        "pathways": {
+          "type": "array",
+          "description": "KEGG PATHWAY map(s) this network belongs to. Empty for nt######-style (Map-class) network IDs.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "pathway_id": {"type": "string"},
+              "name": {"type": "string"}
+            }
+          }
+        }
       }
     },
     "test_examples": [

--- a/src/tooluniverse/data/mgnify_expanded_tools.json
+++ b/src/tooluniverse/data/mgnify_expanded_tools.json
@@ -229,7 +229,7 @@
   },
   {
     "name": "MGnify_get_study_detail",
-    "description": "Get detailed information about a specific MGnify metagenomics study. Returns study name, abstract, associated BioProject, centre, biomes, and counts of analyses/downloads. Complementary to MGnify_search_studies which lists studies. Example: MGYS00002008 is a Tara Oceans marine metagenomics study.",
+    "description": "Get detailed information about a specific MGnify metagenomics study. Returns study name, abstract, associated BioProject, centre, public/private status, sample count, and biomes. Complementary to MGnify_search_studies which lists studies; use MGnify_list_analyses / MGnify_list_analysis_downloads for exact analyses/downloads counts (this endpoint does not provide them). Example: MGYS00002008 is a Tara Oceans marine metagenomics study.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -281,7 +281,13 @@
                 "type": "string"
               }
             },
-            "analyses_count": {
+            "is_public": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "samples_count": {
               "type": [
                 "integer",
                 "null"

--- a/src/tooluniverse/data/monarch_tools.json
+++ b/src/tooluniverse/data/monarch_tools.json
@@ -52,14 +52,38 @@
         "HPO_ID_list": ["HP:0001250"],
         "limit": 5,
         "offset": 1
+      },
+      {
+        "HPO_ID_list": ["HP:9999999", "HP:0001249"],
+        "limit": 5
       }
     ],
     "return_schema": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      },
-      "description": "List of disease names associated with the provided HPO phenotype IDs"
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of disease names associated with the intersection of ALL provided HPO phenotype IDs. Returned when every input HPO ID matched at least one disease."
+        },
+        {
+          "type": "object",
+          "description": "Returned when one or more input HPO IDs matched zero diseases (e.g. an invalid/obsolete ID, or a genuinely unassociated phenotype). Those IDs are excluded from the intersection rather than collapsing the whole result to an empty list.",
+          "properties": {
+            "diseases": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "warning": {
+              "type": "string"
+            }
+          },
+          "required": ["diseases", "warning"]
+        }
+      ]
     }
   },
   {

--- a/src/tooluniverse/data/openalex_tools.json
+++ b/src/tooluniverse/data/openalex_tools.json
@@ -39,13 +39,27 @@
           "minimum": 1,
           "maximum": 200
         },
+        "num_results": {
+          "type": "integer",
+          "description": "Alias for `max_results` (OpenAlex max 200).",
+          "minimum": 1,
+          "maximum": 200
+        },
         "year_from": {
           "type": "integer",
           "description": "Start year for publication date filter (e.g., 2020). Optional parameter to limit search to papers published from this year onwards."
         },
+        "start_year": {
+          "type": "integer",
+          "description": "Alias for `year_from`."
+        },
         "year_to": {
           "type": "integer",
           "description": "End year for publication date filter (e.g., 2023). Optional parameter to limit search to papers published up to this year."
+        },
+        "end_year": {
+          "type": "integer",
+          "description": "Alias for `year_to`."
         },
         "open_access": {
           "type": "boolean",

--- a/src/tooluniverse/data/openfda_tools.json
+++ b/src/tooluniverse/data/openfda_tools.json
@@ -22,7 +22,11 @@
             ]
         },
         "fields": {
-            "endpoint": "https://api.fda.gov/drug/label.json"
+            "endpoint": "https://api.fda.gov/drug/label.json",
+            "auth_param": {
+                "env_var": "FDA_API_KEY",
+                "param": "api_key"
+            }
         },
         "type": "BaseRESTTool",
         "test_examples": [
@@ -252,7 +256,11 @@
             "required": []
         },
         "fields": {
-            "endpoint": "https://api.fda.gov/drug/event.json"
+            "endpoint": "https://api.fda.gov/drug/event.json",
+            "auth_param": {
+                "env_var": "FDA_API_KEY",
+                "param": "api_key"
+            }
         },
         "type": "OpenFDADrugEventsTool",
         "test_examples": [
@@ -389,7 +397,11 @@
             ]
         },
         "fields": {
-            "endpoint": "https://api.fda.gov/drug/ndc.json"
+            "endpoint": "https://api.fda.gov/drug/ndc.json",
+            "auth_param": {
+                "env_var": "FDA_API_KEY",
+                "param": "api_key"
+            }
         },
         "type": "BaseRESTTool",
         "test_examples": [
@@ -532,7 +544,11 @@
             "required": []
         },
         "fields": {
-            "endpoint": "https://api.fda.gov/drug/enforcement.json"
+            "endpoint": "https://api.fda.gov/drug/enforcement.json",
+            "auth_param": {
+                "env_var": "FDA_API_KEY",
+                "param": "api_key"
+            }
         },
         "type": "BaseRESTTool",
         "test_examples": [
@@ -667,7 +683,11 @@
             "required": []
         },
         "fields": {
-            "endpoint": "https://api.fda.gov/device/enforcement.json"
+            "endpoint": "https://api.fda.gov/device/enforcement.json",
+            "auth_param": {
+                "env_var": "FDA_API_KEY",
+                "param": "api_key"
+            }
         },
         "type": "BaseRESTTool",
         "test_examples": [
@@ -769,7 +789,11 @@
             ]
         },
         "fields": {
-            "endpoint": "https://api.fda.gov/device/510k.json"
+            "endpoint": "https://api.fda.gov/device/510k.json",
+            "auth_param": {
+                "env_var": "FDA_API_KEY",
+                "param": "api_key"
+            }
         },
         "type": "BaseRESTTool",
         "test_examples": [
@@ -885,7 +909,11 @@
             "required": []
         },
         "fields": {
-            "endpoint": "https://api.fda.gov/food/enforcement.json"
+            "endpoint": "https://api.fda.gov/food/enforcement.json",
+            "auth_param": {
+                "env_var": "FDA_API_KEY",
+                "param": "api_key"
+            }
         },
         "type": "BaseRESTTool",
         "test_examples": [
@@ -1005,7 +1033,11 @@
             ]
         },
         "fields": {
-            "endpoint": "https://api.fda.gov/drug/shortages.json"
+            "endpoint": "https://api.fda.gov/drug/shortages.json",
+            "auth_param": {
+                "env_var": "FDA_API_KEY",
+                "param": "api_key"
+            }
         },
         "type": "BaseRESTTool",
         "test_examples": [
@@ -1128,7 +1160,11 @@
             ]
         },
         "fields": {
-            "endpoint": "https://api.fda.gov/device/event.json"
+            "endpoint": "https://api.fda.gov/device/event.json",
+            "auth_param": {
+                "env_var": "FDA_API_KEY",
+                "param": "api_key"
+            }
         },
         "type": "BaseRESTTool",
         "test_examples": [
@@ -1239,7 +1275,11 @@
             ]
         },
         "fields": {
-            "endpoint": "https://api.fda.gov/device/recall.json"
+            "endpoint": "https://api.fda.gov/device/recall.json",
+            "auth_param": {
+                "env_var": "FDA_API_KEY",
+                "param": "api_key"
+            }
         },
         "type": "BaseRESTTool",
         "test_examples": [
@@ -1358,7 +1398,11 @@
             ]
         },
         "fields": {
-            "endpoint": "https://api.fda.gov/food/event.json"
+            "endpoint": "https://api.fda.gov/food/event.json",
+            "auth_param": {
+                "env_var": "FDA_API_KEY",
+                "param": "api_key"
+            }
         },
         "type": "BaseRESTTool",
         "test_examples": [
@@ -1472,7 +1516,11 @@
             ]
         },
         "fields": {
-            "endpoint": "https://api.fda.gov/animalandveterinary/event.json"
+            "endpoint": "https://api.fda.gov/animalandveterinary/event.json",
+            "auth_param": {
+                "env_var": "FDA_API_KEY",
+                "param": "api_key"
+            }
         },
         "type": "BaseRESTTool",
         "test_examples": [

--- a/src/tooluniverse/data/opentarget_tools.json
+++ b/src/tooluniverse/data/opentarget_tools.json
@@ -461,7 +461,7 @@
                 "chemblId"
             ]
         },
-        "query_schema": "\n  query drugMechanismsOfAction($chemblId: String!) {\n    drug(chemblId: $chemblId) {\n      id\n      name\n      mechanismsOfAction {\n        rows {\n          mechanismOfAction\n          actionType\n         targetName\n          targets {\n            id\n            approvedSymbol\n          }\n        }\n      }\n    }\n  }\n  ",
+        "query_schema": "\n  query drugMechanismsOfAction($chemblId: String!) {\n    drug(chemblId: $chemblId) {\n      id\n      name\n      mechanismsOfAction {\n        rows {\n          mechanismOfAction\n          actionType\n         targetName\n          targets {\n            id\n            approvedSymbol\n          }\n          references {\n            source\n            urls\n          }\n        }\n      }\n    }\n  }\n  ",
         "label": [
             "Drug",
             "MechanismsOfAction",
@@ -519,6 +519,23 @@
                                                                 },
                                                                 "approvedSymbol": {
                                                                     "type": "string"
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    "references": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "source": {
+                                                                    "type": "string"
+                                                                },
+                                                                "urls": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "type": "string"
+                                                                    }
                                                                 }
                                                             }
                                                         }

--- a/src/tooluniverse/data/panelapp_tools.json
+++ b/src/tooluniverse/data/panelapp_tools.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "PanelApp_search_panels",
-    "description": "Search Genomics England PanelApp for gene panels used in clinical genetic testing. PanelApp is the authoritative source for curated gene panels used by the NHS and global genomic medicine services. Returns panel IDs, names, disease groups, status, version, and gene count statistics. Use this to find relevant gene panels for a disease area, then use PanelApp_get_panel to get the full gene list. Panels contain genes with confidence levels (green=3 for diagnostic grade, amber=2 for borderline, red=1 for limited evidence).",
+    "description": "Search Genomics England PanelApp for gene panels used in clinical genetic testing. PanelApp is the authoritative source for curated gene panels used by the NHS and global genomic medicine services. Returns panel IDs, names, disease groups, status, version, and gene count statistics. Use this to find relevant gene panels for a disease area, then use PanelApp_get_panel to get the full gene list. Panels contain genes with confidence levels (green=3 for diagnostic grade, amber=2 for borderline, red=1 for limited evidence). Matches only against panel-level metadata (name/disease group), not gene-level phenotype text, so some disease names (e.g. 'haemophilia') won't match any panel directly even though a relevant panel exists -- if a disease-name search returns nothing, try PanelApp_search_genes with the causal gene symbol instead (e.g. F8, F9 for haemophilia).",
     "parameter": {
       "type": "object",
       "properties": {

--- a/src/tooluniverse/data/pubchem_tools.json
+++ b/src/tooluniverse/data/pubchem_tools.json
@@ -212,11 +212,11 @@
       "endpoint": "/compound/cid/{cid}/property/{property_list}/JSON",
       "use_pugview": false,
       "input_description": "Input is a PubChem compound ID (integer).",
-      "output_description": "Returns a JSON object with structure example:\n{\n  \"PropertyTable\": {\n    \"Properties\": [\n      {\n        \"CID\": 2244,\n        \"MolecularWeight\": 180.157,\n        \"IUPACName\": \"2-acetyloxybenzoic acid\",\n        \"CanonicalSMILES\": \"CC(=O)OC1=CC=CC=C1C(=O)O\",\n        ...\n      }\n    ]\n  }\n}\n\nWhere:\n- PropertyTable.Properties list: each element contains properties for that CID;\n- Property names determined by {property_list}, example here is [\"MolecularWeight\",\"IUPACName\",\"CanonicalSMILES\"].\nAfter calling, LLM can directly access these important molecular properties for subsequent chemical/pharmacological reasoning.",
+      "output_description": "Returns a JSON object with structure example:\n{\n  \"PropertyTable\": {\n    \"Properties\": [\n      {\n        \"CID\": 2244,\n        \"MolecularWeight\": 180.157,\n        \"IUPACName\": \"2-acetyloxybenzoic acid\",\n        \"ConnectivitySMILES\": \"CC(=O)OC1=CC=CC=C1C(=O)O\",\n        ...\n      }\n    ]\n  }\n}\n\nWhere:\n- PropertyTable.Properties list: each element contains properties for that CID;\n- Property names determined by {property_list}, example here is [\"MolecularWeight\",\"IUPACName\",\"ConnectivitySMILES\"]. Note: PubChem's PUG-REST API renamed the legacy \"CanonicalSMILES\" property to \"ConnectivitySMILES\" (and \"IsomericSMILES\" to \"SMILES\") — requesting the old names either returns data under the new key or drops the field entirely, so use the current names shown here.\nAfter calling, LLM can directly access these important molecular properties for subsequent chemical/pharmacological reasoning.",
       "property_list": [
         "MolecularWeight",
         "IUPACName",
-        "CanonicalSMILES"
+        "ConnectivitySMILES"
       ]
     },
     "type": "PubChemRESTTool",

--- a/src/tooluniverse/data/pubmed_tools.json
+++ b/src/tooluniverse/data/pubmed_tools.json
@@ -11,7 +11,7 @@
       "properties": {
         "query": {
           "type": "string",
-          "description": "Search query for PubMed articles. Use keywords, author names, journal names, or MeSH terms. Examples: 'cancer immunotherapy', 'Smith J[Author]', 'Nature[Journal]', 'diabetes[MeSH]'. Use AND/OR/NOT for complex queries."
+          "description": "Search query for PubMed articles. Use keywords, author names, journal names, or MeSH terms. Examples: 'cancer immunotherapy', 'Smith J[Author]', 'Nature[Journal]', 'diabetes[MeSH]'. Use AND/OR/NOT for complex queries. Note: PubMed ANDs every space-separated keyword by default, so a long, highly specific free-text query (5+ concepts) often returns 0 results even when relevant literature exists. Prefer 2-4 key concepts, add explicit OR for synonyms, or try EuropePMC_search_articles for broader relevance-ranked full-text search if this returns 0 results."
         },
         "limit": {
           "type": "integer",

--- a/src/tooluniverse/data/usda_plants_tools.json
+++ b/src/tooluniverse/data/usda_plants_tools.json
@@ -1,7 +1,7 @@
 [
     {
         "name": "USDA_plants_get_profile",
-        "description": "Get a USDA PLANTS Database profile for a plant by its PLANTS symbol (e.g. 'ABBA' = balsam fir): scientific name, common name, taxonomic group/rank, duration (annual/perennial), growth habits (tree/shrub/forb), native status, synonyms, and US distribution FIPS codes. Authoritative US plant taxonomy. No API key required.",
+        "description": "Get a USDA PLANTS Database profile for a plant by its PLANTS symbol (e.g. 'ABBA' = balsam fir): scientific name, common name, taxonomic group/rank, duration (annual/perennial), growth habits (tree/shrub/forb), and synonyms. 'native_statuses' gives region-level (e.g. 'L48', 'CAN') native/introduced status; fine-grained per-state/county FIPS distribution codes are not returned by this endpoint (fips_distribution is included for forward-compatibility but is null in the current USDA API response). Authoritative US plant taxonomy. No API key required.",
         "parameter": {"type": "object", "properties": {
             "symbol": {"type": "string", "description": "USDA PLANTS symbol, e.g. 'ABBA' (balsam fir), 'ACRU' (red maple), 'QUAL' (white oak)."}
         }, "required": ["symbol"]},

--- a/src/tooluniverse/data/wikipathways_ext_tools.json
+++ b/src/tooluniverse/data/wikipathways_ext_tools.json
@@ -6,8 +6,18 @@
       "type": "object",
       "properties": {
         "pathway_id": {
-          "type": "string",
-          "description": "WikiPathways pathway identifier. Examples: 'WP254' (Apoptosis, 87 gene products), 'WP179' (Cell cycle), 'WP4216' (Chromosomal and microsatellite instability), 'WP1584' (Type II diabetes mellitus)."
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "WikiPathways pathway identifier. Examples: 'WP254' (Apoptosis, 87 gene products), 'WP179' (Cell cycle), 'WP4216' (Chromosomal and microsatellite instability), 'WP1584' (Type II diabetes mellitus). Required unless `wpid` is given instead."
+        },
+        "wpid": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Alias for `pathway_id`, matching the parameter name used by the sibling WikiPathways_get_pathway tool. Provide either `pathway_id` or `wpid`."
         },
         "code": {
           "type": [
@@ -16,10 +26,7 @@
           ],
           "description": "Optional filter restricting results to gene products annotated from one identifier system: 'H' (HGNC), 'En' (Ensembl), 'S' (UniProt), 'L' (Entrez Gene), 'Ce' (ChEBI, metabolites). Omit to return every gene product in the pathway. Most pathways are annotated from Entrez Gene or Ensembl and carry no HGNC-sourced entries, so filtering can legitimately return 0."
         }
-      },
-      "required": [
-        "pathway_id"
-      ]
+      }
     },
     "fields": {
       "endpoint": "get_pathway_genes"
@@ -189,13 +196,20 @@
       "type": "object",
       "properties": {
         "pathway_id": {
-          "type": "string",
-          "description": "WikiPathways pathway identifier. Examples: 'WP534' (Glycolysis & Gluconeogenesis), 'WP78' (TCA cycle), 'WP143' (Fatty acid beta-oxidation), 'WP550' (Biogenic amine synthesis)."
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "WikiPathways pathway identifier. Examples: 'WP534' (Glycolysis & Gluconeogenesis), 'WP78' (TCA cycle), 'WP143' (Fatty acid beta-oxidation), 'WP550' (Biogenic amine synthesis). Required unless `wpid` is given instead."
+        },
+        "wpid": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Alias for `pathway_id`, matching the parameter name used by the sibling WikiPathways_get_pathway tool. Provide either `pathway_id` or `wpid`."
         }
-      },
-      "required": [
-        "pathway_id"
-      ]
+      }
     },
     "fields": {
       "endpoint": "get_pathway_metabolites"

--- a/src/tooluniverse/disgenet_tool.py
+++ b/src/tooluniverse/disgenet_tool.py
@@ -27,6 +27,22 @@ DISGENET_API_URL = "https://api.disgenet.com/api/v1"
 # A disease passed as a bare UMLS CUI looks like "C0006142".
 _CUI_RE = re.compile(r"^C\d+$")
 
+# Fix-R13B-2: DisGeNET's /summary endpoints emit one "warning" per
+# *unset* optional filter param (e.g. "min_pli > The parameter value is
+# unspecified or not a double number."), regardless of whether the
+# caller ever intended to supply it. A plain gene-only query returns
+# ~30 of these alongside the one warning that's actually actionable
+# (the academic-key CURATED-sources-only note), burying it. These are
+# recognizable by their fixed "unspecified" phrasing and are dropped;
+# any other warning text (real data-quality notes) is kept.
+_UNSET_PARAM_WARNING_RE = re.compile(
+    r"is (?:empty / unspecified|unspecified or not an? [\w\s]+)\.?\s*$"
+)
+
+
+def _drop_unset_param_noise(warnings: List[str]) -> List[str]:
+    return [w for w in warnings if not _UNSET_PARAM_WARNING_RE.search(w)]
+
 
 @register_tool("DisGeNETTool")
 class DisGeNETTool(BaseTool):
@@ -94,7 +110,7 @@ class DisGeNETTool(BaseTool):
         response.raise_for_status()
         body = response.json()
         payload = body.get("payload") or []
-        warnings = body.get("warnings") or []
+        warnings = _drop_unset_param_noise(body.get("warnings") or [])
         return payload, warnings
 
     @staticmethod
@@ -222,6 +238,28 @@ class DisGeNETTool(BaseTool):
             arguments.get("min_score"),
             arguments.get("limit", self._declared_limit_default(25)),
         )
+        metadata: Dict[str, Any] = {
+            "source": "DisGeNET GDA",
+            "warnings": warnings,
+            "note": "Academic keys return CURATED sources only.",
+        }
+        # Fix-R13B-2: DisGeNET matches gene_symbol exactly, so a legacy/
+        # alias symbol (e.g. 'CARD15', the old official symbol for NOD2)
+        # silently returns an empty list with no hint that a symbol
+        # mismatch -- not a real absence of associations -- is the cause.
+        # Confirmed live: gene='CARD15' -> 0 associations, gene='NOD2' ->
+        # real Crohn/Blau-syndrome associations. We can't safely
+        # auto-resolve the alias ourselves (that needs a maintained
+        # gene-symbol synonym table we don't have), so just flag the
+        # ambiguity instead of leaving an empty result unexplained.
+        if gene and not rows and not gene.isdigit():
+            metadata["note"] += (
+                f" No associations found for gene symbol '{gene}'. DisGeNET "
+                "matches the current HGNC-approved symbol only, not older "
+                "aliases -- if this might be a legacy/alias symbol, resolve "
+                "it to its current official symbol first (e.g. via "
+                "NCBIGene_search_genes or HGNC) and retry."
+            )
         return {
             "status": "success",
             "data": {
@@ -230,11 +268,7 @@ class DisGeNETTool(BaseTool):
                 "associations": rows,
                 "count": len(rows),
             },
-            "metadata": {
-                "source": "DisGeNET GDA",
-                "warnings": warnings,
-                "note": "Academic keys return CURATED sources only.",
-            },
+            "metadata": metadata,
         }
 
     def _disease_genes(self, arguments: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/tooluniverse/disgenet_tool.py
+++ b/src/tooluniverse/disgenet_tool.py
@@ -96,6 +96,22 @@ class DisGeNETTool(BaseTool):
             return d
         return None
 
+    @staticmethod
+    def _cui_format_error(disease: str) -> Dict[str, Any]:
+        """Feature-14C-01: shared by every '{disease}' is not a UMLS CUI'
+        error path. 'C0006142' is a fixed format example (breast cancer),
+        never a resolution of the caller's own input -- state that
+        explicitly so it can't be mistaken for a dynamically-resolved CUI."""
+        return {
+            "status": "error",
+            "error": (
+                f"'{disease}' is not a UMLS CUI. Resolve '{disease}' to its "
+                f"own CUI via umls_search_concepts -- 'C0006142' (breast "
+                f"cancer) is only a format example and unrelated to "
+                f"'{disease}'."
+            ),
+        }
+
     def _query_summary(self, kind: str, query: Dict[str, Any]):
         """Call /{gda,vda}/summary with query params. Returns (payload, warnings).
         Raises requests exceptions on HTTP error (handled by callers)."""
@@ -220,10 +236,7 @@ class DisGeNETTool(BaseTool):
         if disease:
             code = self._normalize_disease(disease)
             if code is None:
-                return {
-                    "status": "error",
-                    "error": f"'{disease}' is not a UMLS CUI. Resolve the disease name to a CUI first (e.g. umls_search_concepts), then pass disease='C0152200'.",
-                }
+                return self._cui_format_error(disease)
             query["disease"] = code
         if arguments.get("source"):
             query["source"] = arguments["source"]
@@ -277,13 +290,13 @@ class DisGeNETTool(BaseTool):
         if not disease:
             return {
                 "status": "error",
-                "error": "Missing required parameter: disease (UMLS CUI, e.g. C0152200).",
+                "error": "Missing required parameter: disease (UMLS CUI, e.g. 'C0006142' for breast cancer -- an example format, not a default value).",
             }
         code = self._normalize_disease(disease)
         if code is None:
             return {
                 "status": "error",
-                "error": f"'{disease}' is not a UMLS CUI. Resolve the disease name to a CUI first (e.g. umls_search_concepts), then pass disease='C0152200'.",
+                "error": f"'{disease}' is not a UMLS CUI. Resolve '{disease}' to its own CUI via umls_search_concepts -- 'C0006142' (breast cancer) is only a format example and unrelated to '{disease}'.",
             }
 
         query: Dict[str, Any] = {"disease": code}

--- a/src/tooluniverse/dna_tools.py
+++ b/src/tooluniverse/dna_tools.py
@@ -1879,10 +1879,31 @@ class DNATool(BaseTool):
                 "error": f"Target region ({target_end - target_start} bp) is smaller than product_size_min ({product_size_min} bp)",
             }
 
-        fwd_search_start = max(0, target_start - 50)
-        fwd_search_end = min(seq_len - 18, target_start + 50)
+        # Whole-sequence amplification (no target_start/target_end given) has no
+        # real edge to anchor to -- both primers are free to land anywhere near
+        # the ends, so the coverage constraint below is skipped for this case.
+        is_full_sequence = target_start == 0 and target_end == seq_len
 
-        rev_search_start = max(18, target_end - 50)
+        # The forward primer must *start* at or before target_start (else the
+        # product misses the left edge of the target), and the reverse primer
+        # must *end* at or after target_end (else it misses the right edge) --
+        # both are enforced by the coverage check below. Searching past those
+        # boundaries wastes effort on candidates that can never pass that check,
+        # and worse, can make one of them win the Tm-closeness scoring, causing
+        # a spurious "does not cover the target" failure even though a slightly
+        # worse-scoring, actually-covering primer was available in-window.
+        # Whole-sequence amplification has no such boundary to respect, so it
+        # keeps the original symmetric ±50 bp search window on both ends.
+        fwd_search_start = max(0, target_start - 50)
+        fwd_search_end = (
+            min(seq_len - 18, target_start + 50)
+            if is_full_sequence
+            else min(seq_len - 18, target_start)
+        )
+
+        rev_search_start = (
+            max(18, target_end - 50) if is_full_sequence else max(18, target_end)
+        )
         rev_search_end = min(seq_len, target_end + 50)
 
         complement_map = str.maketrans("ATGCNatgcn", "TACGNtacgn")
@@ -2011,11 +2032,11 @@ class DNATool(BaseTool):
                 ),
             }
 
-        # Verify the product actually spans the requested target region.
-        # Primer search windows are centered ±50 bp around target_start/target_end, so
-        # when the target falls near a sequence boundary the best primers may sit
-        # entirely before (or after) the target, producing a valid product that misses
-        # the declared target. Detect and report instead of silently returning wrong coords.
+        # Verify the product actually spans the requested target region. This is
+        # now mostly a formality since the search windows above already exclude
+        # non-covering candidates for a real target region -- but it stays as a
+        # defensive check (e.g. a target so close to a sequence boundary that no
+        # covering primer exists at all within the ±50 bp search radius).
         #
         # Skip the coverage check when the user requested full-sequence
         # amplification (target_start == 0 and target_end == seq_len).  In that case
@@ -2023,7 +2044,6 @@ class DNATool(BaseTool):
         # be satisfied simultaneously — no primer can start before position 0 or end
         # after the last base.  Any valid primer pair covering the majority of the
         # sequence is acceptable for full-sequence amplification.
-        is_full_sequence = target_start == 0 and target_end == seq_len
         if not is_full_sequence and (
             best_fwd["start"] > target_start or best_rev["end"] < target_end
         ):
@@ -2155,7 +2175,7 @@ class DNATool(BaseTool):
                 "status": "error",
                 "error": f"Unknown enzyme: {enzyme_name}. Golden Gate uses a Type IIS enzyme (BsaI, BbsI, Esp3I/BsmBI, SapI).",
             }
-        canonical, site, _off = resolved
+        canonical, site, cut_off = resolved
 
         # Overhang length: from Biopython when available, else the curated table.
         # The previous -4 default was silently wrong for SapI (3 nt).
@@ -2191,9 +2211,37 @@ class DNATool(BaseTool):
         labels = arguments.get("labels") or []
 
         rc_site = _reverse_complement(site)
+        site_len = len(site)
 
         def _has_site(seq: str) -> bool:
             return site in seq or rc_site in seq
+
+        def _overhang_at(seq2: str, pos: int) -> str:
+            """The ov_len-bp overhang belonging to the fragment on the cut's
+            downstream side, in standard (top-strand-of-the-assembled-insert)
+            notation.
+
+            `pos` is always a top-strand bond index (see `_enzyme_cut_positions`),
+            regardless of which strand actually carried the recognition site that
+            produced it. For a forward-oriented site, the cut leaves a genuine 5'
+            overhang on the top strand immediately downstream, so the literal
+            top-strand bases at `pos` already are the overhang. For a
+            reverse-oriented site (recognition sequence on the bottom strand,
+            e.g. BsaI's GAGACC), the top-strand bond instead lands *before* the
+            overhang region, whose bases on the top strand are only the
+            complement strand's remnant — the real 5' overhang is on the bottom
+            strand at that position, so recovering it requires reverse-
+            complementing the literal read. Distinguish the two cases by checking
+            whether the forward pattern actually starts `cut_off` bases upstream
+            of `pos` (how every forward-type cut was produced); if not, this cut
+            came from the reverse-oriented match instead.
+            """
+            raw = seq2[pos : pos + ov_len]
+            fwd_start = pos - cut_off
+            is_forward_cut = (
+                fwd_start >= 0 and seq2[fwd_start : fwd_start + site_len] == site
+            )
+            return raw if is_forward_cut else _reverse_complement(raw)
 
         pieces = []
         per_input = []
@@ -2223,6 +2271,7 @@ class DNATool(BaseTool):
                 continue
 
             released = 0
+            seq2 = seq + seq
             for i, start in enumerate(cuts):
                 end = cuts[(i + 1) % len(cuts)]
                 if end > start:
@@ -2231,9 +2280,11 @@ class DNATool(BaseTool):
                     span = seq[start:] + seq[:end]
                 else:
                     continue
-                # The overhang at a cut is the ov_len bases starting at the cut.
-                left_ov = (seq + seq)[start : start + ov_len]
-                right_ov = (seq + seq)[end : end + ov_len]
+                # The overhang at a cut is the ov_len bases starting at the cut,
+                # corrected to standard notation if the cut came from a
+                # reverse-oriented site match (see `_overhang_at`).
+                left_ov = _overhang_at(seq2, start)
+                right_ov = _overhang_at(seq2, end)
                 if _has_site(span):
                     continue  # re-cut in the reaction; cannot persist
                 pieces.append(

--- a/src/tooluniverse/ensembl_compara_tool.py
+++ b/src/tooluniverse/ensembl_compara_tool.py
@@ -51,9 +51,33 @@ class EnsemblComparaTool(BaseTool):
         except requests.exceptions.ConnectionError:
             return {"status": "error", "error": "Failed to connect to Ensembl REST API"}
         except requests.exceptions.HTTPError as e:
+            # Include the response body instead of just the status code --
+            # Ensembl's 400s carry a JSON {"error": "..."} explaining what
+            # wasn't recognized (e.g. an unresolved gene symbol), and
+            # silently dropping it left a bare "HTTP error: 400" with no
+            # indication of what to fix. Matches the error-body-extraction
+            # pattern already used by ensembl_map_tool.py and
+            # ensembl_variation_ext_tool.py.
+            status = e.response.status_code if e.response is not None else "unknown"
+            body = ""
+            if e.response is not None:
+                try:
+                    body = e.response.json().get("error", "")
+                except Exception:
+                    body = e.response.text[:200]
+            gene = arguments.get("gene", "")
+            hint = (
+                f" -- gene symbol '{gene}' may not exist for the requested "
+                "species; verify it via ensembl_lookup_gene or "
+                "HGNC_search_genes."
+                if gene
+                else ""
+            )
             return {
                 "status": "error",
-                "error": f"Ensembl API HTTP error: {e.response.status_code}",
+                "error": (
+                    f"Ensembl API HTTP {status}{f': {body}' if body else ''}{hint}"
+                ),
             }
         except Exception as e:
             return {

--- a/src/tooluniverse/ensembl_tool.py
+++ b/src/tooluniverse/ensembl_tool.py
@@ -83,6 +83,19 @@ class EnsemblRESTTool(BaseTool):
             if k not in path_keys and v is not None:
                 query_params[k] = v
 
+        # Ensembl's /sequence/id endpoint calls its protein-sequence option
+        # "protein", not "peptide" -- confirmed live: type=peptide -> HTTP
+        # 400 "The type 'peptide' is not understood by this service" for
+        # every input, making protein sequence retrieval impossible via this
+        # tool. "peptide" is kept as an accepted schema value (it's the
+        # intuitive guess) and silently normalized here rather than removed,
+        # so existing callers using either name both work.
+        if (
+            "/sequence/id" in self.endpoint_template
+            and query_params.get("type") == "peptide"
+        ):
+            query_params["type"] = "protein"
+
         # 4. Special handling for certain endpoints
         # Lookup by symbol needs special routing - handle both stable IDs
         # and symbols.
@@ -110,14 +123,19 @@ class EnsemblRESTTool(BaseTool):
                     if "expand" in arguments:
                         query_params["expand"] = arguments["expand"]
 
-        # Handle overlap/region endpoint - ensure feature parameter is passed
-        if "/overlap/region" in self.endpoint_template:
-            # Feature parameter is required for overlap endpoints
-            if "feature" not in query_params and "feature" in arguments:
-                query_params["feature"] = arguments["feature"]
-            elif "feature" not in query_params:
-                # Default to variation if not specified
-                query_params["feature"] = "variation"
+        # Handle overlap/region endpoint - ensure feature parameter is passed.
+        # Different overlap/region tools mean different things by "default"
+        # (e.g. ensembl_get_structural_variants defaults to
+        # "structural_variation", ensembl_get_overlap_features defaults to
+        # "gene") — use each tool's own schema default instead of hardcoding
+        # "variation" for all of them, which silently returned SNP data from
+        # tools that promise structural variants or genes.
+        if (
+            "/overlap/region" in self.endpoint_template
+            and "feature" not in query_params
+        ):
+            schema_default = schema_props.get("feature", {}).get("default")
+            query_params["feature"] = schema_default or "variation"
 
         # 5. Make HTTP request (with small retry for transient failures)
         try:

--- a/src/tooluniverse/ensembl_tool.py
+++ b/src/tooluniverse/ensembl_tool.py
@@ -50,6 +50,18 @@ class EnsemblRESTTool(BaseTool):
     def run(self, arguments: dict):
         # 0. Apply schema defaults and parameter aliases for path params
         schema_props = self.tool_config.get("parameter", {}).get("properties", {})
+        # Fix-R15C-4: remember which params the caller actually supplied
+        # (before default-injection below) so the stable-ID branch can tell
+        # "user explicitly asked for homo_sapiens" apart from "species was
+        # silently defaulted to homo_sapiens because it's a path placeholder
+        # for the /lookup/symbol/{species}/{gene_id} route". Ensembl stable
+        # IDs (ENSG.../ENSBTAG.../etc.) are already species-specific, so
+        # /lookup/id/{gene_id} needs no species filter -- but forwarding an
+        # auto-defaulted species=homo_sapiens there makes Ensembl reject any
+        # non-human stable ID with a misleading "ID not found" (confirmed
+        # live for bovine ENSBTAG00000026356: works with no species param or
+        # species=cow, HTTP 400 "not found" with species=homo_sapiens).
+        explicitly_provided = set(arguments.keys())
         arguments = dict(arguments)
         # Inject schema defaults for any missing path parameters
         for path_key in re.findall(r"\{([^{}]+)\}", self.endpoint_template):
@@ -110,7 +122,10 @@ class EnsemblRESTTool(BaseTool):
                     url = f"{ENSEMBL_BASE_URL}/lookup/id/{gene_id}"
                     # Don't use expand=1 by default to avoid timeouts
                     query_params = {}
-                    if "species" in arguments:
+                    # Only forward species if the caller explicitly passed
+                    # it -- not when it was auto-defaulted for the (unused,
+                    # for stable IDs) /lookup/symbol/{species}/... route.
+                    if "species" in arguments and "species" in explicitly_provided:
                         query_params["species"] = arguments["species"]
                     if "expand" in arguments:
                         query_params["expand"] = arguments["expand"]

--- a/src/tooluniverse/ensembl_xrefs_tool.py
+++ b/src/tooluniverse/ensembl_xrefs_tool.py
@@ -56,7 +56,22 @@ class EnsemblXrefsTool(BaseTool):
                     "status": "error",
                     "error": "Ensembl ID not found. Provide a valid Ensembl stable ID.",
                 }
-            return {"status": "error", "error": f"Ensembl REST API HTTP {status}"}
+            # Fix-18B-1: swallowing the response body dropped Ensembl's own
+            # actionable message -- e.g. a bad `species` value (common for
+            # xrefs_by_symbol, which takes species as free text like "canine"
+            # instead of the required internal name "canis_lupus_familiaris")
+            # returns HTTP 400 with body {"error": "Can not find internal
+            # name for species 'canine'"}, but callers only ever saw the bare
+            # "Ensembl REST API HTTP 400". The sibling ensembl_tool.py already
+            # includes response text for this reason; do the same here.
+            detail = ""
+            if e.response is not None:
+                detail = (e.response.text or "").strip()[:200]
+            return {
+                "status": "error",
+                "error": f"Ensembl REST API HTTP {status}"
+                + (f": {detail}" if detail else ""),
+            }
         except Exception as e:
             return {"status": "error", "error": f"Unexpected error: {str(e)}"}
 

--- a/src/tooluniverse/faers_analytics_tool.py
+++ b/src/tooluniverse/faers_analytics_tool.py
@@ -112,21 +112,33 @@ class FAERSAnalyticsTool(BaseTool):
                 }
 
             # Get counts for 2x2 table
+            fetch_errors: list = []
             # a = drug + event
-            a = self._get_faers_count(drug_name, adverse_event)
+            a = self._get_faers_count(drug_name, adverse_event, errors=fetch_errors)
 
             # b = drug + no event (all drug reports - drug+event)
-            b = self._get_faers_count(drug_name, None) - a
+            b = self._get_faers_count(drug_name, None, errors=fetch_errors) - a
 
             # c = no drug + event (all event reports - drug+event)
-            c = self._get_faers_count(None, adverse_event) - a
+            c = self._get_faers_count(None, adverse_event, errors=fetch_errors) - a
 
             # d = no drug + no event (total - a - b - c)
-            total = self._get_faers_total_count()
+            total = self._get_faers_total_count(errors=fetch_errors)
             d = total - a - b - c
 
             # Check for valid counts
             if a <= 0 or b <= 0 or c <= 0 or d <= 0:
+                if fetch_errors:
+                    return {
+                        "status": "error",
+                        "error": (
+                            "Could not compute disproportionality: one or more openFDA "
+                            "requests failed, so counts default to 0 rather than "
+                            "reflecting real data. Underlying error(s): "
+                            + "; ".join(dict.fromkeys(fetch_errors))
+                        ),
+                        "contingency_table": {"a": a, "b": b, "c": c, "d": d},
+                    }
                 return {
                     "status": "error",
                     "error": f"Insufficient data: a={a}, b={b}, c={c}, d={d}. Need all counts > 0 for analysis.",
@@ -567,8 +579,26 @@ class FAERSAnalyticsTool(BaseTool):
 
     # Helper methods for statistical calculations
 
-    def _get_faers_count(self, drug_name: str = None, adverse_event: str = None) -> int:
-        """Get count of FAERS reports matching criteria."""
+    def _get_faers_count(
+        self,
+        drug_name: str = None,
+        adverse_event: str = None,
+        errors: list = None,
+    ) -> int:
+        """Get count of FAERS reports matching criteria.
+
+        Fix-R15B-5: a failed fetch (e.g. openFDA's HTTP 429 rate limit) was
+        silently treated the same as a genuine zero-count result, so
+        `_calculate_disproportionality` reported "Insufficient data: a=0,
+        b=0, c=0, d=0" for well-known drug/event pairs during a rate-limit
+        window -- indistinguishable from "this combination truly has no
+        FAERS reports". Confirmed live: retrying the exact same query after
+        the rate limit cleared returned correct nonzero counts and a real
+        ROR/PRR/IC signal. `errors` (when passed) collects the failure
+        reason so the caller can surface "API request failed" instead of a
+        misleading data-availability conclusion; existing callers that don't
+        pass it keep the prior silent-zero behavior unchanged.
+        """
         try:
             query_parts = []
             if drug_name:
@@ -591,12 +621,14 @@ class FAERSAnalyticsTool(BaseTool):
             data = response.json()
             return data.get("meta", {}).get("results", {}).get("total", 0)
 
-        except Exception:
+        except Exception as e:
+            if errors is not None:
+                errors.append(str(e))
             return 0
 
-    def _get_faers_total_count(self) -> int:
+    def _get_faers_total_count(self, errors: list = None) -> int:
         """Get total number of reports in FAERS database."""
-        return self._get_faers_count(None, None)
+        return self._get_faers_count(None, None, errors=errors)
 
     def _calculate_ror_ci(self, a: int, b: int, c: int, d: int) -> Dict[str, float]:
         """Calculate 95% confidence interval for ROR."""

--- a/src/tooluniverse/faers_analytics_tool.py
+++ b/src/tooluniverse/faers_analytics_tool.py
@@ -443,15 +443,45 @@ class FAERSAnalyticsTool(BaseTool):
             ror1 = result1.get("metrics", {}).get("ROR", {}).get("value")
             ror2 = result2.get("metrics", {}).get("ROR", {}).get("value")
 
-            # Determine which drug has stronger signal
+            # Fix-19B-2: comparison text used to rank drugs purely by raw ROR
+            # magnitude ("X shows stronger signal than Y") even when NEITHER
+            # drug actually crossed this tool's own signal-detection
+            # threshold (signal_detection.signal_detected, from ROR lower CI
+            # > 1.0 and case count >= 3) -- confirmed live with
+            # nirsevimab/palivizumab + anaphylactic reaction, where both
+            # drugs had signal_detected=False (ROR < 1, i.e. no elevated-risk
+            # association) but the narrative still said one showed a
+            # "stronger signal" than the other. Ground the wording in
+            # signal_detected so "signal" language only appears when a
+            # signal was actually detected.
+            sig1 = result1.get("signal_detection", {}).get("signal_detected", False)
+            sig2 = result2.get("signal_detection", {}).get("signal_detected", False)
+
             comparison = "Inconclusive"
             if ror1 and ror2:
-                if ror1 > ror2 * 1.5:
-                    comparison = f"{drug1} shows stronger signal than {drug2}"
+                if not sig1 and not sig2:
+                    comparison = (
+                        f"Neither {drug1} nor {drug2} shows a detected safety signal "
+                        f"for {adverse_event} (ROR does not meet the signal-detection "
+                        "threshold for either drug); the higher raw ROR is not a "
+                        "meaningful difference."
+                    )
+                elif sig1 and not sig2:
+                    comparison = (
+                        f"{drug1} shows a detected safety signal for {adverse_event}; "
+                        f"{drug2} does not."
+                    )
+                elif sig2 and not sig1:
+                    comparison = (
+                        f"{drug2} shows a detected safety signal for {adverse_event}; "
+                        f"{drug1} does not."
+                    )
+                elif ror1 > ror2 * 1.5:
+                    comparison = f"Both show a detected signal; {drug1}'s is stronger than {drug2}'s"
                 elif ror2 > ror1 * 1.5:
-                    comparison = f"{drug2} shows stronger signal than {drug1}"
+                    comparison = f"Both show a detected signal; {drug2}'s is stronger than {drug1}'s"
                 else:
-                    comparison = f"{drug1} and {drug2} show similar signals"
+                    comparison = f"{drug1} and {drug2} show similar-strength detected signals"
 
             return {
                 "status": "success",

--- a/src/tooluniverse/faers_analytics_tool.py
+++ b/src/tooluniverse/faers_analytics_tool.py
@@ -1,9 +1,11 @@
 # faers_analytics_tool.py
 
+import os
 import requests
 import math
-from typing import Dict, Any, List, Tuple
+from typing import Dict, Any, List, Tuple, Optional
 from .base_tool import BaseTool
+from .http_utils import request_with_retry
 from .tool_registry import register_tool
 
 FDA_BASE_URL = "https://api.fda.gov/drug/event.json"
@@ -27,6 +29,7 @@ class FAERSAnalyticsTool(BaseTool):
         super().__init__(tool_config)
         self.parameter = tool_config.get("parameter", {})
         self.required = self.parameter.get("required", [])
+        self.api_key = os.getenv("FDA_API_KEY")
 
     def run(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Route to analytics operation."""
@@ -74,6 +77,15 @@ class FAERSAnalyticsTool(BaseTool):
 
         return self._with_data_payload(operation_result)
 
+    def _with_api_key(self, url: str) -> str:
+        """Append FDA_API_KEY (if set) to an openFDA request URL -- reduces
+        how often the anonymous tier's low rate limit is hit (see
+        _get_faers_count)."""
+        if self.api_key:
+            separator = "&" if "?" in url else "?"
+            return f"{url}{separator}api_key={self.api_key}"
+        return url
+
     def _with_data_payload(self, result: Dict[str, Any]) -> Dict[str, Any]:
         """Ensure successful operation responses include a standardized data wrapper."""
         if not isinstance(result, dict):
@@ -111,34 +123,37 @@ class FAERSAnalyticsTool(BaseTool):
                     "error": "Must provide drug_name and adverse_event",
                 }
 
-            # Get counts for 2x2 table
-            fetch_errors: list = []
-            # a = drug + event
-            a = self._get_faers_count(drug_name, adverse_event, errors=fetch_errors)
+            # Get counts for 2x2 table. Each call is Optional[int]: None means
+            # the openFDA request itself failed (e.g. rate limited), which
+            # must not be treated as a genuine zero count -- see
+            # _get_faers_count.
+            a = self._get_faers_count(drug_name, adverse_event)
+            drug_total = self._get_faers_count(drug_name, None)
+            event_total = self._get_faers_count(None, adverse_event)
+            total = self._get_faers_total_count()
+
+            if None in (a, drug_total, event_total, total):
+                return {
+                    "status": "error",
+                    "error": (
+                        "One or more openFDA FAERS count queries failed "
+                        "(commonly HTTP 429 rate limiting on the anonymous "
+                        "tier), so a disproportionality analysis cannot be "
+                        "computed right now. Retry in a moment, or set the "
+                        "FDA_API_KEY environment variable to raise the rate "
+                        "limit (https://open.fda.gov/apis/authentication/)."
+                    ),
+                }
 
             # b = drug + no event (all drug reports - drug+event)
-            b = self._get_faers_count(drug_name, None, errors=fetch_errors) - a
-
+            b = drug_total - a
             # c = no drug + event (all event reports - drug+event)
-            c = self._get_faers_count(None, adverse_event, errors=fetch_errors) - a
-
+            c = event_total - a
             # d = no drug + no event (total - a - b - c)
-            total = self._get_faers_total_count(errors=fetch_errors)
             d = total - a - b - c
 
             # Check for valid counts
             if a <= 0 or b <= 0 or c <= 0 or d <= 0:
-                if fetch_errors:
-                    return {
-                        "status": "error",
-                        "error": (
-                            "Could not compute disproportionality: one or more openFDA "
-                            "requests failed, so counts default to 0 rather than "
-                            "reflecting real data. Underlying error(s): "
-                            + "; ".join(dict.fromkeys(fetch_errors))
-                        ),
-                        "contingency_table": {"a": a, "b": b, "c": c, "d": d},
-                    }
                 return {
                     "status": "error",
                     "error": f"Insufficient data: a={a}, b={b}, c={c}, d={d}. Need all counts > 0 for analysis.",
@@ -249,9 +264,9 @@ class FAERSAnalyticsTool(BaseTool):
             else:
                 base_query = f'patient.drug.openfda.generic_name:"{drug_name}"'
 
-            url = f"{FDA_BASE_URL}?search={base_query}&count={count_field}"
+            url = self._with_api_key(f"{FDA_BASE_URL}?search={base_query}&count={count_field}")
 
-            response = requests.get(url, timeout=30)
+            response = request_with_retry(requests, "GET", url, timeout=30)
             response.raise_for_status()
 
             data = response.json()
@@ -342,17 +357,19 @@ class FAERSAnalyticsTool(BaseTool):
             search_query = base_query + seriousness_map[seriousness_type]
 
             # Get top reactions for serious events
-            url = f"{FDA_BASE_URL}?search={search_query}&count=patient.reaction.reactionmeddrapt.exact"
+            url = self._with_api_key(
+                f"{FDA_BASE_URL}?search={search_query}&count=patient.reaction.reactionmeddrapt.exact"
+            )
 
-            response = requests.get(url, timeout=30)
+            response = request_with_retry(requests, "GET", url, timeout=30)
             response.raise_for_status()
 
             data = response.json()
             results = data.get("results", [])
 
             # Get total serious event count
-            total_url = f"{FDA_BASE_URL}?search={search_query}&limit=1"
-            total_response = requests.get(total_url, timeout=30)
+            total_url = self._with_api_key(f"{FDA_BASE_URL}?search={search_query}&limit=1")
+            total_response = request_with_retry(requests, "GET", total_url, timeout=30)
             total_data = total_response.json()
             total_serious = (
                 total_data.get("meta", {}).get("results", {}).get("total", 0)
@@ -472,9 +489,9 @@ class FAERSAnalyticsTool(BaseTool):
                 search_query = f'patient.drug.openfda.generic_name:"{drug_name}"'
 
             # Get counts by receive date (year)
-            url = f"{FDA_BASE_URL}?search={search_query}&count=receivedate"
+            url = self._with_api_key(f"{FDA_BASE_URL}?search={search_query}&count=receivedate")
 
-            response = requests.get(url, timeout=30)
+            response = request_with_retry(requests, "GET", url, timeout=30)
             response.raise_for_status()
 
             data = response.json()
@@ -542,9 +559,11 @@ class FAERSAnalyticsTool(BaseTool):
 
             # Get preferred term (PT) level reactions
             search_query = f'patient.drug.openfda.generic_name:"{drug_name}"'
-            url = f"{FDA_BASE_URL}?search={search_query}&count=patient.reaction.reactionmeddrapt.exact"
+            url = self._with_api_key(
+                f"{FDA_BASE_URL}?search={search_query}&count=patient.reaction.reactionmeddrapt.exact"
+            )
 
-            response = requests.get(url, timeout=30)
+            response = request_with_retry(requests, "GET", url, timeout=30)
             response.raise_for_status()
 
             data = response.json()
@@ -580,24 +599,20 @@ class FAERSAnalyticsTool(BaseTool):
     # Helper methods for statistical calculations
 
     def _get_faers_count(
-        self,
-        drug_name: str = None,
-        adverse_event: str = None,
-        errors: list = None,
-    ) -> int:
+        self, drug_name: str = None, adverse_event: str = None
+    ) -> Optional[int]:
         """Get count of FAERS reports matching criteria.
 
-        Fix-R15B-5: a failed fetch (e.g. openFDA's HTTP 429 rate limit) was
-        silently treated the same as a genuine zero-count result, so
-        `_calculate_disproportionality` reported "Insufficient data: a=0,
-        b=0, c=0, d=0" for well-known drug/event pairs during a rate-limit
-        window -- indistinguishable from "this combination truly has no
-        FAERS reports". Confirmed live: retrying the exact same query after
-        the rate limit cleared returned correct nonzero counts and a real
-        ROR/PRR/IC signal. `errors` (when passed) collects the failure
-        reason so the caller can surface "API request failed" instead of a
-        misleading data-availability conclusion; existing callers that don't
-        pass it keep the prior silent-zero behavior unchanged.
+        Returns None (not 0) if the request fails (e.g. rate limited or a
+        network error), so a failure isn't mistaken for a genuine zero
+        count -- a failed fetch used to be silently treated as a genuine
+        zero-count result, so `_calculate_disproportionality` reported
+        "Insufficient data: a=0, b=0, c=0, d=0" for well-known drug/event
+        pairs during a rate-limit window, indistinguishable from "this
+        combination truly has no FAERS reports" (confirmed live: retrying
+        the exact same query after the rate limit cleared returned correct
+        nonzero counts and a real ROR/PRR/IC signal). Callers must check
+        for None before doing arithmetic.
         """
         try:
             query_parts = []
@@ -615,20 +630,23 @@ class FAERSAnalyticsTool(BaseTool):
                 search_query = "+AND+".join(query_parts)
                 url = f"{FDA_BASE_URL}?search={search_query}&limit=1"
 
-            response = requests.get(url, timeout=30)
+            url = self._with_api_key(url)
+
+            response = request_with_retry(requests, "GET", url, timeout=30)
+            if response.status_code == 404:
+                # openFDA returns 404 (not an empty 200) for a query with no matches.
+                return 0
             response.raise_for_status()
 
             data = response.json()
             return data.get("meta", {}).get("results", {}).get("total", 0)
 
-        except Exception as e:
-            if errors is not None:
-                errors.append(str(e))
-            return 0
+        except Exception:
+            return None
 
-    def _get_faers_total_count(self, errors: list = None) -> int:
+    def _get_faers_total_count(self) -> Optional[int]:
         """Get total number of reports in FAERS database."""
-        return self._get_faers_count(None, None, errors=errors)
+        return self._get_faers_count(None, None)
 
     def _calculate_ror_ci(self, a: int, b: int, c: int, d: int) -> Dict[str, float]:
         """Calculate 95% confidence interval for ROR."""

--- a/src/tooluniverse/fda_label_tool.py
+++ b/src/tooluniverse/fda_label_tool.py
@@ -7,9 +7,11 @@ prescribing information including indications, dosing, contraindications,
 warnings, drug interactions, and pharmacology.
 
 API: https://open.fda.gov/apis/drug/label/
-No authentication required. Optional API key raises rate limits.
+No authentication required. Set the FDA_API_KEY env var to raise the
+default ~40 req/min anonymous rate limit (https://open.fda.gov/apis/authentication/).
 """
 
+import os
 import requests
 from typing import Any
 
@@ -17,6 +19,16 @@ from .base_tool import BaseTool
 from .tool_registry import register_tool
 
 FDA_LABEL_URL = "https://api.fda.gov/drug/label.json"
+
+# Placeholder values users sometimes leave in FDA_API_KEY; treat as "unset".
+_API_KEY_PLACEHOLDERS = {"none", "null", "your_fda_key_here", "your_key_here"}
+
+
+def _valid_api_key(value: Any) -> bool:
+    if not isinstance(value, str):
+        return False
+    v = value.strip()
+    return bool(v) and v.lower() not in _API_KEY_PLACEHOLDERS
 
 
 def _ok(data: Any, **metadata: Any) -> dict:
@@ -84,6 +96,17 @@ class FDALabelTool(BaseTool):
     def __init__(self, tool_config: dict[str, Any]):
         super().__init__(tool_config)
         self.query_type = tool_config.get("fields", {}).get("query_type", "search")
+        self.api_key = os.getenv("FDA_API_KEY")
+
+    def _params(self, **kwargs: Any) -> dict:
+        """Build request params, adding api_key when a valid FDA_API_KEY is set.
+
+        openFDA's anonymous tier is heavily rate-limited (~40 req/min); an
+        API key raises that substantially. See https://open.fda.gov/apis/authentication/
+        """
+        if _valid_api_key(self.api_key):
+            kwargs["api_key"] = self.api_key
+        return kwargs
 
     def run(self, arguments: dict[str, Any]) -> Any:
         try:
@@ -113,7 +136,7 @@ class FDALabelTool(BaseTool):
             for q in (f'{field}:"{drug_name}"', f"{field}:{drug_name}"):
                 resp = requests.get(
                     FDA_LABEL_URL,
-                    params={"search": q, "limit": limit},
+                    params=self._params(search=q, limit=limit),
                     timeout=20,
                 )
                 if resp.status_code == 404:
@@ -139,7 +162,7 @@ class FDALabelTool(BaseTool):
         q = f'indications_and_usage:"{indication}"'
         resp = requests.get(
             FDA_LABEL_URL,
-            params={"search": q, "limit": limit},
+            params=self._params(search=q, limit=limit),
             timeout=20,
         )
         labels = []
@@ -173,10 +196,10 @@ class FDALabelTool(BaseTool):
         limit = min(int(arguments.get("limit", 20)), 100)
         resp = requests.get(
             FDA_LABEL_URL,
-            params={
-                "count": "openfda.pharm_class_epc.exact",
-                "limit": limit,
-            },
+            params=self._params(
+                count="openfda.pharm_class_epc.exact",
+                limit=limit,
+            ),
             timeout=20,
         )
         resp.raise_for_status()

--- a/src/tooluniverse/graphql_tool.py
+++ b/src/tooluniverse/graphql_tool.py
@@ -3,10 +3,13 @@ from graphql.language import parse
 from graphql.validation import validate
 from .base_tool import BaseTool
 from .tool_registry import register_tool
+import logging
 import re
 import requests
 import copy
 import time
+
+logger = logging.getLogger(__name__)
 
 # Upper bound on how long DiseaseTargetScoreTool will paginate through
 # OpenTargets associatedTargets before returning what it has so far. A
@@ -73,18 +76,29 @@ def execute_query(endpoint_url, query, variables=None):
         result = remove_none_and_empty_values(result)
         # Check if the response contains errors
         if "errors" in result:
-            print("Invalid Query: ", result["errors"])
+            # Log only the human-readable `message` of each GraphQL error, not
+            # the raw error objects: some APIs (e.g. OpenNeuro) include an
+            # `extensions.stacktrace` with internal server file paths, which
+            # was previously printed to stdout verbatim -- visible in every
+            # caller's output (CLI, MCP client) as an internal-implementation
+            # leak, not a useful diagnostic. `logger.debug` also keeps this out
+            # of default-level output entirely.
+            messages = [
+                e.get("message", str(e)) if isinstance(e, dict) else str(e)
+                for e in result["errors"]
+            ]
+            logger.debug("GraphQL query returned errors: %s", "; ".join(messages))
             return None
         # Feature-94A-002: always return result when data key is present,
         # even if all values are empty/null (e.g. disease not found = {"data": {}}).
         # Callers distinguish empty results from errors via status envelope.
         elif "data" not in result:
-            print("No data returned")
+            logger.debug("GraphQL response had no 'data' key")
             return None
         else:
             return result
     except requests.exceptions.JSONDecodeError:
-        print("JSONDecodeError: Could not decode the response as JSON")
+        logger.debug("Could not decode GraphQL response as JSON")
         return None
 
 

--- a/src/tooluniverse/graphql_tool.py
+++ b/src/tooluniverse/graphql_tool.py
@@ -145,7 +145,25 @@ class GraphQLTool(BaseTool):
         # ({"search": {}}) and is therefore not caught here.
         if not data:
             return {"status": "error", "error": self._empty_result_error(arguments)}
-        return {"status": "success", "data": data}
+        result = {"status": "success", "data": data}
+        # Fix Round 17: for a search(...)-shaped query, the same stripping
+        # collapses a genuine 0-hit result down to an opaque empty container
+        # ({"search": {}}) once its "hits": [] list is removed -- indistinguishable
+        # from a malformed/broken response without reading this source file.
+        # Confirmed live: OpenTargets_get_disease_ids_by_name with
+        # "high-risk prostate cancer" returns status=success, data={"search": {}},
+        # with no indication that this means zero matches. Only fires for queries
+        # that actually declare a "hits" field, so entity-lookup tools (which
+        # legitimately return smaller nested objects) are unaffected.
+        if "hits" in self.query_schema:
+            empty_key = next((k for k, v in data.items() if v == {}), None)
+            if empty_key:
+                result.setdefault("metadata", {})["note"] = (
+                    f"0 matches found (empty '{empty_key}' result). This is a "
+                    "genuine zero-hit search, not an error -- try a shorter or "
+                    "simpler phrasing of the search term."
+                )
+        return result
 
 
 _OT_SEARCH_QUERY = """

--- a/src/tooluniverse/gwas_tool.py
+++ b/src/tooluniverse/gwas_tool.py
@@ -152,11 +152,33 @@ class GWASRESTTool(BaseTool):
         # them was GWAS_search_associations_by_gene/gwas_get_snps_for_gene
         # (gene-based lookup), not a reworded trait string. Point to that
         # real fallback instead of a generic, non-adaptive example.
+        #
+        # Fix-R13C-1: GWAS Catalog's own trait-label search (used to
+        # resolve a plain-text disease_trait) isn't restricted to EFO --
+        # it also returns HPO/Orphanet/MONDO terms, and does no synonym
+        # expansion, so the exact current clinical term for a disease can
+        # resolve to a real-but-disconnected ontology term with zero
+        # tagged associations while an older/alternate synonym resolves
+        # to a term with real data. Confirmed live: "premature ovarian
+        # insufficiency" resolves to HP_0008209 (0 associations), but the
+        # older synonym "premature ovarian failure" resolves to
+        # MONDO_0005387 (9 real associations, e.g. PMID 21989058).
+        non_efo = not efo_id.upper().startswith("EFO")
+        ontology_hint = (
+            f" '{efo_id}' is not an EFO term (GWAS Catalog's trait search "
+            "also returns HPO/Orphanet/MONDO terms), and this ontology "
+            "does no synonym expansion, so it may resolve a current "
+            "clinical term to a real-but-disconnected entry."
+            if non_efo
+            else ""
+        )
         return (
-            f"No associations found for EFO ID '{efo_id}'. "
+            f"No associations found for EFO ID '{efo_id}'.{ontology_hint} "
             "GWAS Catalog may tag related associations under a different "
             "EFO/MONDO term, or under pleiotropic traits rather than this "
-            "specific one. If you know the gene of interest, try "
+            "specific one -- try an older/alternate clinical synonym of "
+            "the trait (e.g. an outdated but still-indexed name) if one "
+            "exists. If you know the gene of interest, try "
             "GWAS_search_associations_by_gene or gwas_get_snps_for_gene "
             "instead, which search by gene rather than by trait term."
         )

--- a/src/tooluniverse/hpo_tool.py
+++ b/src/tooluniverse/hpo_tool.py
@@ -291,13 +291,34 @@ class HPOTool(BaseTool):
                 if t and t.get("name")
             ]
 
+        metadata = {
+            "source": "HPO (JAX Ontology)",
+            "term_id": term_id,
+        }
+        # The JAX ontology API silently resolves an obsolete/merged HPO ID to
+        # its replacement term's record -- with no obsolescence flag anywhere
+        # in the payload -- rather than 404ing or marking the response as a
+        # redirect. Detect the ID mismatch ourselves and surface it, so a
+        # caller doesn't mistake the replacement term's data for the term
+        # they actually asked about (confirmed live: querying an obsolete ID
+        # like HP:0006887 silently returns HP:0001249's full record).
+        resolved_id = result["id"]
+        if resolved_id and resolved_id != term_id:
+            metadata["requested_id"] = term_id
+            metadata["resolved_id"] = resolved_id
+            metadata["note"] = (
+                f"The requested term ID ({term_id}) differs from the "
+                f"returned term's ID ({resolved_id}). This usually means "
+                f"{term_id} is obsolete or was merged into {resolved_id} "
+                "upstream. Use get_phenotype_by_HPO_ID for an explicit "
+                "'deprecated' flag, or HPO_search_terms to find the "
+                "current preferred term."
+            )
+
         return {
             "status": "success",
             "data": result,
-            "metadata": {
-                "source": "HPO (JAX Ontology)",
-                "term_id": term_id,
-            },
+            "metadata": metadata,
         }
 
     def _search_terms(self, arguments: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/tooluniverse/hpo_tool.py
+++ b/src/tooluniverse/hpo_tool.py
@@ -213,7 +213,8 @@ class HPOTool(BaseTool):
         """Get genes or diseases annotated to an HPO phenotype term.
 
         Uses the JAX network-annotation endpoint, which returns the genes,
-        diseases, assays and medical actions linked to a phenotype.
+        diseases, assays and medical actions linked to a phenotype in a
+        single response (the endpoint itself has no server-side paging).
         """
         term_id = arguments.get("term_id", "")
         if not term_id:
@@ -229,6 +230,21 @@ class HPOTool(BaseTool):
             limit = 50
         limit = max(1, min(limit, 500))
 
+        # Fix-19C-1/19C-2: a phenotype term can be linked to thousands of
+        # genes/diseases (confirmed live: HP:0001263 "Global developmental
+        # delay" has 2077 genes), but `limit` is capped at 500 and this
+        # endpoint has no server-side paging -- previously the tool always
+        # sliced from position 0, so well-known genes/diseases sorted past
+        # position 500 by the API (e.g. SHANK3, MECP2 for that term) were
+        # permanently unreachable with no way to page further. The full list
+        # is already in memory from the one API call below, so paging is a
+        # free client-side slice -- no extra round-trip needed.
+        try:
+            offset = int(arguments.get("offset", 0) or 0)
+        except (TypeError, ValueError):
+            offset = 0
+        offset = max(0, offset)
+
         # The annotation endpoint lives under /api/network/, not /api/hp/.
         url = f"{HPO_ANNOTATION_URL}/{term_id}"
         response = requests.get(url, timeout=self.timeout)
@@ -238,7 +254,7 @@ class HPOTool(BaseTool):
         items = data.get(kind) or []
         total = len(items)
         trimmed = []
-        for it in items[:limit]:
+        for it in items[offset : offset + limit]:
             entry = {"id": it.get("id"), "name": it.get("name")}
             if kind == "diseases":
                 entry["mondo_id"] = it.get("mondoId")
@@ -251,7 +267,9 @@ class HPOTool(BaseTool):
                 "source": "HPO (JAX Ontology) network annotation",
                 "term_id": term_id,
                 "total": total,
+                "offset": offset,
                 "returned": len(trimmed),
+                "has_more": offset + len(trimmed) < total,
             },
         }
 

--- a/src/tooluniverse/kegg_ext_tool.py
+++ b/src/tooluniverse/kegg_ext_tool.py
@@ -219,6 +219,32 @@ class KEGGExtTool(BaseTool):
                     "error": f"Could not resolve gene symbol '{gene_id}' to a KEGG gene ID for organism '{organism}'. Use KEGG format 'hsa:7157' directly, or verify the gene symbol.",
                 }
             gene_id = resolved
+        else:
+            # Fix-R15C-2: a caller can plausibly pass "org:SYMBOL" (e.g.
+            # "bta:DGAT1") by analogy with the documented "hsa:7157" format,
+            # assuming the part after the colon is a gene identifier of any
+            # kind. KEGG's numeric gene IDs are org-specific and don't match
+            # symbols, so link/pathway silently returns zero rows for a
+            # symbol -- confirmed live: "bta:DGAT1" -> pathway_count 0, while
+            # the equivalent gene_symbol="DGAT1", organism="bta" resolves to
+            # "bta:282609" and returns 4 real pathways. Detect this shape
+            # (non-numeric ID part) and resolve it the same way as the
+            # bare-symbol branch above, instead of returning a silently
+            # empty "no pathways" result that looks like a real negative.
+            org_prefix, _, id_part = gene_id.partition(":")
+            if id_part and not id_part.isdigit():
+                resolved = self._resolve_gene_symbol(id_part, org_prefix)
+                if not resolved:
+                    return {
+                        "status": "error",
+                        "error": (
+                            f"'{gene_id}' looks like 'organism:SYMBOL' rather than a KEGG "
+                            f"numeric gene ID, and '{id_part}' could not be resolved to one "
+                            f"for organism '{org_prefix}'. Use KEGG format '{org_prefix}:7157' "
+                            f"directly, or pass gene_symbol='{id_part}', organism='{org_prefix}'."
+                        ),
+                    }
+                gene_id = resolved
 
         # Get pathway links for this gene
         url = f"{KEGG_BASE_URL}/link/pathway/{gene_id}"

--- a/src/tooluniverse/kegg_ext_tool.py
+++ b/src/tooluniverse/kegg_ext_tool.py
@@ -1032,8 +1032,12 @@ class KEGGExtTool(BaseTool):
             "diseases": [],
             "drugs": [],
             "elements": [],
+            "genes": [],
+            "pathways": [],
         }
 
+        gene_lines: list = []
+        pathway_lines: list = []
         current_field = None
         for line in text.split("\n"):
             if line.startswith("NAME"):
@@ -1066,6 +1070,18 @@ class KEGGExtTool(BaseTool):
                 # they're merged into the one "elements" output field.
                 current_field = "ELEMENT"
                 result["elements"].append(line[12:].strip())
+            elif line.startswith("GENE"):
+                # N#####-style perturbed-network records (e.g. N00151) list
+                # the genes driving the network here as "<entrez_id>  <SYMBOL>;
+                # <description>" -- previously unhandled entirely, so the tool
+                # returned an empty gene list for exactly the records where a
+                # caller needs it most, forcing manual decoding of the numeric
+                # Entrez IDs embedded in "expanded" instead.
+                current_field = "GENE"
+                gene_lines.append(line[12:].strip())
+            elif line.startswith("PATHWAY"):
+                current_field = "PATHWAY"
+                pathway_lines.append(line[12:].strip())
             elif line.startswith("///"):
                 break
             elif line.startswith("            "):
@@ -1078,10 +1094,32 @@ class KEGGExtTool(BaseTool):
                     result["drugs"].append(content)
                 elif current_field == "ELEMENT":
                     result["elements"].append(content)
+                elif current_field == "GENE":
+                    gene_lines.append(content)
+                elif current_field == "PATHWAY":
+                    pathway_lines.append(content)
                 elif current_field == "DEFINITION":
                     result["definition"] = (result["definition"] or "") + " " + content
             else:
                 current_field = None
+
+        for gene_line in gene_lines:
+            entrez_id, _, rest = gene_line.partition("  ")
+            entrez_id = entrez_id.strip()
+            symbol, _, description = rest.strip().partition(";")
+            if entrez_id:
+                result["genes"].append(
+                    {
+                        "entrez_id": entrez_id,
+                        "symbol": symbol.strip(),
+                        "description": description.strip(),
+                    }
+                )
+
+        result["pathways"] = [
+            {"pathway_id": pid, "name": name}
+            for pid, name in self._parse_id_map(pathway_lines).items()
+        ]
 
         return {
             "status": "success",

--- a/src/tooluniverse/llm_clients.py
+++ b/src/tooluniverse/llm_clients.py
@@ -6,6 +6,25 @@ import time
 import json as _json
 
 
+def _model_family(model_id: str) -> str:
+    """Return the provider-independent model portion of a model ID."""
+    if not isinstance(model_id, str):
+        return ""
+    return model_id.rsplit("/", 1)[-1].lower()
+
+
+def is_reasoning_model(model_id: str) -> bool:
+    """True for OpenAI "reasoning" model families (o1/o3/o4/gpt-5 and their
+    variants, e.g. "o4-mini", "gpt-5-mini"). These models only support the
+    default temperature (reject any explicit value with a 400 error) and
+    take `max_completion_tokens` instead of `max_tokens`. Single source of
+    truth for both restrictions so the two checks can't drift out of sync
+    the way they previously did (temperature normalization was missing
+    "gpt-5" even though token-limit routing already had it).
+    """
+    return _model_family(model_id).startswith(("gpt-5", "o1", "o3", "o4"))
+
+
 class BaseLLMClient:
     def test_api(self) -> None:
         raise NotImplementedError
@@ -177,9 +196,12 @@ class AzureOpenAIClient(BaseLLMClient):
     def _normalize_temperature(
         self, model_id: str, temperature: Optional[float]
     ) -> Optional[float]:
-        if isinstance(model_id, str) and (
-            model_id.startswith("o3-mini") or model_id.startswith("o4-mini")
-        ):
+        # Reasoning-style models (o-series and gpt-5 family) only support
+        # the default temperature (1) and reject any explicit value with a
+        # 400 error. self._model_id defaults to "gpt-5" (see AgenticTool),
+        # so is_reasoning_model() previously missing "gpt-5" meant this
+        # fired on every default-configured Azure call.
+        if is_reasoning_model(model_id):
             if temperature is not None:
                 self.logger.warning(
                     f"Model {model_id} does not support 'temperature'; ignoring provided value."
@@ -722,15 +744,17 @@ class OpenAICompatibleClient(BaseLLMClient):
 
     @classmethod
     def _uses_max_completion_tokens(cls, model_id: str) -> bool:
-        family = cls._model_family(model_id)
-        return family.startswith(("gpt-5", "o1", "o3", "o4"))
+        return is_reasoning_model(model_id)
 
     @classmethod
     def _normalize_temperature(
         cls, model_id: str, temperature: Optional[float]
     ) -> Optional[float]:
-        family = cls._model_family(model_id)
-        if family.startswith(("o1", "o3", "o4")):
+        # Both this and _uses_max_completion_tokens above now delegate to
+        # the single module-level is_reasoning_model() classifier, so the
+        # two checks can no longer independently drift out of sync (gpt-5
+        # was previously missing from this method only).
+        if is_reasoning_model(model_id):
             return None
         return temperature
 

--- a/src/tooluniverse/mgnify_expanded_tool.py
+++ b/src/tooluniverse/mgnify_expanded_tool.py
@@ -52,9 +52,26 @@ class MGnifyExpandedTool(BaseTool):
                 "error": "Failed to connect to MGnify API. Check network connectivity.",
             }
         except requests.exceptions.HTTPError as e:
+            status_code = e.response.status_code if e.response is not None else None
+            query_id = (
+                arguments.get("study_accession")
+                or arguments.get("analysis_id")
+                or arguments.get("genome_id")
+                or arguments.get("sample_accession")
+            )
+            if status_code == 404:
+                detail = f" for '{query_id}'" if query_id else ""
+                return {
+                    "status": "error",
+                    "error": (
+                        f"MGnify API returned 404 Not Found{detail}. Check that the "
+                        "accession/ID is correct (e.g. a typo, or an ID from a "
+                        "different record type)."
+                    ),
+                }
             return {
                 "status": "error",
-                "error": f"MGnify API HTTP error: {e.response.status_code}",
+                "error": f"MGnify API HTTP error: {status_code}",
             }
         except Exception as e:
             return {
@@ -266,16 +283,24 @@ class MGnifyExpandedTool(BaseTool):
         attrs = data.get("attributes", {})
         rels = data.get("relationships", {})
 
+        # The MGnify studies/{accession} endpoint exposes "is-private" (not
+        # "is-public"), and does not include analyses/downloads counts under
+        # relationships.*.meta.count (only a "related" link with no count) --
+        # confirmed live against the API. Invert is-private into is_public,
+        # and surface samples-count (which the API does return) instead of
+        # the two counts that could never be populated from this endpoint.
+        # Use MGnify_list_analyses / MGnify_list_analysis_downloads to get
+        # exact analyses/downloads counts for a study.
+        is_private = attrs.get("is-private")
         result = {
             "study_id": data.get("id"),
             "study_name": attrs.get("study-name"),
             "study_abstract": attrs.get("study-abstract"),
             "bioproject": attrs.get("bioproject"),
             "centre_name": attrs.get("centre-name"),
-            "is_public": attrs.get("is-public"),
+            "is_public": (not is_private) if is_private is not None else None,
             "last_update": attrs.get("last-update"),
-            "analyses_count": rels.get("analyses", {}).get("meta", {}).get("count"),
-            "downloads_count": rels.get("downloads", {}).get("meta", {}).get("count"),
+            "samples_count": attrs.get("samples-count"),
             "biomes": [b.get("id") for b in rels.get("biomes", {}).get("data", [])],
         }
 

--- a/src/tooluniverse/ncbi_datasets_tool.py
+++ b/src/tooluniverse/ncbi_datasets_tool.py
@@ -288,15 +288,41 @@ class NCBIDatasetsTool(BaseTool):
 
         reports = result.get("reports", [])
         if not reports:
+            metadata = {
+                "total_results": 0,
+                "query_symbol": symbol,
+                "query_taxon": taxon,
+                "source": "NCBI Datasets API v2",
+            }
+            # Fix-R15C-1: NCBI returns HTTP 200 (not an error) for some
+            # unresolvable taxon tokens, but includes a "messages" warning
+            # explaining why -- e.g. taxon="cattle" gets
+            # gene_warning_code=ABOVE_SPECIES_TAXON ("belongs to a taxonomy
+            # level above species") instead of the "reports" the caller
+            # expects. Previously this warning was discarded, so a plain
+            # empty-success response was indistinguishable from "this gene
+            # genuinely has no match for this taxon" (confirmed: taxon="cow"
+            # succeeds with data, taxon="bovine" errors outright, and
+            # taxon="cattle" -- silently -- returns neither). Surface the
+            # warning so the caller can tell "bad taxon token" from "real
+            # zero-match".
+            api_messages = result.get("messages") or []
+            warnings = [
+                m["warning"]["message"]
+                for m in api_messages
+                if isinstance(m, dict) and m.get("warning", {}).get("message")
+            ]
+            if warnings:
+                metadata["warning"] = (
+                    " ".join(warnings)
+                    + " Try a more specific taxon (e.g. a species common name "
+                    "like 'cow' or 'pig' rather than a broader group name, "
+                    "or an NCBI Taxonomy ID)."
+                )
             return {
                 "status": "success",
                 "data": [],
-                "metadata": {
-                    "total_results": 0,
-                    "query_symbol": symbol,
-                    "query_taxon": taxon,
-                    "source": "NCBI Datasets API v2",
-                },
+                "metadata": metadata,
             }
 
         genes = []

--- a/src/tooluniverse/omim_tool.py
+++ b/src/tooluniverse/omim_tool.py
@@ -114,16 +114,37 @@ class OMIMTool(BaseTool):
             omim_data = data.get("omim", {})
             search_response = omim_data.get("searchResponse", {})
 
+            # Search results are a lightweight index, not full records: keep
+            # only MIM number, title, entry type (prefix), and status. The
+            # full record (text sections, allelic variants, references, gene
+            # map, etc.) is available per-entry via OMIM_get_entry using the
+            # mimNumber returned here.
+            summarized_entries = []
+            for item in search_response.get("entryList", []):
+                entry = item.get("entry", {})
+                summarized_entries.append(
+                    {
+                        "mim_number": entry.get("mimNumber"),
+                        "prefix": entry.get("prefix"),
+                        "status": entry.get("status"),
+                        "preferred_title": entry.get("titles", {}).get(
+                            "preferredTitle"
+                        ),
+                        "matches": entry.get("matches"),
+                    }
+                )
+
             return {
                 "status": "success",
                 "data": {
                     "total_results": search_response.get("totalResults", 0),
                     "start": search_response.get("startIndex", 0),
-                    "entries": search_response.get("entryList", []),
+                    "entries": summarized_entries,
                 },
                 "metadata": {
                     "source": "OMIM",
                     "query": query,
+                    "note": "Use OMIM_get_entry with mim_number for full record details.",
                 },
             }
 

--- a/src/tooluniverse/openalex_tool.py
+++ b/src/tooluniverse/openalex_tool.py
@@ -40,9 +40,20 @@ class OpenAlexTool(BaseTool):
                 "status": "error",
                 "error": "`search_keywords` (or `query`) parameter is required and must be non-empty.",
             }
-        max_results = arguments.get("max_results", arguments.get("limit", 10))
-        year_from = arguments.get("year_from", None)
-        year_to = arguments.get("year_to", None)
+        # Fix Round 16: the schema has no `additionalProperties: false`, so a
+        # plausible-but-wrong param name (confirmed live: `num_results` and
+        # `start_year`, both natural guesses given other ToolUniverse
+        # literature tools use those exact names) was silently dropped by
+        # jsonschema and the call fell back to defaults/unfiltered results
+        # with no error -- a caller asking for "papers since 2023" got
+        # 2011/2018 papers back with no indication the year filter never
+        # applied. Accept the same common variants already covered for
+        # search_keywords/max_results above.
+        max_results = arguments.get(
+            "max_results", arguments.get("limit", arguments.get("num_results", 10))
+        )
+        year_from = arguments.get("year_from", arguments.get("start_year", None))
+        year_to = arguments.get("year_to", arguments.get("end_year", None))
         open_access = arguments.get("open_access", None)
         require_has_fulltext = bool(arguments.get("require_has_fulltext", False))
         fulltext_terms = arguments.get("fulltext_terms")

--- a/src/tooluniverse/package_tool.py
+++ b/src/tooluniverse/package_tool.py
@@ -67,6 +67,53 @@ class PackageTool(BaseTool):
             # chained .get() then crashes with "'NoneType' has no attribute 'get'".
             project_urls = info.get("project_urls") or {}
 
+            # Repository URL: PyPI project_urls has no fixed key name -- projects
+            # use "Repository", "Source", "Source Code", "Code", "Homepage",
+            # or "GitHub" interchangeably (e.g. mne-python only sets "Source
+            # Code"). Try the common variants in order before giving up.
+            repository = ""
+            for key in (
+                "Repository",
+                "Source",
+                "Source Code",
+                "Code",
+                "GitHub",
+                "Development",
+                "Homepage",
+            ):
+                if project_urls.get(key):
+                    repository = project_urls[key]
+                    break
+
+            # Supported Python versions: `classifiers` is a flat list of ALL PyPI
+            # trove classifiers (license, OS, dev status, audience, ...), not
+            # just Python versions -- filtering to "Programming Language ::
+            # Python :: 3.X" entries gives the real list. Some packages (e.g.
+            # mne-python) only declare the generic "Python :: 3" classifier
+            # without per-minor-version entries; `requires_python` (e.g.
+            # ">=3.10") is the reliable fallback for those.
+            classifiers = info.get("classifiers") or []
+            python_versions = []
+            for classifier in classifiers:
+                if not classifier.startswith("Programming Language :: Python ::"):
+                    continue
+                version = classifier.rsplit("::", 1)[-1].strip()
+                if "." in version and version.replace(".", "").isdigit():
+                    python_versions.append(version)
+            if not python_versions and info.get("requires_python"):
+                python_versions = [info["requires_python"]]
+
+            # Last-updated date: `last_serial` is PyPI's internal monotonic
+            # change-counter (currently tens of millions), not a timestamp --
+            # using it as a Unix epoch decodes to bogus 1970s dates. The real
+            # upload date of the current release lives in `urls[*].upload_time_iso_8601`.
+            urls_info = pypi_data.get("urls") or []
+            last_updated = (
+                urls_info[0].get("upload_time_iso_8601", "Unknown")
+                if urls_info
+                else "Unknown"
+            )
+
             # Build response with PyPI data
             result = {
                 "package_name": info.get("name", self.package_name),
@@ -76,10 +123,8 @@ class PackageTool(BaseTool):
                 "license": info.get("license", "Not specified"),
                 "home_page": info.get("home_page", ""),
                 "documentation": project_urls.get("Documentation", ""),
-                "repository": project_urls.get(
-                    "Repository", project_urls.get("Source", "")
-                ),
-                "python_versions": info.get("classifiers", []),
+                "repository": repository,
+                "python_versions": python_versions,
                 "keywords": (
                     info.get("keywords", "").split(",") if info.get("keywords") else []
                 ),
@@ -89,7 +134,7 @@ class PackageTool(BaseTool):
                     "pip_upgrade": f"pip install --upgrade {self.package_name}",
                 },
                 "source": "pypi",
-                "last_updated": pypi_data.get("last_serial", "Unknown"),
+                "last_updated": last_updated,
             }
 
             # Merge with local enhanced information

--- a/src/tooluniverse/panelapp_tool.py
+++ b/src/tooluniverse/panelapp_tool.py
@@ -11,6 +11,7 @@ API's fixed page_size=100) and filters client-side by substring match
 against name/disease_group/disease_sub_group.
 """
 
+import os
 from typing import Any, Dict
 
 from .base_rest_tool import BaseRESTTool
@@ -18,6 +19,41 @@ from .tool_registry import register_tool
 
 PANELS_URL = "https://panelapp.genomicsengland.co.uk/api/v1/panels/"
 _MAX_PAGES = 10  # safety cap; ~434 panels / 100 per page = 5 pages today
+
+# Thresholds for the inflection heuristic in _word_matches(). English
+# plural/adjectival suffixes (e.g. "y"->"ies", "-opathy"->"-opathies") are
+# usually 1-3 characters, so a shared prefix within 3 characters of the
+# shorter word's length is treated as the same term. _MIN_WORD_LEN and
+# _MAX_LEN_DIFF guard against short/dissimilar-length words matching by
+# coincidence (e.g. "cardiac" vs "cardiomyopathy" must NOT match).
+_MIN_WORD_LEN = 6
+_MAX_LEN_DIFF = 4
+_MAX_SUFFIX_DROP = 3
+
+
+def _word_matches(query_word: str, haystack_word: str) -> bool:
+    """True if two words are the same disease term modulo simple English
+    inflection (singular/plural, e.g. "haemoglobinopathy" vs
+    "haemoglobinopathies"). Deliberately NOT a general substring match --
+    e.g. "myopathy" is a literal substring of "cardiomyopathy" but they are
+    different, unrelated panel topics, so containment alone is too loose.
+    Only an exact match, or a shared prefix between two words of similar
+    length (inflectional suffixes differ by a couple of characters, not by
+    a whole extra word), counts as the same term.
+    """
+    if not query_word or not haystack_word:
+        return False
+    if query_word == haystack_word:
+        return True
+    if (
+        len(query_word) >= _MIN_WORD_LEN
+        and len(haystack_word) >= _MIN_WORD_LEN
+        and abs(len(query_word) - len(haystack_word)) <= _MAX_LEN_DIFF
+    ):
+        shorter = min(len(query_word), len(haystack_word))
+        common_prefix = len(os.path.commonprefix([query_word, haystack_word]))
+        return common_prefix >= shorter - _MAX_SUFFIX_DROP
+    return False
 
 
 @register_tool("PanelAppSearchTool")
@@ -43,14 +79,46 @@ class PanelAppSearchTool(BaseRESTTool):
             if not url:
                 break
 
+        # Query-derived, so computed once outside the per-panel loop below.
+        query_words = search.split()
+
         def matches(p: Dict[str, Any]) -> bool:
             haystack = " ".join(
                 str(p.get(k) or "")
                 for k in ("name", "disease_group", "disease_sub_group")
             ).lower()
-            return search in haystack
+            if search in haystack:
+                return True
+            # Plain substring matching misses simple English inflection --
+            # e.g. query "haemoglobinopathy" (singular) against panel name
+            # "...haemoglobinopathies" (plural) never matches even though a
+            # clinician typing the singular disease name expects a hit.
+            # Fall back to a per-word fuzzy-prefix match: every query word
+            # must share a long common prefix with some haystack word.
+            haystack_words = haystack.split()
+            return all(
+                any(_word_matches(qw, hw) for hw in haystack_words)
+                for qw in query_words
+            )
 
         results = [p for p in panels if matches(p)]
+        note = (
+            "PanelApp's API has no server-side search filter, so this "
+            "matches client-side against name/disease_group/"
+            "disease_sub_group across all panels."
+        )
+        if not results:
+            # This only searches panel-level metadata, which doesn't
+            # include every gene-level phenotype term (e.g. "haemophilia"
+            # doesn't appear in any panel name/disease_group text -- it's
+            # only reachable through the genes it curates, F8/F9). Point
+            # the caller at the gene-level fallback instead of a dead end.
+            note += (
+                " No panel matched this term in its name/disease_group/"
+                "disease_sub_group metadata. If you're looking for a "
+                "condition by its causal gene(s) instead, try "
+                "PanelApp_search_genes with the gene symbol."
+            )
         return {
             "status": "success",
             "data": {
@@ -62,10 +130,6 @@ class PanelAppSearchTool(BaseRESTTool):
             "metadata": {
                 "query": arguments.get("search"),
                 "total_panels_searched": len(panels),
-                "note": (
-                    "PanelApp's API has no server-side search filter, so this "
-                    "matches client-side against name/disease_group/"
-                    "disease_sub_group across all panels."
-                ),
+                "note": note,
             },
         }

--- a/src/tooluniverse/plant_reactome_tool.py
+++ b/src/tooluniverse/plant_reactome_tool.py
@@ -11,8 +11,9 @@ API: https://plantreactome.gramene.org/ContentService/
 No authentication required. Free for all use.
 """
 
+import re
 import requests
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 from .base_tool import BaseTool
 from .tool_registry import register_tool
 
@@ -53,9 +54,22 @@ class PlantReactomeTool(BaseTool):
                 "error": "Failed to connect to Plant Reactome API. Check network connectivity.",
             }
         except requests.exceptions.HTTPError as e:
+            code = e.response.status_code if e.response is not None else None
+            if code == 404:
+                # Plant Reactome's ContentService uses 404 (not an empty 200)
+                # to signal "no matches" for /search/query, and "not found"
+                # for a bad pathway_id/tax_id -- surface the query so a
+                # zero-result search doesn't look like a broken request.
+                query = arguments.get("query") or arguments.get(
+                    "pathway_id", arguments.get("tax_id", "")
+                )
+                return {
+                    "status": "error",
+                    "error": f"No Plant Reactome results found for: {query}",
+                }
             return {
                 "status": "error",
-                "error": f"Plant Reactome API HTTP error: {e.response.status_code}",
+                "error": f"Plant Reactome API HTTP error: {code}",
             }
         except Exception as e:
             return {
@@ -77,6 +91,14 @@ class PlantReactomeTool(BaseTool):
             return self._get_species_tree(arguments)
         else:
             return {"status": "error", "error": f"Unknown action: {self.action}"}
+
+    @staticmethod
+    def _strip_html(text: Optional[str]) -> Optional[str]:
+        """Remove HTML tags (e.g. the <span class="highlighting"> markup the
+        Reactome ContentService search endpoint wraps matched terms in)."""
+        if not text:
+            return text
+        return re.sub(r"<[^>]+>", "", text)
 
     def _search(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Search for plant pathways."""
@@ -107,7 +129,7 @@ class PlantReactomeTool(BaseTool):
                 results.append(
                     {
                         "stId": entry.get("stId", ""),
-                        "name": entry.get("name", ""),
+                        "name": self._strip_html(entry.get("name", "")),
                         "species": entry.get("species", [None]),
                         "exact_type": entry.get("exactType"),
                         "compartment_names": entry.get("compartmentNames"),

--- a/src/tooluniverse/reactome_tool.py
+++ b/src/tooluniverse/reactome_tool.py
@@ -176,6 +176,35 @@ class ReactomeRESTTool(BaseTool):
 
         # 5. Check HTTP status code
         if resp.status_code != 200:
+            # Fix-R15C-3: for the /data/mapping/... "list everything linked
+            # to this identifier" endpoints, Reactome signals a genuine
+            # empty result (identifier exists but has no entries of the
+            # requested kind -- e.g. a non-human ortholog with no directly
+            # curated pathways) as HTTP 404 with reason=NOT_FOUND and a
+            # "No <things> found for <id>" message, not as a real error.
+            # Confirmed live for bovine DGAT1 (Q8MK44): mapping/pathways and
+            # mapping/reactions both 404 this way, while the human ortholog
+            # (O75907) succeeds with real data via the same endpoint. Treat
+            # that specific shape as an empty list so batch/automated
+            # pipelines get a normal empty result instead of a hard
+            # exception. Scoped to /data/mapping/ only -- single-entity
+            # lookups (e.g. /data/pathway/{stId}) should keep erroring on a
+            # bad ID rather than silently returning nothing.
+            if resp.status_code == 404 and "/data/mapping/" in self.endpoint_template:
+                try:
+                    body = resp.json()
+                except ValueError:
+                    body = {}
+                if body.get("reason") == "NOT_FOUND":
+                    return {
+                        "status": "success",
+                        "data": [],
+                        "metadata": {
+                            "note": (body.get("messages") or [None])[0]
+                            or "No results found.",
+                            "source": "Reactome Content Service",
+                        },
+                    }
             return {
                 "status": "error",
                 "error": f"Reactome API returned HTTP {resp.status_code}",

--- a/src/tooluniverse/restful_tool.py
+++ b/src/tooluniverse/restful_tool.py
@@ -141,6 +141,7 @@ class MonarchDiseasesForMultiplePhenoTool(MonarchTool):
             if (key != "HPO_ID_list") and (key in arguments):
                 query_schema_runtime[key] = arguments[key]
         all_diseases = []
+        uninformative_ids = []
         for HPOID in arguments["HPO_ID_list"]:
             each_query_schema_runtime = copy.deepcopy(query_schema_runtime)
             each_query_schema_runtime["object"] = HPOID
@@ -150,7 +151,24 @@ class MonarchDiseasesForMultiplePhenoTool(MonarchTool):
             )
             each_output = each_output["items"]
             each_output_names = [disease["subject_label"] for disease in each_output]
-            all_diseases.append(each_output_names)
+            # Fix-R8B-9: A single unrecognized/obsolete HPO ID (typo, stale ID)
+            # returns zero diseases from Monarch. Previously that empty set
+            # was ANDed into the running intersection, silently collapsing
+            # the WHOLE result to [] with no signal that one input ID was
+            # the culprit -- a real clinician entering a mostly-correct HPO
+            # panel would see "no candidate diseases" instead of a partial,
+            # still-useful differential. Track zero-hit IDs separately and
+            # exclude them from the intersection instead of letting them
+            # veto every other (valid) phenotype in the panel.
+            if each_output_names:
+                all_diseases.append(each_output_names)
+            else:
+                uninformative_ids.append(HPOID)
+
+        if not all_diseases:
+            # Every HPO ID returned zero diseases -- genuinely no data,
+            # not a single bad ID nuking a good intersection.
+            return []
 
         intersection = set(all_diseases[0])
         for element in all_diseases[1:]:
@@ -158,4 +176,16 @@ class MonarchDiseasesForMultiplePhenoTool(MonarchTool):
         intersection = list(intersection)
         if query_schema_runtime["limit"] < len(intersection):
             intersection = intersection[: query_schema_runtime["limit"]]
+        if uninformative_ids:
+            return {
+                "diseases": intersection,
+                "warning": (
+                    f"No disease associations found for HPO ID(s) "
+                    f"{uninformative_ids} (invalid/obsolete ID or a phenotype "
+                    "with no known disease association) -- excluded from the "
+                    "intersection below, which is based only on the "
+                    f"remaining {len(all_diseases)} of "
+                    f"{len(arguments['HPO_ID_list'])} input HPO ID(s)."
+                ),
+            }
         return intersection

--- a/src/tooluniverse/restful_tool.py
+++ b/src/tooluniverse/restful_tool.py
@@ -67,6 +67,39 @@ class MonarchTool(RESTfulTool):
         for key in query_schema_runtime:
             if key in arguments:
                 query_schema_runtime[key] = arguments[key]
+
+        # Feature-14C-03: the /association endpoint's "subject"/"object"
+        # filters are CURIEs (e.g. "HGNC:11998"), never free-text gene/
+        # disease names -- but Monarch's API doesn't reject a bare symbol
+        # like "IRF6", it just matches nothing and returns an empty,
+        # status:success "total": 0 page that looks identical to a real
+        # "no associations for this gene" result. Confirmed live:
+        # Monarch_get_gene_diseases({"subject": "IRF6"}) silently returned
+        # total=0, while the correct CURIE HGNC:6121 returns 2 real
+        # associations. Only checked for params whose own schema
+        # description says "CURIE" (e.g. Monarch_get_gene_diseases,
+        # Monarch_get_gene_phenotypes) so tools where subject/object mean
+        # something else (e.g. free-text search) are unaffected.
+        properties = self.tool_config.get("parameter", {}).get("properties", {})
+        for curie_param in ("subject", "object"):
+            value = query_schema_runtime.get(curie_param)
+            if not isinstance(value, str) or not value.strip():
+                continue
+            description = properties.get(curie_param, {}).get("description", "")
+            if "CURIE" not in description:
+                continue
+            if ":" not in _normalize_curie(value):
+                return {
+                    "status": "error",
+                    "error": (
+                        f"'{value}' is not a CURIE for the '{curie_param}' "
+                        f"parameter. This tool requires a prefixed identifier "
+                        f"like 'HGNC:11998', not a plain gene/disease name. "
+                        f"Use Monarch_search_gene (or the relevant lookup "
+                        f"tool) to resolve '{value}' to its CURIE first."
+                    ),
+                }
+
         if "url_key" in query_schema_runtime:
             url_key_name = query_schema_runtime["url_key"]
             # Normalize an underscore ontology CURIE (HP_0000639) to the colon

--- a/src/tooluniverse/usda_plants_tool.py
+++ b/src/tooluniverse/usda_plants_tool.py
@@ -444,8 +444,10 @@ class USDAPlantsProfileTool(_USDAPlantsBase):
             "data": {
                 "id": profile.get("Id"),
                 "symbol": profile.get("Symbol"),
-                "scientific_name": profile.get("ScientificNameWithoutAuthor")
-                or profile.get("ScientificName"),
+                "scientific_name": _strip_html(
+                    profile.get("ScientificNameWithoutAuthor")
+                    or profile.get("ScientificName")
+                ),
                 "common_name": profile.get("CommonName"),
                 "group": profile.get("GroupName") or profile.get("Group"),
                 "rank": profile.get("Rank"),

--- a/src/tooluniverse/vdjdb_tool.py
+++ b/src/tooluniverse/vdjdb_tool.py
@@ -188,6 +188,26 @@ class VDJDBTool(BaseTool):
         if not cdr3:
             return {"status": "error", "error": "cdr3 parameter is required"}
 
+        # Fix-R8A-3: VDJdb's API 500s on a CDR3 containing a character
+        # outside the 20 standard amino acid one-letter codes (confirmed
+        # live with 'X', a common placeholder for an unresolved residue in
+        # real sequencing-derived CDR3 calls) instead of a clean 4xx/empty
+        # result. Reject it client-side with an actionable message rather
+        # than passing the raw upstream 500 through.
+        invalid_chars = sorted(set(cdr3.upper()) - set("ACDEFGHIKLMNPQRSTVWY"))
+        if invalid_chars:
+            return {
+                "status": "error",
+                "error": (
+                    f"cdr3 contains character(s) not in the 20 standard "
+                    f"amino acid one-letter codes: {invalid_chars}. VDJdb's "
+                    "API does not accept ambiguous codes (e.g. 'X' for an "
+                    "unresolved residue) and returns a server error rather "
+                    "than a normal empty result. Remove or resolve these "
+                    "positions before searching."
+                ),
+            }
+
         species = _normalize_species(arguments.get("species"))
         gene = arguments.get("gene")
         match_type = arguments.get("match_type", "exact")

--- a/src/tooluniverse/wikipathways_ext_tool.py
+++ b/src/tooluniverse/wikipathways_ext_tool.py
@@ -68,6 +68,18 @@ def _wpid_from_uri(uri: str) -> str:
     return tail.split("_", 1)[0]
 
 
+def _resolve_pathway_id(arguments: Dict[str, Any]) -> str:
+    """`pathway_id`, normalized, accepting `wpid` as an alias.
+
+    WikiPathways_get_pathway (the sibling tool in wikipathways_tool.py) names
+    this parameter `wpid`; accept it here too so a caller who just used that
+    tool doesn't hit a validation error switching to this one.
+    """
+    return (arguments.get("pathway_id") or arguments.get("wpid") or "").upper().replace(
+        '"', ""
+    )
+
+
 class WikiPathwaysExtTool(BaseTool):
     """WikiPathways extended endpoints via SPARQL."""
 
@@ -93,7 +105,7 @@ class WikiPathwaysExtTool(BaseTool):
             }
 
     def _get_pathway_genes(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
-        pathway_id = (arguments.get("pathway_id") or "").upper().replace('"', "")
+        pathway_id = _resolve_pathway_id(arguments)
         if not pathway_id:
             return {
                 "status": "error",
@@ -178,7 +190,7 @@ SELECT DISTINCT ?gene ?gene_label WHERE {{
         the central entities (unlike get_pathway_genes which returns only gene
         products).
         """
-        pathway_id = (arguments.get("pathway_id") or "").upper().replace('"', "")
+        pathway_id = _resolve_pathway_id(arguments)
         if not pathway_id:
             return {
                 "status": "error",

--- a/src/tooluniverse/wikipathways_tool.py
+++ b/src/tooluniverse/wikipathways_tool.py
@@ -86,6 +86,15 @@ class WikiPathwaysSearchTool:
         organism = arguments.get("organism")
         limit = int(arguments.get("limit", 20))
 
+        # Fix-11B-2: pathway titles in WikiPathways are typically unhyphenated
+        # gene/protein shorthand ("IL4 signaling"), but researchers naturally
+        # type the hyphenated form ("IL-4 signaling") -- confirmed live this
+        # returned zero results even though the pathway exists (WP395).
+        # Stripping hyphens from both sides of the CONTAINS comparison keeps
+        # the plain-substring search simple while absorbing this common
+        # notation mismatch.
+        query_norm = query.replace("-", "")
+
         organism_filter = (
             f'  FILTER(LCASE(STR(?organism)) = "{organism.lower()}")'
             if organism
@@ -98,7 +107,7 @@ SELECT DISTINCT ?pathway ?title ?organism WHERE {{
   ?pathway a wp:Pathway ;
            dc:title ?title ;
            wp:organismName ?organism .
-  FILTER(CONTAINS(LCASE(?title), "{query}"))
+  FILTER(CONTAINS(REPLACE(LCASE(?title), "-", ""), "{query_norm}"))
 {organism_filter}
 }} LIMIT {limit}
 """

--- a/src/tooluniverse/xml_tool.py
+++ b/src/tooluniverse/xml_tool.py
@@ -4,6 +4,14 @@ from typing import List, Dict, Any, Optional, Set
 from .base_tool import BaseTool
 from .utils import download_from_hf
 from .tool_registry import register_tool
+from .logging_config import get_logger
+
+# Fix-R13B-4: dataset-load status was reported via print(), which writes
+# straight to stdout. Any caller piping a tool's raw stdout as JSON (e.g.
+# `tu run ... --raw` or a script parsing captured output) got this line
+# prepended ahead of the JSON payload and failed to parse it. Routing
+# through the logging module keeps it on stderr instead.
+logger = get_logger(__name__)
 
 
 @register_tool("XMLTool")
@@ -47,12 +55,14 @@ class XMLDatasetTool(BaseTool):
                 self.record_xpath, namespaces=self.namespaces
             )
 
-            print(
-                f"Loaded XML dataset: {len(self.records)} records from root '{self.xml_root.tag}'"
+            logger.info(
+                "Loaded XML dataset: %d records from root '%s'",
+                len(self.records),
+                self.xml_root.tag,
             )
 
         except Exception as e:
-            print(f"Error loading XML dataset: {e}")
+            logger.error("Error loading XML dataset: %s", e)
             self.records = []
 
     def _get_dataset_path(self) -> Optional[str]:
@@ -61,14 +71,28 @@ class XMLDatasetTool(BaseTool):
             result = download_from_hf(self.tool_config["settings"])
             if result.get("success"):
                 return result["local_path"]
-            print(f"Failed to download dataset: {result.get('error')}")
+            logger.error("Failed to download dataset: %s", result.get("error"))
             return None
 
         if "local_dataset_path" in self.tool_config["settings"]:
             return self.tool_config["settings"]["local_dataset_path"]
 
-        print("No dataset path provided in tool configuration")
+        logger.warning("No dataset path provided in tool configuration")
         return None
+
+    # Fix-R13B-4: a record's nested list field (e.g. DrugBank's
+    # interacting_drugs) has no size bound of its own -- the tool's `limit`
+    # parameter only caps how many *top-level matched records* come back,
+    # not the length of a list field inside one record. A well-connected
+    # drug like azathioprine has ~1286 documented interactions, so a
+    # single matched record (limit=5 had no effect, since only 1 record
+    # matched "azathioprine") produced an 80k+ token payload with the
+    # clinically critical interaction undifferentiated among hundreds of
+    # others. Capping nested list fields for display (while still using
+    # the untruncated list to build searchable text, so search matching
+    # is unaffected) keeps responses usable; the true count is preserved
+    # in a sibling `<field>_total_count` key so callers know more exist.
+    _NESTED_LIST_DISPLAY_CAP = 25
 
     def _extract_record_data(self, record_element: ET.Element) -> Dict[str, Any]:
         """Extract data from a record element with caching."""
@@ -95,9 +119,8 @@ class XMLDatasetTool(BaseTool):
                     if any(entry.values()):  # Only add entries with non-empty values
                         structured_list.append(entry)
 
-                data[field_name] = structured_list
-
-                # Flatten for search
+                # Flatten for search using the full, untruncated list so
+                # matching behavior doesn't change based on the display cap.
                 for sf_name, _ in subfields.items():
                     flat_key = f"{field_name}_{sf_name}"
 
@@ -107,6 +130,13 @@ class XMLDatasetTool(BaseTool):
                     )
 
                     self.temporary_record_fields.add(flat_key)
+
+                total_count = len(structured_list)
+                max_items = xpath_expr.get("max_items", self._NESTED_LIST_DISPLAY_CAP)
+                if max_items and total_count > max_items:
+                    data[f"{field_name}_total_count"] = total_count
+                    structured_list = structured_list[:max_items]
+                data[field_name] = structured_list
             else:
                 # Regular flat field extraction
                 data[field_name] = self._extract_field_value(record_element, xpath_expr)
@@ -363,16 +393,17 @@ class XMLDatasetTool(BaseTool):
         """Get the appropriate filter function for the condition."""
         filter_functions = {
             "contains": lambda data, field: value.lower() in str(data[field]).lower(),
-            "starts_with": lambda data, field: str(data[field])
-            .lower()
-            .startswith(value.lower()),
-            "ends_with": lambda data, field: str(data[field])
-            .lower()
-            .endswith(value.lower()),
+            "starts_with": lambda data, field: (
+                str(data[field]).lower().startswith(value.lower())
+            ),
+            "ends_with": lambda data, field: (
+                str(data[field]).lower().endswith(value.lower())
+            ),
             "exact": lambda data, field: str(data[field]).lower() == value.lower(),
             "not_empty": lambda data, field: str(data[field]).strip() != "",
-            "has_attribute": lambda data, field: field == "_attributes"
-            and value in data["_attributes"],
+            "has_attribute": lambda data, field: (
+                field == "_attributes" and value in data["_attributes"]
+            ),
         }
         return filter_functions.get(condition)
 

--- a/src/tooluniverse/xml_tool.py
+++ b/src/tooluniverse/xml_tool.py
@@ -206,6 +206,36 @@ class XMLDatasetTool(BaseTool):
             .get("default", fallback)
         )
 
+    # Fix Round 17: every _search-mode tool built on this shared class takes
+    # a single param named 'query', regardless of what its own tool NAME
+    # promises (e.g. drugbank_get_pharmacology_by_drug_name_or_drugbank_id,
+    # mesh_get_subjects_by_subject_name). Confirmed live: calling that tool
+    # with 'drug_name' (the exact term in its own name) errored with
+    # "'query' is a required property" -- a natural first guess from reading
+    # the tool name fails. Accept the terms these tool names actually use as
+    # synonyms for 'query' instead of renaming the parameter across every
+    # config entry (a much larger, more disruptive change).
+    _QUERY_ALIASES = ("drug_name", "drugbank_id", "subject_name", "subject_id")
+
+    def _resolve_query_alias(self, arguments: Dict[str, Any]) -> None:
+        """Mutate arguments in place, filling in 'query' from a known alias.
+
+        Must run before schema validation (not just inside run()): jsonschema
+        rejects a missing required 'query' before run() is ever reached, so an
+        alias resolved only in run() would be dead code for every normal
+        (validated) call path.
+        """
+        if "query" in arguments or "condition" in arguments:
+            return
+        for alias in self._QUERY_ALIASES:
+            if arguments.get(alias):
+                arguments["query"] = arguments[alias]
+                break
+
+    def validate_parameters(self, arguments: Dict[str, Any]) -> Optional[Any]:
+        self._resolve_query_alias(arguments)
+        return super().validate_parameters(arguments)
+
     def run(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Main entry point for the tool."""
         if not self.records:
@@ -213,6 +243,10 @@ class XMLDatasetTool(BaseTool):
                 "status": "error",
                 "error": "XML dataset not loaded or contains no records",
             }
+
+        # Also resolve here so direct run() calls that skip validate_parameters
+        # (e.g. validate=False, or calling the tool class directly) still work.
+        self._resolve_query_alias(arguments)
 
         # Route to appropriate function based on arguments
         if "query" in arguments:

--- a/tests/test_aging_cohort_tool.py
+++ b/tests/test_aging_cohort_tool.py
@@ -62,6 +62,42 @@ class TestBasicSearch:
         assert result["metadata"]["total_matched"] == 0
 
 
+class TestRelevanceFiltering:
+    """Regression guard for Fix Round 12 / Feature-12A-1: a query where only
+    one low-signal word (e.g. "biomarker", present in ~85% of the registry,
+    or "study", present in most full_names) happened to match used to
+    return nearly the entire registry -- indistinguishable from "everything
+    is relevant." Matching must actually require the query's meaningful
+    terms, not just any single common word.
+    """
+
+    def test_nonsense_query_with_common_word_returns_nothing(self, tool):
+        # Every word here is either gibberish or a near-universal term
+        # ("biomarker", "study"); none of it describes a real cohort topic.
+        result = tool.run(
+            {"query": "zzzqqxx nonexistent biomarker unicorn study"}
+        )
+        assert result["status"] == "success"
+        assert result["data"] == []
+        assert result["metadata"]["total_matched"] == 0
+
+    def test_multi_word_query_does_not_match_near_whole_registry(self, tool):
+        # A real 3-term query should surface a focused subset, not ~all
+        # cohorts (the old bug: "biomarker"/"study" alone matched 29/30).
+        result = tool.run({"query": "iron intake longitudinal"})
+        assert result["status"] == "success"
+        assert 0 < result["metadata"]["total_matched"] < len(_COHORTS) - 5
+        names = {c["name"] for c in result["data"]}
+        assert "InCHIANTI" in names  # known iron/longitudinal cohort
+
+    def test_single_meaningful_word_still_matches(self, tool):
+        # A genuine single-topic query must still work once low-signal
+        # words are excluded from the meaningful-token set.
+        result = tool.run({"query": "sarcopenia"})
+        assert result["status"] == "success"
+        assert result["metadata"]["total_matched"] >= 1
+
+
 # ---------------------------------------------------------------------------
 # Filter: country
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_graphql_empty_guard.py
+++ b/tests/tools/test_graphql_empty_guard.py
@@ -55,6 +55,31 @@ class TestGraphQLEmptyGuard:
         assert result["status"] == "success"
         assert result["data"] == {"search": {}}
 
+    def test_zero_hit_search_query_gets_explanatory_note(self):
+        # Fix Round 17: a query whose schema actually declares a "hits" field
+        # (a real search(...) { hits {...} } shape, unlike the generic dummy
+        # config above) collapses to the same opaque {"search": {}} on zero
+        # hits. Confirmed live: OpenTargets_get_disease_ids_by_name with
+        # "high-risk prostate cancer" returned status=success, data=
+        # {"search": {}}, with nothing indicating that means zero matches.
+        # Attach a note so the caller isn't left guessing whether this is a
+        # real zero-hit result or something broke.
+        from tooluniverse.graphql_tool import GraphQLTool
+
+        search_cfg = dict(MINIMAL_CFG)
+        search_cfg["query_schema"] = (
+            "query($q: String!) { search(queryString: $q) { hits { id name } } }"
+        )
+        tool = GraphQLTool(search_cfg, "https://example.org/graphql")
+        with patch(
+            "tooluniverse.graphql_tool.execute_query",
+            return_value={"data": {"search": {}}},
+        ):
+            result = tool.run({"id": "anything"})
+        assert result["status"] == "success"
+        assert result["data"] == {"search": {}}
+        assert "0 matches found" in result["metadata"]["note"]
+
     def test_real_data_succeeds(self):
         tool = _base_tool()
         with patch(

--- a/tests/unit/test_biomarker_discovery_compose.py
+++ b/tests/unit/test_biomarker_discovery_compose.py
@@ -1,0 +1,132 @@
+"""Regression guard for Fix Round 12 / Feature-12A-2.
+
+BiomarkerDiscoveryWorkflow's Step 2 (HPA gene search) checked for a
+top-level "genes" key on the result of call_tool("HPA_search_genes_by_query",
+...), but call_tool() returns the tool's raw envelope
+({"status": "success", "data": {"genes": [...]}}), not the unwrapped
+payload. The check therefore never matched a real response, always fell
+through to a hardcoded fallback of unrelated cancer genes (BRCA1/BRCA2/
+TP53/EGFR/MYC) regardless of the actual disease queried, and printed a
+misleading "✅ Using fallback cancer genes" success line while doing so.
+
+This test exercises the fix directly: `_extract_genes` must correctly pull
+genes out of the real (wrapped) response shape, and the compose script must
+no longer contain the hardcoded fallback gene list at all.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_MODULE_PATH = (
+    Path(__file__).parent.parent.parent
+    / "src"
+    / "tooluniverse"
+    / "compose_scripts"
+    / "biomarker_discovery.py"
+)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location(
+        "biomarker_discovery_under_test", _MODULE_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def module():
+    return _load_module()
+
+
+class TestExtractGenes:
+    def test_extracts_genes_from_wrapped_envelope(self, module):
+        # This is the real shape call_tool() returns for
+        # HPA_search_genes_by_query: {"status": ..., "data": {"genes": [...]}}
+        result = {
+            "status": "success",
+            "data": {"genes": [{"gene_name": "BCAS1", "ensembl_id": "ENSG1"}]},
+        }
+        genes = module._extract_genes(result)
+        assert genes == [{"gene_name": "BCAS1", "ensembl_id": "ENSG1"}]
+
+    def test_extracts_genes_from_unwrapped_dict(self, module):
+        result = {"genes": [{"gene_name": "TP53"}]}
+        assert module._extract_genes(result) == [{"gene_name": "TP53"}]
+
+    def test_extracts_genes_from_bare_list(self, module):
+        result = [{"gene_name": "EGFR"}]
+        assert module._extract_genes(result) == [{"gene_name": "EGFR"}]
+
+    def test_returns_empty_list_when_no_genes_present(self, module):
+        assert module._extract_genes({"status": "success", "data": {}}) == []
+        assert module._extract_genes(None) == []
+        assert module._extract_genes({"error": "not found"}) == []
+
+
+class TestNoHardcodedFallback:
+    def test_source_no_longer_contains_hardcoded_cancer_genes(self):
+        source = _MODULE_PATH.read_text()
+        # These gene names must not appear anywhere as a hardcoded
+        # substitute -- any mention of them should only come from real API
+        # results, never from source-level fallback data.
+        for stale_marker in (
+            "fallback cancer genes",
+            "Breast cancer type 1 susceptibility protein",
+        ):
+            assert stale_marker not in source
+
+
+class TestGeneSearchStrategy:
+    """End-to-end exercise of compose()'s Step 2 with a fake call_tool that
+    mimics the real wrapped envelope shape.
+    """
+
+    def test_finds_real_genes_via_wrapped_response(self, module):
+        calls = []
+
+        def fake_call_tool(name, args):
+            calls.append((name, args))
+            if name == "HPA_search_genes_by_query":
+                return {
+                    "status": "success",
+                    "data": {
+                        "genes": [
+                            {"gene_name": "BCAS1", "ensembl_id": "ENSG00000064787"}
+                        ]
+                    },
+                }
+            return {"status": "success", "data": {}}
+
+        result = module.compose(
+            {"disease_condition": "breast cancer", "sample_type": "tissue"},
+            tooluniverse=None,
+            call_tool=fake_call_tool,
+        )
+
+        assert result["expression_data"]["genes_found"] == 1
+        assert result["expression_data"]["all_candidates"][0]["gene_name"] == "BCAS1"
+
+    def test_no_genes_found_is_reported_honestly_not_faked(self, module):
+        def fake_call_tool(name, args):
+            if name == "HPA_search_genes_by_query":
+                return {"status": "success", "data": {"genes": []}}
+            return {"status": "success", "data": {}}
+
+        result = module.compose(
+            {"disease_condition": "healthy aging", "sample_type": "blood"},
+            tooluniverse=None,
+            call_tool=fake_call_tool,
+        )
+
+        # Must not silently contain the old fallback genes.
+        expr = result["expression_data"]
+        assert expr.get("error") == "No genes found with any search strategy"
+        candidates = expr.get("all_candidates", [])
+        gene_names = {g.get("gene_name") for g in candidates}
+        assert not gene_names & {"BRCA1", "BRCA2", "TP53", "EGFR", "MYC"}

--- a/tests/unit/test_ctd_tool.py
+++ b/tests/unit/test_ctd_tool.py
@@ -94,13 +94,20 @@ def test_ctd_chemical_diseases_returns_normalised_edges(mock_get):
 
 @pytest.mark.unit
 def test_ctd_gene_disease_returns_redirect_error():
-    """Gene->disease has no live curated CTD source; must redirect callers."""
+    """Gene->disease has no live curated CTD source; must redirect callers.
+
+    Fix Round 12 / Feature-12A-3: the redirect previously pointed to
+    "OpenTargets_get_associated_diseases", which doesn't exist as a tool
+    name (confirmed via `tu run`) -- a dead end for anyone following the
+    suggestion. It now points to gather_gene_disease_associations, a real,
+    live aggregator tool (DisGeNET/OMIM/OpenTargets/GenCC/ClinVar).
+    """
 
     tool = make_ctd_tool(input_type="gene", report_type="diseases_curated")
     result = tool.run({"input_terms": "BRCA1"})
 
     assert result["status"] == "error"
-    assert "OpenTargets_get_associated_diseases" in result["suggestion"]
+    assert "gather_gene_disease_associations" in result["suggestion"]
 
 
 @pytest.mark.unit

--- a/tests/unit/test_ctg_phrase_quoting.py
+++ b/tests/unit/test_ctg_phrase_quoting.py
@@ -14,6 +14,15 @@ aliases in the tool's Python code but undeclared in its JSON schema, so
 `tu info` didn't show them -- and once additionalProperties: false lands
 (a separate round-8 fix), these undocumented aliases would start being
 silently rejected as unrecognized properties.
+
+Fix-R13B-1: a bare query.intr/query.spons value (even phrase-quoted) is
+still matched by CTG API v2's Essie engine against the whole study
+record, not just the intervention-name/lead-sponsor-name field, so
+searching intervention="vedolizumab" surfaced an unrelated oncology
+trial with no vedolizumab intervention, and sponsor="Takeda" surfaced
+trials sponsored by Neurocrine Biosciences and Shire (confirmed live).
+Values are now wrapped in Essie's AREA[InterventionName] /
+AREA[LeadSponsorName] operators (still phrase-quoted when multi-word).
 """
 
 import json
@@ -22,7 +31,11 @@ from unittest.mock import MagicMock, patch
 import jsonschema
 import pytest
 
-from tooluniverse.ctg_tool import ClinicalTrialsTool, _phrase_quote_if_plain
+from tooluniverse.ctg_tool import (
+    ClinicalTrialsTool,
+    _phrase_quote_if_plain,
+    _restrict_to_area,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -62,6 +75,25 @@ def test_already_quoted_value_is_not_double_quoted():
     assert _phrase_quote_if_plain('"cervical cancer"') == '"cervical cancer"'
 
 
+def test_area_restricted_value_is_not_double_wrapped():
+    assert (
+        _restrict_to_area("AREA[InterventionName]nivolumab", "InterventionName")
+        == "AREA[InterventionName]nivolumab"
+    )
+
+
+def test_single_word_value_is_area_restricted_without_quotes():
+    assert _restrict_to_area("nivolumab", "InterventionName") == (
+        "AREA[InterventionName]nivolumab"
+    )
+
+
+def test_multiword_value_is_area_restricted_and_phrase_quoted():
+    assert _restrict_to_area("immunotherapy radiotherapy", "InterventionName") == (
+        'AREA[InterventionName]"immunotherapy radiotherapy"'
+    )
+
+
 def test_condition_and_intervention_are_quoted_in_live_request():
     tool = _tool()
     with patch("requests.get", return_value=_mock_response()) as mock_get:
@@ -75,7 +107,7 @@ def test_condition_and_intervention_are_quoted_in_live_request():
 
     params = mock_get.call_args.kwargs["params"]
     assert params["query.cond"] == '"cervical cancer"'
-    assert params["query.intr"] == '"immunotherapy radiotherapy"'
+    assert params["query.intr"] == 'AREA[InterventionName]"immunotherapy radiotherapy"'
 
 
 def test_sponsor_alias_maps_to_query_spons():
@@ -84,16 +116,18 @@ def test_sponsor_alias_maps_to_query_spons():
         tool.run({"sponsor": "National Cancer Institute"})
 
     params = mock_get.call_args.kwargs["params"]
-    assert params["query.spons"] == "National Cancer Institute"
+    assert params["query.spons"] == 'AREA[LeadSponsorName]"National Cancer Institute"'
 
 
 def test_schema_declares_intervention_and_sponsor():
     with open("src/tooluniverse/data/clinicaltrials_gov_tools.json") as f:
         tools = json.load(f)
-    schema = next(
-        t for t in tools if t["name"] == "ClinicalTrials_search_studies"
-    )["parameter"]
+    schema = next(t for t in tools if t["name"] == "ClinicalTrials_search_studies")[
+        "parameter"
+    ]
 
     assert "intervention" in schema["properties"]
     assert "sponsor" in schema["properties"]
-    jsonschema.validate({"condition": "hearing loss", "intervention": "gene therapy"}, schema)
+    jsonschema.validate(
+        {"condition": "hearing loss", "intervention": "gene therapy"}, schema
+    )

--- a/tests/unit/test_dna_golden_gate_assemble.py
+++ b/tests/unit/test_dna_golden_gate_assemble.py
@@ -26,13 +26,28 @@ ASSEMBLE = {
 }
 
 
+_COMPLEMENT = str.maketrans("ACGT", "TGCA")
+
+
+def _rc(seq):
+    return seq.translate(_COMPLEMENT)[::-1]
+
+
 def _donor(ov_left, ov_right, body, backbone):
     """A circular donor with inward-facing BsaI sites flanking `body`.
 
     Cutting releases `body` (site-free, so it survives the reaction) and leaves
     the recognition sites on the backbone piece.
+
+    `ov_left`/`ov_right` are the overhang identities in the standard
+    Golden-Gate/MoClo notation used by `DNA_golden_gate_design` -- the same
+    4-letter code is shared by both mating ends of a junction. The right-hand
+    site is inward-facing (reverse-oriented, GAGACC on this strand), so BsaI
+    reads it on the bottom strand; the literal top-strand text immediately
+    before that site is therefore the *reverse complement* of `ov_right`, not
+    `ov_right` itself (mirrors `DNA_golden_gate_design`'s own construction).
     """
-    return "GGTCTC" "A" + ov_left + body + ov_right + "A" "GAGACC" + backbone
+    return "GGTCTC" "A" + ov_left + body + _rc(ov_right) + "A" "GAGACC" + backbone
 
 
 DONOR_A = _donor("AGGT", "CATC", "GGGGCCCCGGGGCCCCAAAA", "ACGTACGTACGTACGTACGTACGTAC")

--- a/tests/unit/test_faers_compare_drugs_signal_wording.py
+++ b/tests/unit/test_faers_compare_drugs_signal_wording.py
@@ -1,0 +1,96 @@
+"""FAERS_compare_drugs comparison-text wording (Fix-19B-2).
+
+`_compare_drugs` used to rank drugs purely by raw ROR magnitude ("X shows
+stronger signal than Y") even when neither drug actually crossed this
+tool's own signal-detection threshold (signal_detection.signal_detected).
+Confirmed live with nirsevimab/palivizumab + anaphylactic reaction: both
+drugs had signal_detected=False (ROR < 1, i.e. no elevated-risk
+association) but the narrative still claimed one showed a "stronger
+signal" -- misleading language for a clinician skimming only the text.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    from tooluniverse.faers_analytics_tool import FAERSAnalyticsTool
+
+    return FAERSAnalyticsTool({"name": "t", "type": "FAERSAnalyticsTool"})
+
+
+def _disproportionality_result(ror, signal_detected):
+    return {
+        "status": "success",
+        "metrics": {"ROR": {"value": ror}},
+        "signal_detection": {
+            "signal_detected": signal_detected,
+            "signal_strength": "Weak signal" if signal_detected else "No signal",
+        },
+    }
+
+
+class TestFAERSCompareDrugsSignalWording:
+    def test_neither_drug_has_a_detected_signal(self):
+        # Both RORs are < 1 (no elevated-risk association), so the
+        # comparison must not claim either drug "shows a stronger signal".
+        tool = _tool()
+        with patch.object(
+            tool,
+            "_calculate_disproportionality",
+            side_effect=[
+                _disproportionality_result(0.22, False),
+                _disproportionality_result(0.47, False),
+            ],
+        ):
+            result = tool._compare_drugs(
+                {
+                    "drug1": "nirsevimab",
+                    "drug2": "palivizumab",
+                    "adverse_event": "anaphylactic reaction",
+                }
+            )
+
+        assert result["status"] == "success"
+        comparison = result["comparison"]
+        assert "Neither" in comparison
+        assert "stronger signal" not in comparison
+
+    def test_only_one_drug_has_a_detected_signal(self):
+        tool = _tool()
+        with patch.object(
+            tool,
+            "_calculate_disproportionality",
+            side_effect=[
+                _disproportionality_result(5.0, True),
+                _disproportionality_result(0.8, False),
+            ],
+        ):
+            result = tool._compare_drugs(
+                {"drug1": "drugA", "drug2": "drugB", "adverse_event": "some event"}
+            )
+
+        comparison = result["comparison"]
+        assert "drugA shows a detected safety signal" in comparison
+        assert "drugB does not" in comparison
+
+    def test_both_drugs_have_a_detected_signal_ranks_by_magnitude(self):
+        tool = _tool()
+        with patch.object(
+            tool,
+            "_calculate_disproportionality",
+            side_effect=[
+                _disproportionality_result(8.0, True),
+                _disproportionality_result(2.0, True),
+            ],
+        ):
+            result = tool._compare_drugs(
+                {"drug1": "drugA", "drug2": "drugB", "adverse_event": "some event"}
+            )
+
+        comparison = result["comparison"]
+        assert "Both show a detected signal" in comparison
+        assert "drugA's is stronger" in comparison

--- a/tests/unit/test_faers_disproportionality_rate_limit.py
+++ b/tests/unit/test_faers_disproportionality_rate_limit.py
@@ -1,0 +1,125 @@
+"""FAERS_calculate_disproportionality: a failed openFDA count query must not
+be silently treated as a genuine zero.
+
+Regression for Fix Round 17: _get_faers_count caught every exception
+(including an HTTP 429 from openFDA's rate limit) and returned 0, which is
+indistinguishable from "no matching reports." That fake 0 then flowed into
+the 2x2 contingency-table arithmetic and could produce a mathematically
+impossible negative cell count. Confirmed live with the tool's own
+documented example (IBUPROFEN + "Gastrointestinal haemorrhage"): the
+unfiltered total-count request hit openFDA's rate limit and the tool
+reported "a=0, b=283544, c=0, d=-283544" with no indication anything had
+failed.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+DATA_FILE = (
+    Path(__file__).resolve().parents[2]
+    / "src"
+    / "tooluniverse"
+    / "data"
+    / "faers_analytics_tools.json"
+)
+
+
+def _make_tool():
+    from tooluniverse.faers_analytics_tool import FAERSAnalyticsTool
+
+    with open(DATA_FILE) as f:
+        tools = json.load(f)
+    config = next(
+        t for t in tools if t["name"] == "FAERS_calculate_disproportionality"
+    )
+    return FAERSAnalyticsTool(config)
+
+
+class _FakeResponse:
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self._payload = payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            import requests
+
+            raise requests.HTTPError(f"{self.status_code} error")
+
+    def json(self):
+        return self._payload
+
+
+def test_rate_limited_total_count_returns_actionable_error_not_negative_d():
+    tool = _make_tool()
+
+    def fake_request_with_retry(session, method, url, **kwargs):
+        # The unfiltered total-count request (no `search=`) is rate limited;
+        # every filtered request succeeds -- reproduces the exact live
+        # scenario that produced a=0, b=283544, c=0, d=-283544.
+        if "limit=1" in url and "search=" not in url:
+            return _FakeResponse(429, {"error": {"code": "OVER_RATE_LIMIT"}})
+        return _FakeResponse(200, {"meta": {"results": {"total": 283544}}})
+
+    with patch(
+        "tooluniverse.faers_analytics_tool.request_with_retry",
+        side_effect=fake_request_with_retry,
+    ):
+        result = tool.run(
+            {
+                "operation": "calculate_disproportionality",
+                "drug_name": "IBUPROFEN",
+                "adverse_event": "Gastrointestinal haemorrhage",
+            }
+        )
+
+    assert result["status"] == "error"
+    # Must not silently report a fabricated (and mathematically impossible)
+    # contingency table -- the error should explain the request failed.
+    assert "contingency_table" not in result
+    assert "rate limit" in result["error"].lower() or "429" in result["error"]
+
+
+def test_all_counts_succeed_produces_sane_positive_contingency_table():
+    tool = _make_tool()
+
+    def fake_request_with_retry(session, method, url, **kwargs):
+        if "limit=1" in url and "search=" not in url:
+            return _FakeResponse(200, {"meta": {"results": {"total": 20000000}}})
+        if 'generic_name:"IBUPROFEN"' in url and "reactionmeddrapt" in url:
+            return _FakeResponse(200, {"meta": {"results": {"total": 50}}})
+        if 'generic_name:"IBUPROFEN"' in url:
+            return _FakeResponse(200, {"meta": {"results": {"total": 283544}}})
+        if "reactionmeddrapt" in url:
+            return _FakeResponse(200, {"meta": {"results": {"total": 5000}}})
+        return _FakeResponse(200, {"meta": {"results": {"total": 0}}})
+
+    with patch(
+        "tooluniverse.faers_analytics_tool.request_with_retry",
+        side_effect=fake_request_with_retry,
+    ):
+        result = tool.run(
+            {
+                "operation": "calculate_disproportionality",
+                "drug_name": "IBUPROFEN",
+                "adverse_event": "Gastrointestinal haemorrhage",
+            }
+        )
+
+    assert result["status"] == "success"
+    ct = result["data"]["contingency_table"]
+    assert all(v > 0 for v in ct.values())
+
+
+def test_api_key_appended_to_faers_requests_when_env_var_set(monkeypatch):
+    monkeypatch.setenv("FDA_API_KEY", "test-key-123")
+    tool = _make_tool()
+    assert tool.api_key == "test-key-123"
+    assert tool._with_api_key("https://api.fda.gov/drug/event.json?limit=1") == (
+        "https://api.fda.gov/drug/event.json?limit=1&api_key=test-key-123"
+    )

--- a/tests/unit/test_graphql_tool_error_logging.py
+++ b/tests/unit/test_graphql_tool_error_logging.py
@@ -1,0 +1,63 @@
+"""`execute_query()` (shared by every GraphQLTool subclass, including
+OpenTargets and OpenNeuro) printed the raw GraphQL `errors` array straight to
+stdout on failure. Some APIs embed a full stack trace with internal server
+file paths in `extensions.stacktrace` (confirmed live via
+OpenNeuro_get_dataset with a nonexistent dataset ID, which surfaced
+'/srv/packages/openneuro-server/dist/graphql/permissions.js:92:15' etc. in
+the CLI output) -- an internal-implementation leak, not a useful diagnostic,
+and it happened even though the tool's actual returned `error` field stayed
+clean ("No data returned from API"). Fixed by logging only the sanitized
+`message` text via `logging.debug` (invisible by default) instead of
+`print()`-ing the raw error objects.
+"""
+
+import logging
+
+import pytest
+
+from tooluniverse.graphql_tool import execute_query
+
+pytestmark = pytest.mark.unit
+
+
+class _Resp:
+    ok = True
+
+    def __init__(self, body):
+        self._body = body
+
+    def json(self):
+        return self._body
+
+
+def test_graphql_errors_do_not_leak_to_stdout(monkeypatch, capsys, caplog):
+    body = {
+        "errors": [
+            {
+                "message": "Dataset ds999999 does not exist.",
+                "extensions": {
+                    "code": "INTERNAL_SERVER_ERROR",
+                    "stacktrace": [
+                        "Error: Dataset ds999999 does not exist.",
+                        "    at checkDatasetExists "
+                        "(/srv/packages/openneuro-server/dist/graphql/permissions.js:92:15)",
+                    ],
+                },
+            }
+        ]
+    }
+    monkeypatch.setattr(
+        "tooluniverse.graphql_tool.requests.post", lambda *a, **k: _Resp(body)
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="tooluniverse.graphql_tool"):
+        result = execute_query("https://example.org/graphql", "query { x }")
+
+    assert result is None
+    captured = capsys.readouterr()
+    # The internal server file path must not appear anywhere in stdout/stderr.
+    assert "openneuro-server" not in captured.out
+    assert "openneuro-server" not in captured.err
+    assert "stacktrace" not in captured.out
+    # The sanitized message is still available for debugging, just not printed.
+    assert any("Dataset ds999999 does not exist." in r.message for r in caplog.records)

--- a/tests/unit/test_hpo_phenotype_annotations.py
+++ b/tests/unit/test_hpo_phenotype_annotations.py
@@ -79,6 +79,37 @@ class TestHPOPhenotypeAnnotations(unittest.TestCase):
         self.assertEqual(result["status"], "error")
         get2.assert_not_called()
 
+    def test_offset_pages_past_the_limit_cap(self):
+        # Fix-19C-1/19C-2: a phenotype with more associations than fit in one
+        # `limit`-capped response must be reachable via `offset` -- the
+        # endpoint returns everything in one call, so paging is a client-side
+        # slice over the same fetched list, not a second network round-trip.
+        tool = _tool("get_associated_genes")
+        with patch("tooluniverse.hpo_tool.requests.get", return_value=_resp()) as get:
+            first_page = tool.run({"term_id": "HP:0001250", "limit": 2, "offset": 0})
+        with patch("tooluniverse.hpo_tool.requests.get", return_value=_resp()):
+            second_page = tool.run({"term_id": "HP:0001250", "limit": 2, "offset": 2})
+
+        self.assertEqual(get.call_count, 1)
+        self.assertEqual(len(first_page["data"]["genes"]), 2)
+        self.assertTrue(first_page["metadata"]["has_more"])
+        self.assertEqual(first_page["metadata"]["offset"], 0)
+
+        # Third gene ("LGI1") is only reachable past the first page.
+        self.assertEqual(len(second_page["data"]["genes"]), 1)
+        self.assertEqual(second_page["data"]["genes"][0]["name"], "LGI1")
+        self.assertFalse(second_page["metadata"]["has_more"])
+        self.assertEqual(second_page["metadata"]["offset"], 2)
+
+    def test_offset_defaults_to_zero_when_omitted(self):
+        # Backward compatibility: no `offset` argument behaves exactly as
+        # before this fix (starts from position 0).
+        tool = _tool("get_associated_genes")
+        with patch("tooluniverse.hpo_tool.requests.get", return_value=_resp()):
+            result = tool.run({"term_id": "HP:0001250", "limit": 2})
+        self.assertEqual(result["metadata"]["offset"], 0)
+        self.assertEqual(result["data"]["genes"][0]["name"], "RELN")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_kegg_ext_tool_fixes.py
+++ b/tests/unit/test_kegg_ext_tool_fixes.py
@@ -192,6 +192,82 @@ def test_get_network_does_not_double_prefix_already_prefixed_id():
     assert "network:network:" not in captured["url"]
 
 
+# N#####-style perturbed-network records (unlike the nt######-style Map
+# records above) carry their gene list under GENE and cross-referenced KEGG
+# pathways under PATHWAY -- previously unhandled entirely, so `elements`
+# stayed empty and the raw numeric Entrez IDs in `expanded` had no symbol
+# mapping. Confirmed live for N00151 (TNF-NFKB signaling): 16 real genes and
+# 2 real pathway cross-refs, both silently dropped.
+N_STYLE_NETWORK_FLAT_FILE = """ENTRY       N00151                      Network
+NAME        TNF-NFKB signaling pathway
+DEFINITION  TNF -> TNFRSF1A -> NFKB
+  EXPANDED  7124 -> 7132 -> 4790
+TYPE        Reference
+PATHWAY     hsa04668  TNF signaling pathway
+            hsa04064  NF-kappa B signaling pathway
+GENE        7124  TNF; tumor necrosis factor
+            7132  TNFRSF1A; TNF receptor superfamily member 1A
+            4790  NFKB1; nuclear factor kappa B subunit 1
+REFERENCE   PMID:22119011
+  AUTHORS   Verhelst K, Carpentier I, Beyaert R
+///
+"""
+
+
+def test_get_network_captures_gene_and_pathway_fields_for_n_style_ids():
+    tool = _tool("get_network")
+
+    with patch(
+        "tooluniverse.kegg_ext_tool.requests.get",
+        return_value=_resp(N_STYLE_NETWORK_FLAT_FILE),
+    ):
+        result = tool._get_network({"network_id": "N00151"})
+
+    assert result["data"]["genes"] == [
+        {
+            "entrez_id": "7124",
+            "symbol": "TNF",
+            "description": "tumor necrosis factor",
+        },
+        {
+            "entrez_id": "7132",
+            "symbol": "TNFRSF1A",
+            "description": "TNF receptor superfamily member 1A",
+        },
+        {
+            "entrez_id": "4790",
+            "symbol": "NFKB1",
+            "description": "nuclear factor kappa B subunit 1",
+        },
+    ]
+    assert result["data"]["pathways"] == [
+        {"pathway_id": "hsa04668", "name": "TNF signaling pathway"},
+        {"pathway_id": "hsa04064", "name": "NF-kappa B signaling pathway"},
+    ]
+    # A REFERENCE section (with its own indented AUTHORS/TITLE lines) must not
+    # bleed into the gene/pathway lists just because it's also indented text.
+    assert not any("PMID" in g["description"] for g in result["data"]["genes"])
+
+
+def test_get_network_element_parsing_still_works_for_nt_style_ids():
+    """The new GENE/PATHWAY branches must not regress the existing
+    MEMBER/ELEMENT handling for the other (Map-type) network ID family."""
+    tool = _tool("get_network")
+
+    with patch(
+        "tooluniverse.kegg_ext_tool.requests.get",
+        return_value=_resp(NETWORK_FLAT_FILE),
+    ):
+        result = tool._get_network({"network_id": "nt06276"})
+
+    assert result["data"]["genes"] == []
+    assert result["data"]["pathways"] == []
+    assert result["data"]["elements"] == [
+        "N00001  EGF-EGFR-RAS-ERK signaling pathway",
+        "N00002  BCR-ABL fusion kinase to RAS-ERK signaling pathway",
+    ]
+
+
 def test_brite_hierarchy_404_gives_table_type_hint():
     tool = _tool("get_brite_hierarchy")
 

--- a/tests/unit/test_openai_compatible_client.py
+++ b/tests/unit/test_openai_compatible_client.py
@@ -104,6 +104,37 @@ def test_openai_compatible_default_max_tokens_from_env(monkeypatch):
     assert FakeOpenAIClient.instances[0].completions.calls[0]["max_tokens"] == 123
 
 
+def test_openai_gpt5_model_drops_unsupported_temperature(monkeypatch):
+    """Regression guard for Fix Round 12 / Feature-12A-2: "gpt-5" is the
+    default model_id (see AgenticTool), and the real API rejects any
+    non-default temperature for this family with a 400 error ("Unsupported
+    value: 'temperature' does not support 0.2 with this model"). This was
+    already handled correctly for max-token routing
+    (_uses_max_completion_tokens already lists "gpt-5"), but
+    _normalize_temperature had fallen out of sync and still sent the
+    caller's temperature straight through, crashing every default-
+    configured LLM call site (e.g. BiomarkerDiscoveryWorkflow's literature
+    step) with 0 < temperature < 1.
+    """
+    client = OpenAICompatibleClient(
+        "gpt-5",
+        logger=SimpleNamespace(warning=lambda *_: None, error=lambda *_: None),
+    )
+
+    result = client.infer(
+        messages=[{"role": "user", "content": "ping"}],
+        temperature=0.2,
+        max_tokens=None,
+        return_json=False,
+        max_retries=1,
+        retry_delay=0,
+    )
+
+    assert result == "ok"
+    call = FakeOpenAIClient.instances[0].completions.calls[0]
+    assert "temperature" not in call
+
+
 def test_openai_reasoning_model_uses_completion_tokens(monkeypatch):
     monkeypatch.setenv("OPENAI_MAX_TOKENS_BY_MODEL", '{"o4-mini": 321}')
     client = OpenAICompatibleClient(

--- a/tests/unit/test_package_tool_pypi_metadata.py
+++ b/tests/unit/test_package_tool_pypi_metadata.py
@@ -1,0 +1,136 @@
+"""PackageTool's `_get_pypi_info` (backing every `get_<package>_info` tool, e.g.
+`get_mne_info`, `get_nilearn_info`) derived three fields incorrectly from the raw
+PyPI JSON API response:
+
+- `last_updated` used `last_serial` (PyPI's internal monotonic change-counter,
+  currently in the tens of millions) as if it were a Unix timestamp, decoding to
+  bogus dates in 1970-1971.
+- `python_versions` returned the *entire* `classifiers` list (license, OS, dev
+  status, audience, ...) unfiltered, not just the Python version entries.
+- `repository` only checked the `Repository`/`Source` project_urls keys, missing
+  common variants like `Source Code` (e.g. mne-python) even when `documentation`
+  was found fine from the same dict.
+
+Covers the fix with mocked PyPI responses (no live pypi.org calls).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _make_tool(package_name="mne"):
+    from tooluniverse.package_tool import PackageTool
+
+    return PackageTool(
+        {
+            "name": f"get_{package_name}_info",
+            "type": "PackageTool",
+            "package_name": package_name,
+        }
+    )
+
+
+def _pypi_response(
+    classifiers=None,
+    requires_python=None,
+    project_urls=None,
+    upload_time="2026-04-20T17:16:54.447882Z",
+    last_serial=36296717,
+):
+    body = {
+        "info": {
+            "name": "mne",
+            "summary": "MEG and EEG data analysis.",
+            "version": "1.12.1",
+            "author": "MNE developers",
+            "license": "BSD-3-Clause",
+            "home_page": "",
+            "project_urls": project_urls or {},
+            "classifiers": classifiers or [],
+            "requires_python": requires_python,
+            "keywords": "",
+        },
+        "last_serial": last_serial,
+        "urls": [{"upload_time_iso_8601": upload_time}] if upload_time else [],
+    }
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = body
+    return resp
+
+
+class TestLastUpdated:
+    def test_uses_real_upload_time_not_last_serial(self):
+        tool = _make_tool()
+        with patch("tooluniverse.package_tool.requests.get") as get:
+            get.return_value = _pypi_response()
+            result = tool.run({"source": "pypi", "include_examples": False})
+        assert result["last_updated"] == "2026-04-20T17:16:54.447882Z"
+        # The bogus 1970s-decoding serial number must not leak into the field.
+        assert result["last_updated"] != 36296717
+
+    def test_falls_back_to_unknown_when_no_release_urls(self):
+        tool = _make_tool()
+        with patch("tooluniverse.package_tool.requests.get") as get:
+            get.return_value = _pypi_response(upload_time=None)
+            result = tool.run({"source": "pypi", "include_examples": False})
+        assert result["last_updated"] == "Unknown"
+
+
+class TestPythonVersions:
+    def test_filters_classifiers_to_python_version_entries(self):
+        tool = _make_tool("nilearn")
+        classifiers = [
+            "Development Status :: 5 - Production/Stable",
+            "Intended Audience :: Science/Research",
+            "Programming Language :: Python :: 3.10",
+            "Programming Language :: Python :: 3.11",
+            "Programming Language :: Python :: 3",  # generic, not a real version
+            "Topic :: Scientific/Engineering",
+        ]
+        with patch("tooluniverse.package_tool.requests.get") as get:
+            get.return_value = _pypi_response(classifiers=classifiers)
+            result = tool.run({"source": "pypi", "include_examples": False})
+        assert result["python_versions"] == ["3.10", "3.11"]
+
+    def test_falls_back_to_requires_python_when_no_specific_classifiers(self):
+        """mne-python only declares the generic 'Python :: 3' classifier."""
+        tool = _make_tool()
+        classifiers = ["Programming Language :: Python :: 3"]
+        with patch("tooluniverse.package_tool.requests.get") as get:
+            get.return_value = _pypi_response(
+                classifiers=classifiers, requires_python=">=3.10"
+            )
+            result = tool.run({"source": "pypi", "include_examples": False})
+        assert result["python_versions"] == [">=3.10"]
+
+
+class TestRepository:
+    def test_falls_back_to_source_code_key(self):
+        """mne-python's PyPI metadata only sets project_urls['Source Code']."""
+        tool = _make_tool()
+        with patch("tooluniverse.package_tool.requests.get") as get:
+            get.return_value = _pypi_response(
+                project_urls={
+                    "Documentation": "https://mne.tools/",
+                    "Source Code": "https://github.com/mne-tools/mne-python/",
+                }
+            )
+            result = tool.run({"source": "pypi", "include_examples": False})
+        assert result["repository"] == "https://github.com/mne-tools/mne-python/"
+        assert result["documentation"] == "https://mne.tools/"
+
+    def test_prefers_repository_key_over_alternatives(self):
+        tool = _make_tool()
+        with patch("tooluniverse.package_tool.requests.get") as get:
+            get.return_value = _pypi_response(
+                project_urls={
+                    "Repository": "https://github.com/example/canonical",
+                    "Homepage": "https://example.org",
+                }
+            )
+            result = tool.run({"source": "pypi", "include_examples": False})
+        assert result["repository"] == "https://github.com/example/canonical"

--- a/tests/unit/test_panelapp_client_side_search.py
+++ b/tests/unit/test_panelapp_client_side_search.py
@@ -26,6 +26,21 @@ _PANELS = [
     {"id": 3, "name": "Primary ovarian insufficiency", "disease_group": "Reproductive", "disease_sub_group": ""},
 ]
 
+_BLOOD_PANELS = [
+    {
+        "id": 1397,
+        "name": "Sickle cell, thalassaemia and other haemoglobinopathies",
+        "disease_group": "Haematology",
+        "disease_sub_group": "",
+    },
+    {
+        "id": 200,
+        "name": "Congenital myopathy",
+        "disease_group": "Neurology",
+        "disease_sub_group": "",
+    },
+]
+
 
 def _tool():
     return PanelAppSearchTool({"name": "panelapp_test", "fields": {}, "parameter": {}})
@@ -80,3 +95,32 @@ class TestClientSideSearchFiltering:
         tool = _tool()
         result = tool.run({})
         assert result["status"] == "error"
+
+
+class TestSingularPluralFuzzyMatch:
+    """Regression guard for Fix Round 12 / Feature-12C-1: a clinician
+    searching the singular disease term ("haemoglobinopathy") got zero
+    results because the panel is named in the plural
+    ("...haemoglobinopathies") and plain substring matching doesn't handle
+    inflection. The fuzzy fallback must catch this without over-matching
+    unrelated terms that happen to share a substring (e.g. "myopathy" is a
+    literal substring of "cardiomyopathy" but is a different topic).
+    """
+
+    def test_singular_query_matches_plural_panel_name(self):
+        tool = _tool()
+        with patch.object(tool.session, "get", return_value=_resp(_BLOOD_PANELS)):
+            result = tool.run({"search": "haemoglobinopathy"})
+
+        assert result["data"]["count"] == 1
+        assert "haemoglobinopathies" in result["data"]["results"][0]["name"].lower()
+
+    def test_does_not_over_match_unrelated_shared_substring(self):
+        # "myopathy" is a literal substring of "cardiomyopathy", but
+        # Congenital myopathy is not a relevant hit for a cardiomyopathy
+        # search -- containment alone must not be treated as a match.
+        tool = _tool()
+        with patch.object(tool.session, "get", return_value=_resp(_BLOOD_PANELS)):
+            result = tool.run({"search": "cardiomyopathy"})
+
+        assert result["data"]["count"] == 0

--- a/tests/unit/test_wikipathways_pathway_genes.py
+++ b/tests/unit/test_wikipathways_pathway_genes.py
@@ -129,3 +129,12 @@ def test_empty_result_stays_empty():
 
 def test_missing_pathway_id_is_an_error():
     assert _make().run({})["status"] == "error"
+
+
+def test_wpid_is_accepted_as_an_alias_for_pathway_id():
+    # WikiPathways_get_pathway (the sibling tool) names this parameter `wpid`;
+    # a caller switching tools should not have to know the two use different
+    # names for the same identifier.
+    result, _ = _run({"wpid": "WP254"})
+    assert result["status"] == "success"
+    assert result["data"]["pathway_id"] == "WP254"

--- a/tests/unit/test_xml_tool_query_alias.py
+++ b/tests/unit/test_xml_tool_query_alias.py
@@ -1,0 +1,78 @@
+"""XMLTool-family tools (drugbank_*, mesh_*) all take a single search
+parameter named 'query', regardless of what the tool's own NAME promises.
+
+Regression for Fix Round 17: calling
+drugbank_get_pharmacology_by_drug_name_or_drugbank_id with 'drug_name' (the
+exact term used in the tool's own name) errored with "'query' is a required
+property" -- schema validation runs before run(), so an alias resolved only
+inside run() would never fire for a normal (validated) call. The fix
+resolves the alias inside validate_parameters() itself, mutating the shared
+arguments dict in place so the resolved 'query' is also visible to the
+subsequent run() call.
+"""
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _make_tool(parameter_overrides=None):
+    from tooluniverse.xml_tool import XMLDatasetTool
+
+    config = {
+        "name": "drugbank_get_pharmacology_by_drug_name_or_drugbank_id",
+        "parameter": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string"},
+                "condition": {"type": "string"},
+                "value": {"type": "string"},
+            },
+            "required": ["query"],
+        },
+        "settings": {
+            # No real dataset path -- _load_dataset() catches the failure and
+            # leaves self.records == [], which is fine for validation-layer tests.
+            "record_xpath": ".//*",
+        },
+    }
+    if parameter_overrides:
+        config["parameter"].update(parameter_overrides)
+    return XMLDatasetTool(config)
+
+
+@pytest.mark.parametrize("alias", ["drug_name", "drugbank_id"])
+def test_alias_resolved_before_schema_validation(alias):
+    tool = _make_tool()
+    arguments = {alias: "buprenorphine"}
+    error = tool.validate_parameters(arguments)
+    assert error is None, f"expected no validation error, got: {error}"
+    # The alias resolution must mutate the same dict object run() will see.
+    assert arguments["query"] == "buprenorphine"
+
+
+def test_unrecognized_alias_still_errors_with_helpful_message():
+    tool = _make_tool()
+    error = tool.validate_parameters({"totally_unrelated_key": "x"})
+    assert error is not None
+    assert "query" in str(error.message if hasattr(error, "message") else error)
+
+
+def test_explicit_query_takes_precedence_over_alias():
+    tool = _make_tool()
+    arguments = {"query": "aspirin", "drug_name": "ibuprofen"}
+    error = tool.validate_parameters(arguments)
+    assert error is None
+    assert arguments["query"] == "aspirin"
+
+
+def test_condition_based_filter_call_is_unaffected():
+    # drugbank_filter_drugs_by_name's real schema requires condition+value,
+    # not query -- matches that shape rather than the search-tool default.
+    tool = _make_tool(
+        parameter_overrides={"required": ["condition", "value"]}
+    )
+    arguments = {"condition": "type", "value": "small molecule"}
+    error = tool.validate_parameters(arguments)
+    assert error is None
+    assert "query" not in arguments


### PR DESCRIPTION
## Summary

Consolidates 13 independently-shipped test-harness round PRs (#479-491, rounds 7-19) into a single PR to reduce review/merge overhead. Each fix was individually live-verified via CLI (`tu run`/`tu test`) before being queued, per the test-harness methodology (role-play persona → CLI-verify → fix → retest → ship).

Two files had overlapping fixes from different rounds targeting the same underlying bug; both were manually reconciled by keeping the more complete/robust implementation:

- **`disgenet_tool.py`**: kept the regex-based `_drop_unset_param_noise()` (anchored, handles grammar variants) over a later round's simpler inline substring match — the regex version is a proper superset.
- **`faers_analytics_tool.py`**: kept round 17's `_get_faers_count` design, which returns `Optional[int]` and treats a failed openFDA fetch (`None`) as distinct from a genuine zero count, over an earlier round's `errors`-list opt-in variant. This was already live-verified end-to-end (ibuprofen / GI-haemorrhage contingency table). Removed the now-dead `fetch_errors` branch left behind by the discarded implementation.

## Included fixes (rounds 7-19)

Bug fixes and hardening across NCBI Datasets, OMIM, OpenAlex, package/PyPI metadata, PanelApp, Plant Reactome, Reactome, RESTful/GraphQL tooling, USDA Plants, VDJdb, WikiPathways, XML tool query aliasing, DisGeNET, FAERS analytics (disproportionality + drug-comparison wording), CTD, CTG phrase quoting, HPO phenotype annotations, KEGG extension, DNA Golden Gate assembly, aging cohort tool, biomarker discovery composition, and an OpenAI-compatible client fix. Each round added regression tests alongside its fix (see `tests/unit/*` in the diff).

## Test plan

- [x] All touched source files pass `py_compile`
- [x] Clean cherry-pick of all 16 commits from the 13 source PRs, in round order, onto current `main`
- [x] Two genuine conflicts manually reconciled (see above); no leftover dead code or conflict markers (repo-wide grep confirmed clean)
- [ ] Full local pytest run blocked by shared-machine filesystem contention (not a code issue — `import tooluniverse` itself was hanging in this sandbox); deferring to CI, which runs on isolated infra
- [x] Each individual fix was live CLI-verified when its originating round shipped

Supersedes and closes #479, #480, #481, #482, #483, #484, #485, #486, #487, #488, #489, #490, #491.

🤖 Generated with [Claude Code](https://claude.com/claude-code)