### PR TITLE
Fix Round 21: queries that silently return nothing instead of answering

### DIFF
--- a/src/tooluniverse/bindingdb_tool.py
+++ b/src/tooluniverse/bindingdb_tool.py
@@ -12,6 +12,7 @@ single id or a semicolon-delimited list — so we route every operation
 through the plural endpoint.
 """
 
+import re
 from typing import Any, Dict, List
 
 import requests
@@ -22,6 +23,21 @@ from .tool_registry import register_tool
 
 BASE_URL = "https://www.bindingdb.org/rest"
 DEFAULT_TIMEOUT = 30
+
+
+def _error_detail(resp: "requests.Response") -> str:
+    """Readable one-line summary of an error response body.
+
+    BindingDB serves Tomcat's HTML error page on failures, and echoing its
+    first 200 characters put a doctype and a stylesheet fragment in front of
+    the caller instead of anything diagnostic.
+    """
+    body = (resp.text or "").strip()
+    if "<html" in body[:200].lower() or body[:20].lower().startswith("<!doctype"):
+        title = re.search(r"<title>(.*?)</title>", body, re.IGNORECASE | re.DOTALL)
+        summary = title.group(1).strip() if title else "HTML error page"
+        return f"upstream returned an HTML error page ({summary})"
+    return body[:200] or "empty response body"
 
 
 def _http_get(
@@ -45,7 +61,7 @@ def _http_get(
     except requests.exceptions.ConnectionError as e:
         return {"_err": f"BindingDB connection failed: {e}"}
     if resp.status_code != 200:
-        return {"_err": f"BindingDB HTTP {resp.status_code}: {resp.text[:200]}"}
+        return {"_err": f"BindingDB HTTP {resp.status_code}: {_error_detail(resp)}"}
     try:
         return resp.json()
     except ValueError as e:
@@ -154,7 +170,24 @@ class BindingDBTool(BaseTool):
             timeout=self.timeout,
         )
         if "_err" in result:
-            return {"status": "error", "error": result["_err"]}
+            error = result["_err"]
+            # getLigandsByPDBs is currently answering 500 for every input, valid
+            # ids included (confirmed for 6OIM and 2RH1, with and without the
+            # cutoff parameter; the singular getLigandsByPDB is a 404 while
+            # getLigandsByUniprots answers 200). A bare relay of the upstream
+            # status leaves the caller unable to tell "this structure has no
+            # binding data" from "this whole lookup route is down", so name the
+            # route that does work.
+            if "HTTP 5" in error:
+                error += (
+                    ". BindingDB's PDB lookup endpoint is failing for all "
+                    "structures, not just this one. Map the PDB entry to a "
+                    "UniProt accession with PDBeSIFTS_get_pdb_to_uniprot and "
+                    "query BindingDB_get_ligands_by_uniprot instead, or use "
+                    "get_binding_affinity_by_pdb_id for RCSB's own curated "
+                    "affinity data."
+                )
+            return {"status": "error", "error": error}
         return {
             "status": "success",
             "data": {"pdbs": ids, "cutoff": cutoff, "affinities": _affinities(result)},

--- a/src/tooluniverse/bvbrc_tool.py
+++ b/src/tooluniverse/bvbrc_tool.py
@@ -584,6 +584,21 @@ class BVBRCTool(BaseTool):
         if not taxon_id:
             return {"status": "error", "error": "taxon_id parameter is required"}
 
+        # /taxonomy/{id} is an NCBI-taxid lookup, so a species name reaches
+        # BV-BRC as a nonexistent path and comes back as a bare "HTTP error:
+        # 404" that says nothing about why. Reject the name here and name the
+        # tool that turns it into an id.
+        if not str(taxon_id).strip().isdigit():
+            return {
+                "status": "error",
+                "error": (
+                    f"taxon_id must be a numeric NCBI taxonomy ID (e.g. 573 for "
+                    f"Klebsiella pneumoniae), but got '{taxon_id}'. To look a "
+                    f"species up by name, call BVBRC_search_taxonomy with "
+                    f"keyword='{taxon_id}' and use the taxon_id it returns."
+                ),
+            }
+
         url = f"{BVBRC_BASE_URL}/taxonomy/{taxon_id}"
         headers = {"Accept": "application/json"}
         response = requests.get(url, headers=headers, timeout=self.timeout)

--- a/src/tooluniverse/chem_tool.py
+++ b/src/tooluniverse/chem_tool.py
@@ -390,8 +390,13 @@ class ChEMBLRESTTool(BaseTool):
             # Correct approach: query /activity.json?molecule_chembl_id=X and
             # deduplicate the target fields from the activity records.
             if tool_name == "ChEMBL_get_molecule_targets":
-                mol_id = arguments.get("molecule_chembl_id__exact") or arguments.get(
-                    "molecule_chembl_id"
+                mol_id = (
+                    arguments.get("molecule_chembl_id__exact")
+                    or arguments.get("molecule_chembl_id")
+                    # ChEMBL_get_molecule names this same identifier `chembl_id`,
+                    # so chaining its output into this tool otherwise failed
+                    # parameter validation on the ID you just looked up.
+                    or arguments.get("chembl_id")
                 )
                 if mol_id:
                     activity_url = self.base_url + "/activity.json"

--- a/src/tooluniverse/data/alphafold_tools.json
+++ b/src/tooluniverse/data/alphafold_tools.json
@@ -18,6 +18,10 @@
           "type": "string",
           "description": "Alias for qualifier: UniProt accession (e.g., 'P69905')."
         },
+        "accession": {
+          "type": "string",
+          "description": "Alias for qualifier. UniProt accession (e.g., 'P04637') -- the same parameter name the UniProt_*_by_accession tools use."
+        },
         "sequence_checksum": {
           "type": "string",
           "description": "Optional CRC64 checksum of the UniProt sequence."
@@ -280,6 +284,10 @@
         "uniprot_accession": {
           "type": "string",
           "description": "Alias for qualifier. UniProt accession (e.g., 'P04637')."
+        },
+        "accession": {
+          "type": "string",
+          "description": "Alias for qualifier. UniProt accession (e.g., 'P04637') -- the same parameter name the UniProt_*_by_accession tools use."
         }
       },
       "required": []
@@ -517,6 +525,10 @@
         "uniprot_accession": {
           "type": "string",
           "description": "Alias for qualifier. UniProt accession (e.g., 'P69905')."
+        },
+        "accession": {
+          "type": "string",
+          "description": "Alias for qualifier. UniProt accession (e.g., 'P04637') -- the same parameter name the UniProt_*_by_accession tools use."
         }
       },
       "required": []

--- a/src/tooluniverse/data/chembl_tools.json
+++ b/src/tooluniverse/data/chembl_tools.json
@@ -283,6 +283,10 @@
           "type": "string",
           "description": "Alias for molecule_chembl_id__exact. ChEMBL molecule ID."
         },
+        "chembl_id": {
+          "type": "string",
+          "description": "Alias for molecule_chembl_id__exact. Accepts the same name ChEMBL_get_molecule uses, so an ID can be carried straight from that call into this one."
+        },
         "limit": {
           "type": "integer",
           "default": 500,

--- a/src/tooluniverse/data/gwas_tools.json
+++ b/src/tooluniverse/data/gwas_tools.json
@@ -1965,6 +1965,14 @@
         },
         "total_found": {
           "type": "integer"
+        },
+        "queried_gene_name": {
+          "type": "string",
+          "description": "Present only when the requested symbol matched nothing and an unhyphenated spelling was used instead; holds the symbol originally requested."
+        },
+        "gene_name_note": {
+          "type": "string",
+          "description": "Present only when the requested symbol matched nothing and an unhyphenated spelling was used instead; explains which spelling produced these results."
         }
       }
     },

--- a/src/tooluniverse/data/opentarget_tools.json
+++ b/src/tooluniverse/data/opentarget_tools.json
@@ -278,7 +278,7 @@
     },
     {
         "name": "OpenTargets_get_evidence_by_datasource",
-        "description": "Get target-disease evidence from Open Targets filtered by configurable data sources. Unlike OpenTargets_target_disease_evidence (intogen-only), this tool accepts any datasourceIds. Valid sources include: ot_genetics_portal, eva, eva_somatic, gene_burden, genomics_england, intogen, cancer_gene_census, clinical_precedence, crispr, europepmc, expression_atlas, gene2phenotype, orphanet, uniprot_literature, uniprot_variants, clingen, phewas_catalog, reactome, progeny, slapenrich, sysbio. Note: 'chembl' was renamed to 'clinical_precedence' upstream (confirmed live: 'chembl' now returns 0 rows even for well-documented drug-target-disease evidence). Returns evidence rows with scores, literature references, and source attribution.",
+        "description": "Get target-disease evidence from Open Targets filtered by configurable data sources. Unlike OpenTargets_target_disease_evidence (intogen-only), this tool accepts any datasourceIds. Valid sources include: gwas_credible_sets, eva, eva_somatic, gene_burden, genomics_england, intogen, cancer_gene_census, cancer_biomarkers, clinical_precedence, crispr, europepmc, expression_atlas, gene2phenotype, impc, orphanet, uniprot_literature, uniprot_variants, clingen, phewas_catalog, reactome, progeny, slapenrich, sysbio. Note: two source IDs were renamed upstream and the retired names now match nothing rather than erroring — 'ot_genetics_portal' became 'gwas_credible_sets' (confirmed live: IL23R/Crohn disease returns 0 rows for the old name and 43 for the new one) and 'chembl' became 'clinical_precedence'. This tool remaps both retired names automatically and reports the substitution in metadata.datasource_rename_note. Returns evidence rows with scores, literature references, and source attribution.",
         "label": [
             "Target",
             "Disease",
@@ -311,7 +311,7 @@
                     "items": {
                         "type": "string"
                     },
-                    "description": "List of datasource IDs to filter evidence. Examples: ['clinical_precedence', 'europepmc'], ['eva', 'clinvar'], ['intogen', 'cancer_gene_census']. Omit or pass empty array for all sources."
+                    "description": "List of datasource IDs to filter evidence. Examples: ['gwas_credible_sets', 'europepmc'], ['eva', 'clinical_precedence'], ['intogen', 'cancer_gene_census']. For genetic (GWAS) association evidence use 'gwas_credible_sets' — the retired 'ot_genetics_portal' name is remapped automatically. Omit or pass empty array for all sources."
                 },
                 "size": {
                     "type": "integer",

--- a/src/tooluniverse/data/pubchem_tools.json
+++ b/src/tooluniverse/data/pubchem_tools.json
@@ -184,7 +184,7 @@
   },
   {
     "name": "PubChem_get_compound_properties_by_CID",
-    "description": "Get a set of specified molecular properties through CID (Compound ID), such as molecular weight, IUPAC name, Canonical SMILES.",
+    "description": "Get a set of specified molecular properties through CID (Compound ID), such as molecular weight, IUPAC name, and SMILES. PubChem's PUG-REST renamed its SMILES properties: ask for 'ConnectivitySMILES' (formerly 'CanonicalSMILES') and 'SMILES' (formerly 'IsomericSMILES'). Requesting a legacy name returns the value under the CURRENT key, so a caller that looks up the key it asked for will not find it.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -201,7 +201,7 @@
           "items": {
             "type": "string"
           },
-          "description": "Optional list of PubChem property names to retrieve (e.g. ['MolecularFormula','InChIKey','XLogP','IUPACName','MolecularWeight']). If omitted, returns a default set (MolecularWeight, IUPACName, SMILES). See PubChem PUG-REST property tables for valid names. Accepts a list or a comma-separated string."
+          "description": "Optional list of PubChem property names to retrieve (e.g. ['MolecularFormula','InChIKey','XLogP','IUPACName','MolecularWeight']). If omitted, returns a default set (MolecularWeight, IUPACName, ConnectivitySMILES). For SMILES use the current names 'ConnectivitySMILES' (was 'CanonicalSMILES') or 'SMILES' (was 'IsomericSMILES') — a legacy name still returns data, but under the current key, not the one requested. See PubChem PUG-REST property tables for valid names. Accepts a list or a comma-separated string."
         }
       },
       "required": [

--- a/src/tooluniverse/ebi_taxonomy_tool.py
+++ b/src/tooluniverse/ebi_taxonomy_tool.py
@@ -10,6 +10,7 @@ API: https://www.ebi.ac.uk/ena/taxonomy/rest
 No authentication required.
 """
 
+import re
 import requests
 from typing import Dict, Any
 from .base_tool import BaseTool
@@ -121,6 +122,28 @@ class EBITaxonomyTool(BaseTool):
         name = arguments.get("scientific_name", "")
         if not name:
             return {"status": "error", "error": "scientific_name parameter is required"}
+
+        # ENA indexes full binomials only, so the abbreviated genus form
+        # clinicians write ("K. pneumoniae") returns an ordinary empty
+        # success -- identical to a species that genuinely is not in the
+        # database. The genus letter cannot be expanded unambiguously
+        # ("K." is Klebsiella, Klebsormidium, Kluyveromyces, ...), so reject
+        # it rather than guess.
+        abbreviated = re.match(r"^([A-Z])\.\s*(\S.*)$", str(name).strip())
+        if abbreviated:
+            return {
+                "status": "error",
+                "error": (
+                    f"'{name}' abbreviates the genus to "
+                    f"'{abbreviated.group(1)}.'. ENA taxonomy indexes full "
+                    f"binomials only, so this matches nothing — re-send it "
+                    f"with the genus spelled out (e.g. 'Klebsiella pneumoniae' "
+                    f"rather than 'K. pneumoniae'). If you do not know which "
+                    f"genus '{abbreviated.group(1)}.' stands for, search on "
+                    f"'{abbreviated.group(2)}' with EBITaxonomy_search_by_name "
+                    f"or EBITaxonomy_suggest."
+                ),
+            }
 
         url = f"{EBI_TAXONOMY_BASE}/scientific-name/{name}"
         response = requests.get(

--- a/src/tooluniverse/faers_analytics_tool.py
+++ b/src/tooluniverse/faers_analytics_tool.py
@@ -11,6 +11,23 @@ from .tool_registry import register_tool
 FDA_BASE_URL = "https://api.fda.gov/drug/event.json"
 
 
+def _drug_clause(drug_name: str) -> str:
+    """openFDA search clause matching a drug by generic OR brand name.
+
+    Matching only `generic_name` makes every brand name look like a drug with
+    zero reports, which for the disproportionality math is indistinguishable
+    from a genuinely unreported drug (confirmed live: "XELJANZ" yielded
+    a=0, b=0 and an "Insufficient data" error while its generic "tofacitinib"
+    returned a real ROR; the generic-or-brand form returns 183,405 reports for
+    the same brand name). Brand names are what prescribers and labels use, so
+    they must resolve to the same reports as the generic.
+    """
+    return (
+        f'(patient.drug.openfda.generic_name:"{drug_name}"'
+        f'+OR+patient.drug.openfda.brand_name:"{drug_name}")'
+    )
+
+
 @register_tool("FAERSAnalyticsTool")
 class FAERSAnalyticsTool(BaseTool):
     """
@@ -260,9 +277,9 @@ class FAERSAnalyticsTool(BaseTool):
 
             # Feature-121A-003: adverse_event is optional — filter by drug alone if omitted
             if adverse_event:
-                base_query = f'patient.drug.openfda.generic_name:"{drug_name}"+AND+patient.reaction.reactionmeddrapt:"{adverse_event}"'
+                base_query = f'{_drug_clause(drug_name)}+AND+patient.reaction.reactionmeddrapt:"{adverse_event}"'
             else:
-                base_query = f'patient.drug.openfda.generic_name:"{drug_name}"'
+                base_query = _drug_clause(drug_name)
 
             url = self._with_api_key(f"{FDA_BASE_URL}?search={base_query}&count={count_field}")
 
@@ -331,7 +348,7 @@ class FAERSAnalyticsTool(BaseTool):
                 return {"status": "error", "error": "Must provide drug_name"}
 
             # Build query for serious events
-            base_query = f'patient.drug.openfda.generic_name:"{drug_name}"'
+            base_query = _drug_clause(drug_name)
 
             # Add specific reaction filter if provided
             if adverse_event:
@@ -514,9 +531,9 @@ class FAERSAnalyticsTool(BaseTool):
 
             # Build base query
             if adverse_event:
-                search_query = f'patient.drug.openfda.generic_name:"{drug_name}"+AND+patient.reaction.reactionmeddrapt:"{adverse_event}"'
+                search_query = f'{_drug_clause(drug_name)}+AND+patient.reaction.reactionmeddrapt:"{adverse_event}"'
             else:
-                search_query = f'patient.drug.openfda.generic_name:"{drug_name}"'
+                search_query = _drug_clause(drug_name)
 
             # Get counts by receive date (year)
             url = self._with_api_key(f"{FDA_BASE_URL}?search={search_query}&count=receivedate")
@@ -588,7 +605,7 @@ class FAERSAnalyticsTool(BaseTool):
                 return {"status": "error", "error": "Must provide drug_name"}
 
             # Get preferred term (PT) level reactions
-            search_query = f'patient.drug.openfda.generic_name:"{drug_name}"'
+            search_query = _drug_clause(drug_name)
             url = self._with_api_key(
                 f"{FDA_BASE_URL}?search={search_query}&count=patient.reaction.reactionmeddrapt.exact"
             )
@@ -647,7 +664,7 @@ class FAERSAnalyticsTool(BaseTool):
         try:
             query_parts = []
             if drug_name:
-                query_parts.append(f'patient.drug.openfda.generic_name:"{drug_name}"')
+                query_parts.append(_drug_clause(drug_name))
             if adverse_event:
                 query_parts.append(
                     f'patient.reaction.reactionmeddrapt:"{adverse_event}"'

--- a/src/tooluniverse/genomics_gene_search_tool.py
+++ b/src/tooluniverse/genomics_gene_search_tool.py
@@ -38,36 +38,59 @@ class GWASGeneSearch(BaseTool):
         # diabetes associations were hidden, misleading a clinician into thinking
         # it is not a T2D locus. Also matches the sibling trait-search default.
         size = int(arguments.get("size") or arguments.get("limit") or 100)
-        url = f"{self.base_url}/v2/associations"
-        params = {"mapped_gene": gene_name, "size": size, "page": 0}
 
         try:
-            response = self.session.get(url, params=params, timeout=30)
-            response.raise_for_status()
-            data = response.json()
+            associations, total = self._fetch(gene_name, size)
+            resolved_name = gene_name
 
-            # Extract associations from _embedded structure
-            associations = []
-            if "_embedded" in data and "associations" in data["_embedded"]:
-                associations = data["_embedded"]["associations"]
+            # `mapped_gene` matches the catalog's symbol literally, so writing an
+            # interleukin the way clinicians do ("IL-23R") returns an ordinary
+            # empty result rather than the 112 associations filed under "IL23R".
+            # Genuinely hyphenated symbols are unaffected because they match on
+            # the first attempt (HLA-A returns 107), so only retry after a miss --
+            # and say which spelling produced the answer.
+            fallback_note = None
+            if not associations and "-" in gene_name:
+                candidate = gene_name.replace("-", "")
+                retry_associations, retry_total = self._fetch(candidate, size)
+                if retry_associations:
+                    associations, total = retry_associations, retry_total
+                    resolved_name = candidate
+                    fallback_note = (
+                        f"No GWAS Catalog associations are filed under "
+                        f"'{gene_name}'; these results are for '{candidate}', "
+                        f"the unhyphenated symbol the catalog uses."
+                    )
 
-            # The API does not order by significance, but the tool description
-            # promises the "strongest" associations -- sort the returned set by
-            # p-value (most significant first) so the top rows are the strongest.
-            associations = sorted(associations, key=self._pvalue_sort_key)
-
-            return {
-                "gene_name": gene_name,
+            result = {
+                "gene_name": resolved_name,
                 "association_count": len(associations),
                 "associations": associations,
-                "total_found": (
-                    data.get("page", {}).get("totalElements", 0)
-                    if "page" in data
-                    else 0
-                ),
+                "total_found": total,
             }
+            if fallback_note:
+                result["queried_gene_name"] = gene_name
+                result["gene_name_note"] = fallback_note
+            return result
 
         except requests.exceptions.RequestException as e:
             return {"status": "error", "error": f"Request failed: {str(e)}"}
         except Exception as e:
             return {"status": "error", "error": f"Unexpected error: {str(e)}"}
+
+    def _fetch(self, gene_name, size):
+        """Return (associations sorted by p-value, total matches) for a symbol."""
+        response = self.session.get(
+            f"{self.base_url}/v2/associations",
+            params={"mapped_gene": gene_name, "size": size, "page": 0},
+            timeout=30,
+        )
+        response.raise_for_status()
+        data = response.json()
+
+        associations = data.get("_embedded", {}).get("associations", [])
+        # The API does not order by significance, but the tool description
+        # promises the "strongest" associations -- sort the returned set by
+        # p-value (most significant first) so the top rows are the strongest.
+        associations = sorted(associations, key=self._pvalue_sort_key)
+        return associations, data.get("page", {}).get("totalElements", 0)

--- a/src/tooluniverse/graphql_tool.py
+++ b/src/tooluniverse/graphql_tool.py
@@ -166,6 +166,15 @@ class GraphQLTool(BaseTool):
         return result
 
 
+# Open Targets datasource IDs that were renamed upstream. The retired name is
+# not aliased server-side -- it simply matches nothing -- so queries using it
+# come back as a successful zero-row result.
+_OT_RENAMED_DATASOURCES = {
+    "ot_genetics_portal": "gwas_credible_sets",
+    "chembl": "clinical_precedence",
+}
+
+
 _OT_SEARCH_QUERY = """
 query otSearch($q: String!, $entity: [String!]!) {
   search(queryString: $q, entityNames: $entity, page: {index: 0, size: 1}) {
@@ -362,7 +371,34 @@ class OpentargetTool(GraphQLTool):
                     "Try passing efoId directly (e.g. MONDO_0005011 for Crohn disease).",
                 }
 
+        # Open Targets retires datasource IDs without keeping the old name as an
+        # alias, so a stale ID returns a perfectly successful "count: 0" that is
+        # indistinguishable from "this datasource has no evidence for this pair"
+        # (confirmed live: IL23R/Crohn disease returns 0 rows for
+        # 'ot_genetics_portal' and 43 for 'gwas_credible_sets'; TP53/cancer
+        # returns 0 and 51). Remap the retired IDs and say so, rather than
+        # letting the caller conclude the evidence does not exist.
+        renamed_datasources = []
+        _ds = arguments.get("datasourceIds")
+        if isinstance(_ds, list):
+            remapped = []
+            for _id in _ds:
+                _new = _OT_RENAMED_DATASOURCES.get(_id)
+                if _new:
+                    renamed_datasources.append(f"'{_id}' -> '{_new}'")
+                    remapped.append(_new)
+                else:
+                    remapped.append(_id)
+            arguments = dict(arguments, datasourceIds=remapped)
+
         result = super().run(arguments)
+
+        if renamed_datasources and result.get("status") == "success":
+            result.setdefault("metadata", {})["datasource_rename_note"] = (
+                "Retired Open Targets datasource ID(s) remapped: "
+                + "; ".join(renamed_datasources)
+                + ". Use the current name(s) directly to avoid this remapping."
+            )
 
         # Add note when IntOGen evidence count is 0 (Feature-122B-002).
         # Fix-R31D-3: this note is IntOGen-specific but was applied to every

--- a/src/tooluniverse/tools/ChEMBL_get_molecule_targets.py
+++ b/src/tooluniverse/tools/ChEMBL_get_molecule_targets.py
@@ -11,6 +11,7 @@ from ._shared_client import get_shared_client
 def ChEMBL_get_molecule_targets(
     molecule_chembl_id__exact: Optional[str] = None,
     molecule_chembl_id: Optional[str] = None,
+    chembl_id: Optional[str] = None,
     limit: Optional[int] = 500,
     *,
     stream_callback: Optional[Callable[[str], None]] = None,
@@ -26,6 +27,8 @@ def ChEMBL_get_molecule_targets(
         ChEMBL molecule ID (e.g., 'CHEMBL25' for aspirin). To find a molecule ID, use...
     molecule_chembl_id : str
         Alias for molecule_chembl_id__exact. ChEMBL molecule ID.
+    chembl_id : str
+        Alias for molecule_chembl_id__exact. Accepts the same name...
     limit : int
         Maximum number of activity records to fetch for target deduplication (default...
     stream_callback : Callable, optional
@@ -47,6 +50,7 @@ def ChEMBL_get_molecule_targets(
         for k, v in {
             "molecule_chembl_id__exact": molecule_chembl_id__exact,
             "molecule_chembl_id": molecule_chembl_id,
+            "chembl_id": chembl_id,
             "limit": limit,
         }.items()
         if v is not None

--- a/src/tooluniverse/tools/alphafold_get_annotations.py
+++ b/src/tooluniverse/tools/alphafold_get_annotations.py
@@ -12,6 +12,7 @@ def alphafold_get_annotations(
     qualifier: Optional[str] = None,
     uniprot_id: Optional[str] = None,
     uniprot_accession: Optional[str] = None,
+    accession: Optional[str] = None,
     *,
     stream_callback: Optional[Callable[[str], None]] = None,
     use_cache: bool = False,
@@ -28,6 +29,8 @@ def alphafold_get_annotations(
         Alias for qualifier. UniProt accession (e.g., 'P69905').
     uniprot_accession : str
         Alias for qualifier. UniProt accession (e.g., 'P69905').
+    accession : str
+        Alias for qualifier. UniProt accession (e.g., 'P04637') -- the...
     stream_callback : Callable, optional
         Callback for streaming output
     use_cache : bool, default False
@@ -48,6 +51,7 @@ def alphafold_get_annotations(
             "qualifier": qualifier,
             "uniprot_id": uniprot_id,
             "uniprot_accession": uniprot_accession,
+            "accession": accession,
         }.items()
         if v is not None
     }

--- a/src/tooluniverse/tools/alphafold_get_prediction.py
+++ b/src/tooluniverse/tools/alphafold_get_prediction.py
@@ -12,6 +12,7 @@ def alphafold_get_prediction(
     qualifier: Optional[str] = None,
     uniprot_id: Optional[str] = None,
     uniprot_accession: Optional[str] = None,
+    accession: Optional[str] = None,
     sequence_checksum: Optional[str] = None,
     *,
     stream_callback: Optional[Callable[[str], None]] = None,
@@ -29,6 +30,8 @@ def alphafold_get_prediction(
         Alias for qualifier: UniProt accession (e.g., 'P69905').
     uniprot_accession : str
         Alias for qualifier: UniProt accession (e.g., 'P69905').
+    accession : str
+        Alias for qualifier. UniProt accession (e.g., 'P04637') -- the...
     sequence_checksum : str
         Optional CRC64 checksum of the UniProt sequence.
     stream_callback : Callable, optional
@@ -51,6 +54,7 @@ def alphafold_get_prediction(
             "qualifier": qualifier,
             "uniprot_id": uniprot_id,
             "uniprot_accession": uniprot_accession,
+            "accession": accession,
             "sequence_checksum": sequence_checksum,
         }.items()
         if v is not None

--- a/src/tooluniverse/tools/alphafold_get_summary.py
+++ b/src/tooluniverse/tools/alphafold_get_summary.py
@@ -12,6 +12,7 @@ def alphafold_get_summary(
     qualifier: Optional[str] = None,
     uniprot_id: Optional[str] = None,
     uniprot_accession: Optional[str] = None,
+    accession: Optional[str] = None,
     *,
     stream_callback: Optional[Callable[[str], None]] = None,
     use_cache: bool = False,
@@ -28,6 +29,8 @@ def alphafold_get_summary(
         Alias for qualifier. UniProt accession (e.g., 'P04637').
     uniprot_accession : str
         Alias for qualifier. UniProt accession (e.g., 'P04637').
+    accession : str
+        Alias for qualifier. UniProt accession (e.g., 'P04637') -- the...
     stream_callback : Callable, optional
         Callback for streaming output
     use_cache : bool, default False
@@ -48,6 +51,7 @@ def alphafold_get_summary(
             "qualifier": qualifier,
             "uniprot_id": uniprot_id,
             "uniprot_accession": uniprot_accession,
+            "accession": accession,
         }.items()
         if v is not None
     }

--- a/src/tooluniverse/uniprot_tool.py
+++ b/src/tooluniverse/uniprot_tool.py
@@ -1,8 +1,55 @@
+import re
 import time
 import requests
 from typing import Any, Dict, Optional
 from .base_tool import BaseTool, ToolError
 from .tool_registry import register_tool
+
+
+# Common-name / scientific-name shortcuts for the handful of model organisms
+# callers name in prose. Anything not listed here still works -- it is routed
+# to UniProt's organism_name field rather than being rejected.
+_ORGANISM_TAXIDS = {
+    "human": "9606",
+    "homo sapiens": "9606",
+    "mouse": "10090",
+    "mus musculus": "10090",
+    "rat": "10116",
+    "rattus norvegicus": "10116",
+    "yeast": "559292",
+    "saccharomyces cerevisiae": "559292",
+    "zebrafish": "7955",
+    "danio rerio": "7955",
+    "fruitfly": "7227",
+    "drosophila melanogaster": "7227",
+    "c. elegans": "6239",
+    "caenorhabditis elegans": "6239",
+    "arabidopsis": "3702",
+    "arabidopsis thaliana": "3702",
+    "pig": "9823",
+    "sus scrofa": "9823",
+    "cow": "9913",
+    "bos taurus": "9913",
+    "rabbit": "9986",
+    "oryctolagus cuniculus": "9986",
+}
+
+
+def _uniprot_organism_filter(organism: str) -> str:
+    """Build the UniProt query clause for an organism the caller named.
+
+    UniProt's `organism_id` field accepts numeric taxonomy IDs only; passing a
+    species name to it makes the whole search fail with HTTP 400 rather than
+    returning zero hits. Any organism that does not resolve to a taxid is
+    therefore expressed as `organism_name:"..."`, which accepts free text and
+    covers the long tail of species (pathogens, plants, non-model organisms)
+    that no shortcut table can enumerate.
+    """
+    name = str(organism).strip()
+    resolved = _ORGANISM_TAXIDS.get(name.lower(), name)
+    if resolved.isdigit():
+        return f"organism_id:{resolved}"
+    return f'organism_name:"{resolved}"'
 
 
 def _protein_name(protein_desc: Dict[str, Any]) -> str:
@@ -257,45 +304,24 @@ class UniProtRESTTool(BaseTool):
             limit_value = int(limit_value)
         limit = min(limit_value, 500)
 
-        # Normalize query: replace 'organism:' with 'organism_id:'
-        # for UniProt API compatibility
-        query = query.replace("organism:", "organism_id:")
+        # Normalize query: UniProt has no bare 'organism' field. Numeric values
+        # belong in organism_id, everything else in organism_name -- rewriting a
+        # species name into organism_id makes UniProt reject the whole request
+        # with HTTP 400 (confirmed live: 'organism_id:Klebsiella pneumoniae').
+        query = re.sub(
+            r"\borganism:(\"[^\"]+\"|\S+)",
+            lambda m: _uniprot_organism_filter(m.group(1).strip('"')),
+            query,
+        )
 
         # Build query string
         query_parts = [query]
         if organism:
-            # Support common organism names (both common names and scientific names)
-            organism_map = {
-                "human": "9606",
-                "homo sapiens": "9606",
-                "mouse": "10090",
-                "mus musculus": "10090",
-                "rat": "10116",
-                "rattus norvegicus": "10116",
-                "yeast": "559292",
-                "saccharomyces cerevisiae": "559292",
-                "zebrafish": "7955",
-                "danio rerio": "7955",
-                "fruitfly": "7227",
-                "drosophila melanogaster": "7227",
-                "c. elegans": "6239",
-                "caenorhabditis elegans": "6239",
-                "arabidopsis": "3702",
-                "arabidopsis thaliana": "3702",
-                "pig": "9823",
-                "sus scrofa": "9823",
-                "cow": "9913",
-                "bos taurus": "9913",
-                "rabbit": "9986",
-                "oryctolagus cuniculus": "9986",
-            }
-            taxon_id = organism_map.get(organism.lower(), organism)
-
-            # Check if query already includes organism_id filter
-            # to avoid duplication
-            if "organism_id:" not in query.lower():
-                query_parts.append(f"organism_id:{taxon_id}")
-            # If it does, skip adding the organism filter
+            # Skip when the caller already scoped the query themselves, so we
+            # don't AND two conflicting organism clauses together.
+            lowered = query.lower()
+            if "organism_id:" not in lowered and "organism_name:" not in lowered:
+                query_parts.append(_uniprot_organism_filter(organism))
 
         # Auto-convert length parameters to range syntax
         if min_length or max_length:


### PR DESCRIPTION
Round 21 of the role-play test harness. Three researcher personas (clinical immunologist / autoimmune genetics, structural biologist / drug discovery, clinical microbiologist / infectious disease) worked real multi-tool research questions end to end. They reported 15 issues; 5 were discarded as false positives after CLI verification, and the 10 below reproduced.

They share one failure mode: a lookup that had a good answer available returned an **empty-but-successful** result, or an error whose text gave the caller nothing to act on. Zero rows and "this does not exist" are indistinguishable to the caller, so each of these quietly produced a wrong scientific conclusion rather than a visible failure.

## Verified issues and fixes

### 1. `UniProt_search` rejected every non-model organism (HIGH)
`organism` mapped 22 model organisms to taxids and passed anything else straight into `organism_id:`, which accepts numeric IDs only — so pathogens, plants and non-model species failed the **whole search** with HTTP 400. Non-numeric organisms now route to `organism_name:`, which accepts free text; the same rule applies to an `organism:` clause written inside `query`.

```
python -m tooluniverse.cli run UniProt_search '{"query":"gene:KPC-2","organism":"Klebsiella pneumoniae","limit":5}'
```
Before: `400 Client Error ... organism_id%3AKlebsiella+pneumoniae`. After: Q9F663 `BLKPC_KLEPN`, carbapenem-hydrolyzing beta-lactamase KPC-2. `organism:"human"` is unchanged (1887 results, same as before).

### 2. FAERS analytics found zero reports for any brand name
All six operations searched `openfda.generic_name` only, so a brand name looked like a drug with no reports and disproportionality refused to compute.

```
python -m tooluniverse.cli run FAERS_calculate_disproportionality '{"drug_name":"XELJANZ","adverse_event":"Pulmonary embolism"}'
```
Before: `Insufficient data: a=0, b=0, c=94648, d=20598042`. After: ROR 1.254 (95% CI 1.179–1.332), consistent with generic tofacitinib's 1.306 on the same event. Generic-name queries return identical numbers to before.

### 3. `OpenTargets_get_evidence_by_datasource` advertised a retired datasource ID
`ot_genetics_portal` was renamed upstream to `gwas_credible_sets`; the retired name matches nothing rather than erroring, so genetic-association evidence looked absent. The tool's own description still listed the retired name first. Both known retired IDs (`ot_genetics_portal`, `chembl`) are now remapped, the substitution is reported in `metadata.datasource_rename_note`, and the description is corrected.

```
python -m tooluniverse.cli run OpenTargets_get_evidence_by_datasource '{"gene_symbol":"IL23R","disease_name":"Crohn disease","datasourceIds":["ot_genetics_portal"],"size":2}'
```
Before: `evidences.count: 0`. After: 43 rows. Independently confirmed on TP53/cancer (0 → 51).

### 4. `GWAS_search_associations_by_gene` missed hyphenated gene spellings
`mapped_gene` matches the catalog symbol literally, so `IL-23R` returned nothing while 112 associations sit under `IL23R`. The unhyphenated retry fires **only after a miss**, so genuinely hyphenated symbols are untouched, and the response names the spelling that produced the results.

```
python -m tooluniverse.cli run GWAS_search_associations_by_gene '{"gene_name":"IL-23R","size":2}'
```
Before: `association_count: 0`. After: `total_found: 112` plus `gene_name_note` explaining the substitution. `HLA-A` still resolves on the first attempt (107 associations) and is not rewritten.

### 5. `BVBRC_get_taxonomy` turned a species name into a bare 404
`/taxonomy/{id}` is a taxid path lookup, so a name came back as `BV-BRC API HTTP error: 404` with no indication of why. The id is now validated as numeric up front, pointing at `BVBRC_search_taxonomy`, which resolves names.

```
python -m tooluniverse.cli run BVBRC_get_taxonomy '{"taxon_id":"Klebsiella pneumoniae"}'
```
Numeric ids (`573`) are unaffected.

### 6. `EBITaxonomy_get_by_scientific_name` returned empty success for abbreviated genera
ENA indexes full binomials, so the form clinicians write (`K. pneumoniae`) returned `status: success, data: []` — identical to a species genuinely absent from the database. The genus letter cannot be expanded unambiguously (`K.` is Klebsiella, Klebsormidium, Kluyveromyces…), so it is rejected with the expansion rule rather than guessed.

```
python -m tooluniverse.cli run EBITaxonomy_get_by_scientific_name '{"scientific_name":"K. pneumoniae"}'
```
Full binomials are unaffected (taxid 573).

### 7. `BindingDB_get_ligands_by_pdb` dumped a Tomcat HTML error page
The upstream PDB endpoint answers HTTP 500 for **every** structure — verified on 6OIM and 2RH1, with and without the cutoff parameter, while `getLigandsByUniprots` answers 200 and the singular `getLigandsByPDB` is a 404. The tool echoed the first 200 characters of the HTML error page. HTML bodies are now summarised, and a 5xx from this route names the PDB→UniProt path that does work.

```
python -m tooluniverse.cli run BindingDB_get_ligands_by_pdb '{"pdb_ids":"6OIM"}'
```
Before: `<!doctype html><html lang="en"><head><title>HTTP Status 500 …<style type="text/css">body {font-family:Tahoma…`. After: a one-line error naming `PDBeSIFTS_get_pdb_to_uniprot` + `BindingDB_get_ligands_by_uniprot`.

### 8–9. Chained calls rejected the identifier name their own sibling emits
`ChEMBL_get_molecule_targets` refused `chembl_id` (the name `ChEMBL_get_molecule` uses), and the three `alphafold_*` tools refused `accession` (the name the `UniProt_*_by_accession` tools use) — so feeding one call's output into the next failed validation on an id that had just been looked up. The alphafold *code* already accepted `accession`; only its schema did not, so validation rejected it before the handler ran.

```
python -m tooluniverse.cli run ChEMBL_get_molecule_targets '{"chembl_id":"CHEMBL4535757"}'
python -m tooluniverse.cli run alphafold_get_summary '{"accession":"P01116"}'
```
Both previously `Unrecognized parameter(s)`; existing parameter names still work.

### 10. `PubChem_get_compound_properties_by_CID` promised a property name PubChem no longer returns
PUG-REST renamed `CanonicalSMILES` → `ConnectivitySMILES` (and `IsomericSMILES` → `SMILES`). A request for the legacy name returns the value under the *current* key, so a caller reading back the key it asked for found nothing. Description-only change documenting the current names and both renames.

## Discarded as false positives (CLI-verified clean)

- **`ChEMBL_search_targets` "tyrosine kinase 2" surfaces PTK2B, not TYK2** — `pref_name__contains` is a substring filter and "Protein-tyrosine kinase 2-beta" genuinely contains that substring; TYK2's ChEMBL name is "Non-receptor tyrosine-protein kinase TYK2". `pref_name__contains: "TYK2"` returns CHEMBL3553 correctly. The tool honoured its documented semantics.
- **`get_mutation_annotations_by_pdb_id` omits G12C for 6OIM and reports 4 mutations while listing 3** — reproduced, but this is RCSB's own deposited data: `data.rcsb.org/rest/v1/core/polymer_entity/6OIM/1` returns exactly `rcsb_mutation_count: 4` with `pdbx_mutation: "C51S,C80L,C118S"`. The tool relays upstream faithfully.
- **OpenTargets `efoId` field returns MONDO identifiers** — upstream field naming; MONDO ids are accepted directly by the downstream `efoId` tools, as the persona confirmed.
- **Misspelling "Chrohns disease" returns no hits** — genuine zero-hit search, and the existing metadata note already says so clearly.
- **`ClinicalTrials_search_by_intervention` exposes both `status` and `filter_status`** — documented intentional alias.

## Verification

- Full `tests/unit` suite green before and after (exit 0, failures 0; only environment skips for absent rdkit/torch/bcftools/Rscript).
- `tu test` passes for every touched tool, including `EBITaxonomy_get_by_scientific_name`, `alphafold_get_summary` and `GWAS_search_associations_by_gene`.
- Each fix re-run through the CLI with the persona's original arguments, plus an unchanged-behaviour control alongside it (shown above).
- `test_graphql_tool_round26_fixes.py`, which asserts no `metadata.note` is added for non-IntOGen datasource queries, still passes — the new disclosure uses a distinct `datasource_rename_note` key.
- Generated wrappers for the four tools whose schemas changed were hand-edited to match the committed style; the full regenerator was deliberately not run, as its output currently reformats all 2600 wrappers.
- No overlap with open PR #493 (`efo_tool.py`, `openfda_tool.py`) — this branch touches neither. FAERS analytics lives in `faers_analytics_tool.py`, a different module. Diffs of every other open PR were checked for file overlap.
