### PR TITLE
Fix Round 20: EFO abbreviation lookups return the wrong disease; openFDA fallback results look like exact matches

### DIFF
--- a/src/tooluniverse/efo_tool.py
+++ b/src/tooluniverse/efo_tool.py
@@ -29,7 +29,20 @@ class EFOTool(BaseTool):
         return self._search(disease, rows)
 
     def _search(self, disease, rows):
-        params = {"ontology": "efo", "q": disease, "rows": rows}
+        # Fix-20B-2: OLS4's default relevance ranking scores hits on the full
+        # indexed text (including free-text descriptions), not just the
+        # term's own name. For an abbreviation like "PCOS" this put a term
+        # whose *description* merely mentions "PCOS" in passing (EFO_0005187
+        # "C-peptide measurement") ahead of the actual term for the disease
+        # (MONDO_0008487 "polycystic ovary syndrome", which lists "PCOS" as
+        # an exact_synonym) -- confirmed live against the OLS4 API. Silently
+        # returning the wrong disease's EFO ID is worse than a fetch failure,
+        # since callers treat it as authoritative and chain further lookups
+        # on it. Always fetch enough candidates to see past a mis-ranked top
+        # hit, then prefer any candidate whose own label/exact_synonym is a
+        # case-insensitive exact match to the query over the raw OLS order.
+        fetch_rows = max(rows, 10)
+        params = {"ontology": "efo", "q": disease, "rows": fetch_rows}
         try:
             response = requests.get(self.base_url, params=params, timeout=20)
             response.raise_for_status()
@@ -44,6 +57,18 @@ class EFOTool(BaseTool):
         docs = data.get("docs", [])
         if not docs:
             return None
+
+        def _is_exact_match(doc):
+            target = disease.strip().lower()
+            label = (doc.get("label") or "").strip().lower()
+            if label == target:
+                return True
+            synonyms = doc.get("exact_synonyms") or []
+            return any(target == str(s).strip().lower() for s in synonyms)
+
+        exact = [d for d in docs if _is_exact_match(d)]
+        rest = [d for d in docs if d not in exact]
+        docs = (exact + rest)[:rows]
 
         if rows == 1:
             doc = docs[0]

--- a/src/tooluniverse/openfda_tool.py
+++ b/src/tooluniverse/openfda_tool.py
@@ -430,6 +430,13 @@ def search_openfda(
     applied_return_field_mapping = {}  # primary_field -> fallback_field
     fallback_terms: list[str] = []
     used_generic_fallback = False
+    # Fix-20A-1: `used_generic_fallback` was tracked but never surfaced to the
+    # caller. Each fallback stage weakens the match in a different way, and
+    # the returned payload looked identical to an exact hit, so a caller had
+    # no way to tell "this is the drug you asked for" from "this is the
+    # closest thing we could find". Record which stage fired so we can attach
+    # an honest note.
+    fallback_note: str | None = None
 
     def _all_search_fields_from_orig() -> list[str]:
         out = []
@@ -575,6 +582,11 @@ def search_openfda(
                         requested_return_fields = [fb]
                         applied_return_field_mapping[primary] = fb
                         used_generic_fallback = True
+                        fallback_note = (
+                            f"Label section '{primary}' was not present for this "
+                            f"product; showing content from the related section "
+                            f"'{fb}' instead."
+                        )
                         break
                 if used_generic_fallback:
                     break
@@ -605,6 +617,12 @@ def search_openfda(
             if isinstance(tmp, dict) and "error" not in tmp:
                 response_data = tmp
                 used_generic_fallback = True
+                fallback_note = (
+                    f"No exact phrase match for '{qtext}'; results use a "
+                    f"broadened, term-based match in the same field(s) "
+                    f"({', '.join(sorted(orig_fields_flat))}) -- verify the "
+                    f"returned drug name is the one you intended."
+                )
 
         # Stage B: expand to label-text fields (robust when openfda is empty or name mismatched)
         if (
@@ -636,6 +654,22 @@ def search_openfda(
             if isinstance(tmp, dict) and "error" not in tmp:
                 response_data = tmp
                 used_generic_fallback = True
+                # Fix-20A-1: this stage matches '{qtext}' anywhere in full
+                # label-text fields, including ingredient lists -- so a query
+                # that is not a product name at all still returns rows. Live
+                # example: "magnesium stearate tablet" (an excipient plus a
+                # dosage form) returns unrelated products that merely list it,
+                # indistinguishable from a real hit. Flag that explicitly,
+                # since the field-based fallback above (Stage A) already
+                # covers ordinary name/spelling mismatches.
+                fallback_note = (
+                    f"No product/drug named '{qtext}' matched exactly; "
+                    f"results were broadened to full label text (e.g. "
+                    f"ingredients, indications, description) and may include "
+                    f"unrelated products that merely mention '{qtext}' -- "
+                    f"check the returned openfda.brand_name/generic_name "
+                    f"before treating this as data about '{qtext}' itself."
+                )
 
         # Stage C: data-driven closest-name candidates (name-based only, single token)
         if (
@@ -719,6 +753,13 @@ def search_openfda(
                         if isinstance(tmp, dict) and "error" not in tmp:
                             response_data = tmp
                             used_generic_fallback = True
+                            fallback_note = (
+                                f"No drug named '{term}' was found; showing "
+                                f"the closest-spelling candidate(s) "
+                                f"({', '.join(sorted(near))}) instead -- "
+                                f"verify the returned drug name matches what "
+                                f"you intended."
+                            )
                 except Exception:
                     pass
 
@@ -790,10 +831,16 @@ def search_openfda(
     # Extract results and return only the specified return fields
     results = response_data.get("results", [])
     if return_fields == "ALL":
-        return {"meta": meta_info, "results": results}
+        out = {"meta": meta_info, "results": results}
+        if fallback_note:
+            out["note"] = fallback_note
+        return out
     # If count parameter is used, return results directly (count API format)
     if params.get("count") or count:
-        return {"meta": meta_info, "results": results}
+        out = {"meta": meta_info, "results": results}
+        if fallback_note:
+            out["note"] = fallback_note
+        return out
     flat_keys = []
     # Use original search_fields for consistent output schema even when we fell
     # back to broad text search.
@@ -872,7 +919,10 @@ def search_openfda(
         if user_limit_final:
             extracted_results = extracted_results[:user_limit_final]
 
-    return {"meta": meta_info, "results": extracted_results}
+    out = {"meta": meta_info, "results": extracted_results}
+    if fallback_note:
+        out["note"] = fallback_note
+    return out
 
 
 @register_tool("FDATool")


### PR DESCRIPTION
Round 20 of the test-harness. Two independent data-quality fixes, both reproduced live against the real APIs before and after the change.

## 1. EFO abbreviation lookups return the wrong disease (`efo_tool.py`)

OLS4 ranks search hits on the full indexed text — including a term's free-text description — not just the term's own name. For an abbreviation, the real disease term loses to whatever unrelated term happens to mention the abbreviation in prose.

Reproduced directly against the OLS4 API:

```
GET /ols4/api/search?ontology=efo&q=PCOS&rows=1
  -> EFO_0005187  "C-peptide measurement"     (mentions PCOS only in its description)

rows=10 shows the term that should have won:
  -> MONDO_0008487 "polycystic ovary syndrome" (exact_synonyms includes "PCOS")
```

`EFOTool` passes `rows` straight through, so the default `rows=1` never even fetched the correct term. A confidently wrong EFO ID is worse than a lookup failure here: callers treat the ID as authoritative and chain further lookups onto it.

The fix fetches enough candidates to see past a mis-ranked top hit, then prefers any candidate whose own `label` or `exact_synonyms` matches the query exactly, falling back to OLS's own ordering otherwise.

## 2. openFDA fallback results look identical to exact matches (`openfda_tool.py`)

`search_openfda` has three fallback stages — broadened term-based match in the same fields, full label-text match, and closest-spelling match — plus a label-section substitution. Each weakens the match in a different way, but every one of them returned a payload shaped exactly like an exact hit. `used_generic_fallback` was tracked internally and never surfaced.

The practical consequence: a query that names no product at all still returns rows, and the caller has nothing to distinguish "this is the drug you asked for" from "this is the nearest thing we could find".

Each stage now attaches a `note` describing what was actually matched.

## Verification

CLI, against live APIs:

| Call | Result |
| --- | --- |
| `OSL_get_efo_id_by_disease_name {"disease":"PCOS"}` | `MONDO_0008487` polycystic ovary syndrome (was `EFO_0005187` C-peptide measurement) |
| `OSL_get_efo_id_by_disease_name {"disease":"asthma"}` | `MONDO_0004979` asthma — unchanged |
| `OSL_get_efo_id_by_disease_name {"disease":"breast carcinoma","rows":3}` | 3 ordered hits — unchanged |
| `FDA_get_active_ingredient_info_by_drug_name {"drug_name":"aspirn"}` | section-substitution note: `active_ingredient` absent, served from `spl_product_data_elements` |
| `..."magnesium stearate tablet"` | label-text broadening note |
| `..."ibuprofin"` | closest-spelling note naming `IBUPROFEN` |
| `..."EDTA"` | no note — matches at the primary stage, correctly unannotated |

Also checked:

- `tests/unit/test_openfda_field_value_projection.py`, `test_confidently_wrong_answers_r6.py`, `test_gap_efo_descendants.py` — 55 passed.
- No `return_schema` on any FDA/OpenFDA tool sets `additionalProperties: false`, so the added `note` key does not break envelope validation.

## Notes

This branch was originally produced by a session that was interrupted before it could verify or ship the work; the commit was preserved unverified. Everything above is verification done after the fact, and one code comment was corrected — the original cited an "EDTA" example that does not actually reproduce (that query matches at the primary stage), replaced with a case that does.
