### PR TITLE
Fix Round 22: lookups that report "no data" when the data is there

### DIFF
--- a/src/tooluniverse/aopwiki_tool.py
+++ b/src/tooluniverse/aopwiki_tool.py
@@ -42,11 +42,23 @@ def _aopwiki_not_found(result: Any) -> bool:
             "List Adverse Outcome Pathways (AOPs) from AOPWiki. Returns AOP IDs, "
             "titles, and short names. AOPs describe causal chains from molecular "
             "initiating events through key events to adverse outcomes, used in "
-            "toxicology and risk assessment."
+            "toxicology and risk assessment. Pass `search` to keep only AOPs whose "
+            "title or short name contains a keyword (e.g. 'thyroid', 'PPAR', "
+            "'steatosis') -- AOPWiki publishes ~600 AOPs, so an unfiltered list is "
+            "rarely what you want. Use AOPWiki_get_aop on a returned ID for its key "
+            "events, stressor chemicals, and causal relationships."
         ),
         "parameter": {
             "type": "object",
-            "properties": {},
+            "properties": {
+                "search": {
+                    "type": "string",
+                    "description": (
+                        "Case-insensitive keyword to filter AOPs by title or short "
+                        "name. Omit to return every AOP."
+                    ),
+                },
+            },
         },
         "settings": {"base_url": _BASE, "timeout": 30},
     },
@@ -85,7 +97,33 @@ class AOPWikiListTool:
         except Exception as e:
             return {"status": "error", "error": f"AOPWiki API error: {e}"}
 
-        return {"status": "success", "data": aops}
+        # AOPWiki's /aops.json has no server-side keyword filter, so filter the
+        # fetched list here rather than making callers pull ~600 AOPs and grep.
+        search = str(arguments.get("search") or "").strip().lower()
+        if not search:
+            return {"status": "success", "data": aops}
+
+        matches = [
+            a
+            for a in aops
+            if search in str(a.get("title") or "").lower()
+            or search in str(a.get("short_name") or "").lower()
+        ]
+        result = {
+            "status": "success",
+            "data": matches,
+            "count": len(matches),
+            "total_aops": len(aops),
+            "search": arguments.get("search"),
+        }
+        if not matches:
+            result["note"] = (
+                f"No AOP title or short name contains '{arguments.get('search')}'. "
+                f"Searched all {len(aops)} AOPs. Try a broader keyword (AOPWiki "
+                "titles use terms like 'thyroid', 'PPAR', 'steatosis', "
+                "'neurotoxicity'), or omit `search` to list every AOP."
+            )
+        return result
 
 
 @register_tool(

--- a/src/tooluniverse/data/aopwiki_tools.json
+++ b/src/tooluniverse/data/aopwiki_tools.json
@@ -2,10 +2,15 @@
   {
     "name": "AOPWiki_list_aops",
     "type": "AOPWikiListTool",
-    "description": "List Adverse Outcome Pathways (AOPs) from AOPWiki. Returns AOP IDs, titles, and short names. AOPs describe causal chains from molecular initiating events through key events to adverse outcomes, used in toxicology and risk assessment.",
+    "description": "List Adverse Outcome Pathways (AOPs) from AOPWiki. Returns AOP IDs, titles, and short names. AOPs describe causal chains from molecular initiating events through key events to adverse outcomes, used in toxicology and risk assessment. Pass `search` to keep only AOPs whose title or short name contains a keyword (e.g. 'thyroid', 'PPAR', 'steatosis') -- AOPWiki publishes ~600 AOPs, so an unfiltered list is rarely what you want. Use AOPWiki_get_aop on a returned ID for its key events, stressor chemicals, and causal relationships.",
     "parameter": {
       "type": "object",
-      "properties": {}
+      "properties": {
+        "search": {
+          "type": "string",
+          "description": "Case-insensitive keyword to filter AOPs by title or short name. Omit to return every AOP."
+        }
+      }
     },
     "return_schema": {
       "type": "array",
@@ -19,7 +24,8 @@
       }
     },
     "test_examples": [
-      {}
+      {},
+      {"search": "thyroid"}
     ],
     "label": ["AOPWiki", "Toxicology", "Adverse Outcome Pathway"],
     "metadata": {

--- a/src/tooluniverse/data/disease_target_score_tools.json
+++ b/src/tooluniverse/data/disease_target_score_tools.json
@@ -11,7 +11,7 @@
         },
         "datasourceId": {
           "type": "string",
-          "description": "The datasource ID to extract scores from. Available options: 'clinical_precedence', 'eva', 'eva_somatic', 'cancer_gene_census', 'cancer_biomarkers', 'europepmc', 'expression_atlas', 'genomics_england', 'impc', 'reactome', 'uniprot_literature', 'uniprot_variants'"
+          "description": "The datasource ID to extract scores from. Available options: 'gwas_credible_sets' (genetic/GWAS association), 'gene_burden', 'clinical_precedence', 'eva', 'eva_somatic', 'cancer_gene_census', 'cancer_biomarkers', 'europepmc', 'expression_atlas', 'genomics_england', 'impc', 'reactome', 'uniprot_literature', 'uniprot_variants'. Two IDs were retired upstream and now match nothing rather than erroring: 'ot_genetics_portal' became 'gwas_credible_sets' and 'chembl' became 'clinical_precedence'; both retired names are remapped automatically and reported in datasource_rename_note."
         },
         "pageSize": {
           "type": "integer",

--- a/src/tooluniverse/data/hpa_tools.json
+++ b/src/tooluniverse/data/hpa_tools.json
@@ -599,7 +599,7 @@
   {
     "type": "HPAGetRnaExpressionByTissueTool",
     "name": "HPA_get_rna_expression_in_specific_tissues",
-    "description": "Query RNA expression levels (nTPM) for a specific gene in one or more user-specified tissues with precise tissue matching. Note: HPA's rna_expression_in_specific_tissues endpoint returns 'No data' for many genes; test_examples removed pending a list of pre-populated ENSG ids.",
+    "description": "Query RNA expression levels (nTPM) for a specific gene in one or more user-specified tissues. Reads HPA's full per-tissue nTPM panel (the 'Tissue RNA - <tissue> [nTPM]' columns), so any of HPA's ~50 published tissues and brain regions can be queried, e.g. 'cerebral cortex', 'basal ganglia', 'midbrain', 'liver'. A tissue reported as 'Not found' means the tissue name is unrecognized by HPA, not that the gene lacks expression there.",
     "fields": {
       "endpoint": "https://www.proteinatlas.org/{ensembl_id}.json",
       "timeout": 30,
@@ -626,7 +626,7 @@
       ]
     },
     "input_description": "Input an Ensembl Gene ID and a list of tissue names. The tool will perform intelligent tissue name matching.",
-    "output_description": "Returns a dictionary mapping queried tissue names to their expression data, including matched tissue name, expression value in nTPM, and categorized expression level (Very high/High/Medium/Low/Very low). Also provides a sample of available tissues for reference.",
+    "output_description": "Returns a dictionary mapping queried tissue names to their expression data, including matched tissue name, expression value in nTPM, and categorized expression level (Very high/High/Medium/Low/Very low), and the HPA column the value came from. Also lists the tissues HPA classifies the gene as enriched in.",
     "test_examples": [
       {
         "ensembl_id": "ENSG00000254647",

--- a/src/tooluniverse/data/metabolights_tools.json
+++ b/src/tooluniverse/data/metabolights_tools.json
@@ -42,7 +42,7 @@
   {
     "type": "MetaboLightsRESTTool",
     "name": "metabolights_search_studies",
-    "description": "List MetaboLights study IDs. NOTE: The MetaboLights API does not support keyword filtering — the query parameter is accepted but has no effect; all public study IDs are returned regardless of query. To find studies on a specific topic, use metabolights_get_study on individual IDs. Returns all public MetaboLights study accessions (MTBLS###).",
+    "description": "Keyword-search MetaboLights studies and return the matching study accessions (MTBLS###). Searches organism, disease, metabolite and free-text study content. MetaboLights' own /ws/studies endpoint ignores keyword queries, so this tool searches through EBI Search, which indexes the same studies. Use metabolights_list_studies to browse all public studies without a keyword, and metabolights_get_study for the full record of a returned accession.",
     "parameter": {
       "type": "object",
       "properties": {

--- a/src/tooluniverse/graphql_tool.py
+++ b/src/tooluniverse/graphql_tool.py
@@ -532,6 +532,18 @@ class OpentargetGeneticsTool(GraphQLTool):
         return super().run(arguments)
 
 
+# Open Targets retires datasource IDs without keeping the old name as a
+# server-side alias -- a stale ID simply matches nothing, so the query comes
+# back as a perfectly successful zero-row result that reads as "no evidence
+# exists". Confirmed live: progressive supranuclear palsy (MONDO_0019037)
+# returns 0 targets for 'ot_genetics_portal' and 23 (MOBP 0.69, MAPT 0.62,
+# STX6 0.57) for 'gwas_credible_sets'.
+_RETIRED_DATASOURCE_IDS = {
+    "ot_genetics_portal": "gwas_credible_sets",
+    "chembl": "clinical_precedence",
+}
+
+
 @register_tool("DiseaseTargetScoreTool")
 class DiseaseTargetScoreTool(GraphQLTool):
     """Tool to extract disease-target association scores from specific data sources"""
@@ -560,7 +572,13 @@ class DiseaseTargetScoreTool(GraphQLTool):
         if not datasource_id:
             return {"status": "error", "error": "datasourceId is required"}
 
+        renamed_from = None
+        if datasource_id in _RETIRED_DATASOURCE_IDS:
+            renamed_from = datasource_id
+            datasource_id = _RETIRED_DATASOURCE_IDS[datasource_id]
+
         results = []
+        seen_datasources = set()
         page_index = 0
         total_fetched = 0
         total_count = None
@@ -610,10 +628,11 @@ class DiseaseTargetScoreTool(GraphQLTool):
             for row in rows:
                 symbol = row["target"]["approvedSymbol"]
                 target_id = row["target"]["id"]
-                score_entry = next(
-                    (ds for ds in row["datasourceScores"] if ds["id"] == datasource_id),
-                    None,
-                )
+                score_entry = None
+                for ds in row["datasourceScores"]:
+                    seen_datasources.add(ds["id"])
+                    if ds["id"] == datasource_id:
+                        score_entry = ds
                 if score_entry:
                     results.append(
                         {
@@ -629,18 +648,51 @@ class DiseaseTargetScoreTool(GraphQLTool):
                 break
             page_index += 1
 
+        # The API returns targets in its own order, so a run cut short by the
+        # time budget used to yield an arbitrary subset in arbitrary order --
+        # "the top expression-atlas targets for this disease" was unobtainable.
+        # Sort by score so the strongest associations are always first.
+        results.sort(key=lambda r: r["score"], reverse=True)
+
         data = {
             "disease_info": disease_info,
             "datasource": datasource_id,
             "total_targets_with_scores": len(results),
             "target_scores": results,
         }
+        if renamed_from:
+            data["datasource_rename_note"] = (
+                f"Retired Open Targets datasource ID '{renamed_from}' remapped to "
+                f"'{datasource_id}'. Use the current name directly to avoid this "
+                "remapping."
+            )
+        if not results and seen_datasources:
+            # Distinguish "this datasource has no scores for this disease" from
+            # "that datasource ID does not exist any more" -- otherwise both look
+            # like an empty success. The available IDs cost nothing: they were
+            # already present in the rows just scanned.
+            data["available_datasources"] = sorted(seen_datasources)
+            data["note"] = (
+                f"No target has a '{datasource_id}' score for this disease among the "
+                f"{total_fetched} associated targets scanned. Datasource IDs actually "
+                "present for this disease are listed in available_datasources."
+            )
         if truncated:
             data["truncated"] = True
-            data["note"] = (
+            truncation_note = (
                 f"Stopped after {_DISEASE_TARGET_SCORE_TIME_BUDGET_S:.0f}s; "
                 f"scanned {total_fetched} of {total_count} associated targets. "
+                "Scores are sorted strongest-first within what was scanned. "
                 "Increase pageSize to scan more targets per request, or query a "
                 "more specific disease."
+            )
+            # Don't drop the "which datasources actually exist" guidance when a
+            # zero-result run also hit the time budget -- that combination is
+            # exactly when the caller most needs to know the ID was wrong.
+            existing_note = data.get("note")
+            data["note"] = (
+                f"{existing_note} {truncation_note}"
+                if existing_note
+                else truncation_note
             )
         return {"status": "success", "data": data}

--- a/src/tooluniverse/hpa_tool.py
+++ b/src/tooluniverse/hpa_tool.py
@@ -1224,19 +1224,35 @@ class HPAGetRnaExpressionByTissueTool(HPAJsonApiTool):
         if "error" in data:
             return data
 
-        # Get RNA tissue expression data
+        # "RNA tissue specific nTPM" is HPA's tissue-*enrichment* summary: it is
+        # populated only with the handful of tissues a gene is classified as
+        # enriched in, not the full ~50-tissue nTPM panel. Reading it alone made
+        # every non-enriched tissue look like missing data -- MAPT/'cerebral
+        # cortex' returned "No data" while HPA holds 147.9 nTPM for it. Query the
+        # per-tissue `t_RNA_<tissue>` columns instead (the same correction
+        # already applied to HPAGetRnaExpressionBySourceTool in Fix-R4A-2) and
+        # keep the enrichment summary only as a fallback.
         rna_data = data.get("RNA tissue specific nTPM", {})
         if not isinstance(rna_data, dict):
-            return {
-                "status": "error",
-                "error": "No RNA tissue expression data available for this gene",
-            }
-
-        expression_results = {}
+            rna_data = {}
         available_tissues = list(rna_data.keys())
 
+        panel = self._fetch_tissue_panel(ensembl_id, tissue_names)
+
+        expression_results = {}
         for tissue in tissue_names:
-            # Case-insensitive matching
+            value = panel.get(tissue)
+            if value is not None:
+                expression_results[tissue] = {
+                    "matched_tissue": tissue,
+                    "expression_value": value,
+                    "expression_level": self._categorize_expression(value),
+                    "source_field": f"Tissue RNA - {tissue} [nTPM]",
+                }
+                continue
+
+            # Fall back to the enrichment summary (case-insensitive substring
+            # match), which is all HPA's JSON record carries.
             found_tissue = None
             for available_tissue in available_tissues:
                 if (
@@ -1253,12 +1269,23 @@ class HPAGetRnaExpressionByTissueTool(HPAJsonApiTool):
                     "expression_level": self._categorize_expression(
                         rna_data[found_tissue]
                     ),
+                    "source_field": "RNA tissue specific nTPM (enrichment summary)",
                 }
             else:
+                # HPA silently drops unknown columns, so an absent column means
+                # the tissue name is not one HPA publishes -- report that as a
+                # naming problem rather than as "this gene is not expressed".
                 expression_results[tissue] = {
                     "matched_tissue": "Not found",
                     "expression_value": "N/A",
                     "expression_level": "No data",
+                    "note": (
+                        f"'{tissue}' did not match an HPA tissue column "
+                        f"(t_RNA_{self._tissue_column_suffix(tissue)}). This means the "
+                        "tissue name is unrecognized, not that the gene lacks "
+                        "expression. Use HPA_get_rna_expression_by_source to list "
+                        "valid source names for source_type='tissue' or 'brain'."
+                    ),
                 }
 
         return {
@@ -1270,13 +1297,54 @@ class HPAGetRnaExpressionByTissueTool(HPAJsonApiTool):
                 "expression_unit": "nTPM (normalized Transcripts Per Million)",
                 "queried_tissues": tissue_names,
                 "tissue_expression": expression_results,
-                "available_tissues_sample": (
-                    available_tissues[:10]
-                    if len(available_tissues) > 10
-                    else available_tissues
-                ),
-                "total_available_tissues": len(available_tissues),
+                "enriched_tissues": available_tissues,
             },
+        }
+
+    @staticmethod
+    def _tissue_column_suffix(tissue: str) -> str:
+        """Convert a human tissue name to HPA's column suffix form."""
+        return re.sub(r"[^a-z0-9]+", "_", str(tissue).strip().lower()).strip("_")
+
+    def _fetch_tissue_panel(
+        self, ensembl_id: str, tissue_names: List[str]
+    ) -> Dict[str, Any]:
+        """Fetch per-tissue nTPM values via HPA's search API `t_RNA_<tissue>` columns.
+
+        HPA drops columns it does not recognize instead of erroring, so a tissue
+        missing from the response is an unknown tissue name. Returns a mapping of
+        the caller's original tissue strings to their nTPM values.
+        """
+        suffixes = {t: self._tissue_column_suffix(t) for t in tissue_names}
+        columns = ",".join(["g", "eg"] + [f"t_RNA_{s}" for s in suffixes.values() if s])
+        params = {
+            "search": ensembl_id,
+            "format": "json",
+            "columns": columns,
+            "compress": "no",
+        }
+        try:
+            resp = requests.get(HPA_SEARCH_API, params=params, timeout=self.timeout)
+            if resp.status_code != 200:
+                return {}
+            rows = resp.json()
+        except (requests.RequestException, ValueError):
+            return {}
+        if not isinstance(rows, list) or not rows or not isinstance(rows[0], dict):
+            return {}
+
+        row = rows[0]
+        # HPA labels the returned columns "Tissue RNA - <tissue> [nTPM]".
+        by_suffix = {}
+        for key, value in row.items():
+            match = re.match(r"^Tissue RNA - (.+?) \[nTPM\]$", key)
+            if match:
+                by_suffix[self._tissue_column_suffix(match.group(1))] = value
+
+        return {
+            tissue: by_suffix[suffix]
+            for tissue, suffix in suffixes.items()
+            if by_suffix.get(suffix) not in (None, "")
         }
 
     def _categorize_expression(self, expr_value) -> str:

--- a/src/tooluniverse/metabolights_tool.py
+++ b/src/tooluniverse/metabolights_tool.py
@@ -10,6 +10,10 @@ from typing import Any, Dict
 from .base_tool import BaseTool
 from .tool_registry import register_tool
 
+# MetaboLights' own /ws/studies endpoint ignores keyword queries; EBI Search
+# indexes the same studies and honours them.
+EBI_SEARCH_URL = "https://www.ebi.ac.uk/ebisearch/ws/rest/metabolights"
+
 
 @register_tool("MetaboLightsRESTTool")
 class MetaboLightsRESTTool(BaseTool):
@@ -55,9 +59,6 @@ class MetaboLightsRESTTool(BaseTool):
             if study_id:
                 return f"{self.base_url}/studies/{study_id}"
 
-        elif tool_name == "metabolights_search_studies":
-            return f"{self.base_url}/studies"
-
         elif tool_name == "metabolights_get_study_assays":
             study_id = args.get("study_id", "")
             if study_id:
@@ -80,15 +81,7 @@ class MetaboLightsRESTTool(BaseTool):
         params = {}
         tool_name = self.tool_config.get("name", "")
 
-        if tool_name == "metabolights_search_studies":
-            if "query" in args:
-                params["query"] = args["query"]
-            if "size" in args:
-                params["size"] = args["size"]
-            if "page" in args:
-                params["page"] = args["page"]
-
-        elif tool_name == "metabolights_list_studies":
+        if tool_name == "metabolights_list_studies":
             if "size" in args:
                 params["size"] = args["size"]
             if "page" in args:
@@ -214,9 +207,71 @@ class MetaboLightsRESTTool(BaseTool):
                 "error": f"Failed to extract files from study endpoint: {str(e)}",
             }
 
+    def _search_via_ebi_search(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        """Keyword-search MetaboLights studies through EBI Search.
+
+        MetaboLights' own /ws/studies endpoint accepts a `query` parameter and
+        silently ignores it, so every search returned the same first N study
+        accessions by ID with status "success" -- a wrong answer that looked
+        like a right one. EBI Search indexes the same MetaboLights studies and
+        does honour the query (confirmed live: "acylcarnitine" -> 113 hits).
+        """
+        query = str(arguments.get("query", "")).strip()
+        size = arguments.get("size", 20)
+        page = arguments.get("page", 0)
+        params = {
+            "query": query,
+            "format": "json",
+            "size": size,
+            "start": int(page) * int(size),
+        }
+        # EBI Search's first response for an uncached query regularly exceeds
+        # 30s while warm repeats return in ~1s, so retry once before failing.
+        try:
+            response = self.session.get(
+                EBI_SEARCH_URL, params=params, timeout=self.timeout
+            )
+        except requests.exceptions.Timeout:
+            response = self.session.get(
+                EBI_SEARCH_URL, params=params, timeout=self.timeout * 2
+            )
+        response.raise_for_status()
+        payload = response.json()
+        entries = payload.get("entries", []) or []
+        result = {
+            "status": "success",
+            "data": [e.get("id") for e in entries if e.get("id")],
+            "url": response.url,
+            "count": len(entries),
+            "total_hits": payload.get("hitCount", 0),
+        }
+        if not entries:
+            suggested = payload.get("suggestedQuery")
+            result["note"] = (
+                f"No MetaboLights study matched '{query}'."
+                + (f" Did you mean '{suggested}'?" if suggested else "")
+                + " Use metabolights_list_studies to browse all public studies."
+            )
+        return result
+
     def run(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Execute the MetaboLights API call"""
         tool_name = self.tool_config.get("name", "")
+
+        if tool_name == "metabolights_search_studies":
+            if not str(arguments.get("query", "")).strip():
+                return {
+                    "status": "error",
+                    "error": "query is required. To browse all public studies without "
+                    "a keyword, use metabolights_list_studies.",
+                }
+            try:
+                return self._search_via_ebi_search(arguments)
+            except (requests.RequestException, ValueError) as e:
+                return {
+                    "status": "error",
+                    "error": f"MetaboLights search via EBI Search failed: {str(e)}",
+                }
 
         if tool_name == "metabolights_get_reference_compound":
             if (
@@ -353,11 +408,8 @@ class MetaboLightsRESTTool(BaseTool):
                 extracted_data = data
                 count = len(data)
 
-            # Apply client-side pagination for list/search (API ignores size/page params)
-            if tool_name in (
-                "metabolights_list_studies",
-                "metabolights_search_studies",
-            ):
+            # Apply client-side pagination for the study list (API ignores size/page)
+            if tool_name == "metabolights_list_studies":
                 size = arguments.get("size", 20)
                 page = arguments.get("page", 0)
                 if isinstance(extracted_data, list):

--- a/src/tooluniverse/metabolomics_workbench_tool.py
+++ b/src/tooluniverse/metabolomics_workbench_tool.py
@@ -10,7 +10,7 @@ API Documentation: https://www.metabolomicsworkbench.org/tools/mw_rest.php
 """
 
 import requests
-from typing import Dict, Any
+from typing import Any, Dict, Optional
 from urllib.parse import quote
 from .base_tool import BaseTool
 from .tool_registry import register_tool
@@ -270,7 +270,49 @@ class MetabolomicsWorkbenchTool(BaseTool):
         output_item = arguments.get("output_item", "all")
         if not input_value:
             return {"status": "error", "error": "input_value parameter is required"}
-        return self._make_request(f"refmet/{input_item}/{input_value}/{output_item}")
+        result = self._make_request(f"refmet/{input_item}/{input_value}/{output_item}")
+
+        # `refmet/name/` is exact-match only, so standard clinical/HMDB names
+        # ("Octanoylcarnitine") return an empty success even though RefMet knows
+        # the compound under its own shorthand ("CAR 8:0"). RefMet's separate
+        # `refmet/match/` endpoint resolves synonyms -- use it to recover the
+        # canonical name, then re-run the original query with it.
+        if input_item == "name" and not result.get("data"):
+            canonical = self._resolve_refmet_name(input_value)
+            if canonical and canonical.lower() != str(input_value).lower():
+                retried = self._make_request(
+                    f"refmet/{input_item}/{canonical}/{output_item}"
+                )
+                if retried.get("data"):
+                    retried["name_resolution_note"] = (
+                        f"'{input_value}' is not a RefMet name; resolved to the "
+                        f"canonical RefMet name '{canonical}' via RefMet's synonym "
+                        "match endpoint."
+                    )
+                    return retried
+        return result
+
+    def _resolve_refmet_name(self, name: str) -> Optional[str]:
+        """Resolve a metabolite synonym to its canonical RefMet name.
+
+        Returns None when RefMet has no match -- the endpoint signals that with
+        a record whose every field is the literal string "-", not with an error.
+        """
+        try:
+            response = requests.get(
+                f"{MWBENCH_BASE_URL}/refmet/match/{quote(str(name), safe='')}/name/json",
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            payload = response.json()
+        except (requests.RequestException, ValueError):
+            return None
+        if isinstance(payload, list):
+            payload = payload[0] if payload else None
+        if not isinstance(payload, dict):
+            return None
+        refmet_name = str(payload.get("refmet_name", "")).strip()
+        return None if refmet_name in ("", "-") else refmet_name
 
     def _search_moverz(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Search by m/z value. Requires database as first URL path segment."""

--- a/src/tooluniverse/openalex_tool.py
+++ b/src/tooluniverse/openalex_tool.py
@@ -3,7 +3,10 @@ import requests
 from typing import Any, Dict, Optional
 from .base_tool import BaseTool
 from .http_utils import request_with_retry
+from .logging_config import get_logger
 from .tool_registry import register_tool
+
+logger = get_logger("OpenAlexTool")
 
 
 def _with_api_key(params):
@@ -149,8 +152,8 @@ class OpenAlexTool(BaseTool):
                     # Skip papers with missing data rather than failing completely
                     continue
 
-            print(
-                f"[OpenAlex] Retrieved {len(papers)} papers for keywords: '{search_keywords}'"
+            logger.info(
+                "Retrieved %d papers for keywords: '%s'", len(papers), search_keywords
             )
             return papers
 
@@ -289,7 +292,7 @@ class OpenAlexTool(BaseTool):
             return self._extract_paper_info(work)
 
         except requests.exceptions.RequestException as e:
-            print(f"Error retrieving paper by DOI {doi}: {e}")
+            logger.warning("Error retrieving paper by DOI %s: %s", doi, e)
             return None
 
     def get_papers_by_author(self, author_name, max_results=10):
@@ -320,9 +323,7 @@ class OpenAlexTool(BaseTool):
                 paper_info = self._extract_paper_info(work)
                 papers.append(paper_info)
 
-            print(
-                f"[OpenAlex] Retrieved {len(papers)} papers by author: '{author_name}'"
-            )
+            logger.info("Retrieved %d papers by author: '%s'", len(papers), author_name)
             return papers
 
         except requests.exceptions.RequestException as e:

--- a/src/tooluniverse/tools/AOPWiki_list_aops.py
+++ b/src/tooluniverse/tools/AOPWiki_list_aops.py
@@ -9,6 +9,7 @@ from ._shared_client import get_shared_client
 
 
 def AOPWiki_list_aops(
+    search: Optional[str] = None,
     *,
     stream_callback: Optional[Callable[[str], None]] = None,
     use_cache: bool = False,
@@ -19,7 +20,8 @@ def AOPWiki_list_aops(
 
     Parameters
     ----------
-    No parameters
+    search : str, optional
+        Case-insensitive keyword to filter AOPs by title or short name. Omit t...
     stream_callback : Callable, optional
         Callback for streaming output
     use_cache : bool, default False
@@ -34,7 +36,7 @@ def AOPWiki_list_aops(
     # Handle mutable defaults to avoid B006 linting error
 
     # Strip None values so optional parameters don't trigger schema validation errors
-    _args = {k: v for k, v in {}.items() if v is not None}
+    _args = {k: v for k, v in {"search": search}.items() if v is not None}
     return get_shared_client().run_one_function(
         {
             "name": "AOPWiki_list_aops",

--- a/tests/unit/test_disease_target_score_pagination.py
+++ b/tests/unit/test_disease_target_score_pagination.py
@@ -5,6 +5,7 @@ paginates client-side over all of them; without a wall-clock bound the
 loop issues hundreds of sequential requests and can run for minutes.
 These tests pin the time-budget guard without touching the live API.
 """
+
 from unittest.mock import patch
 
 import pytest
@@ -20,12 +21,12 @@ def make_tool():
             "type": "DiseaseTargetScoreTool",
             "query_schema": "query { disease { id } }",
             "parameter": {"type": "object", "properties": {}},
-            "datasource_id": "chembl",
+            "datasource_id": "clinical_precedence",
         }
     )
 
 
-def _page(index, page_size, total, datasource="chembl"):
+def _page(index, page_size, total, datasource="clinical_precedence"):
     """Build one associatedTargets page that always reports a huge total."""
     rows = [
         {
@@ -61,7 +62,11 @@ def test_pagination_stops_at_time_budget(monkeypatch):
 
     with patch.object(gqt, "execute_query", side_effect=fake_execute):
         result = make_tool().run(
-            {"efoId": "EFO_0000339", "datasourceId": "chembl", "pageSize": 5}
+            {
+                "efoId": "EFO_0000339",
+                "datasourceId": "clinical_precedence",
+                "pageSize": 5,
+            }
         )
 
     assert result["status"] == "success"
@@ -82,7 +87,11 @@ def test_pagination_completes_without_truncation(monkeypatch):
 
     with patch.object(gqt, "execute_query", side_effect=fake_execute):
         result = make_tool().run(
-            {"efoId": "EFO_0000339", "datasourceId": "chembl", "pageSize": 5}
+            {
+                "efoId": "EFO_0000339",
+                "datasourceId": "clinical_precedence",
+                "pageSize": 5,
+            }
         )
 
     assert result["status"] == "success"
@@ -107,7 +116,90 @@ def test_omitted_page_size_falls_back_to_100(monkeypatch):
         return _page(variables["index"], variables["size"], total=variables["size"])
 
     with patch.object(gqt, "execute_query", side_effect=fake_execute):
-        result = make_tool().run({"efoId": "EFO_0000339", "datasourceId": "chembl"})
+        result = make_tool().run(
+            {"efoId": "EFO_0000339", "datasourceId": "clinical_precedence"}
+        )
 
     assert result["status"] == "success"
     assert captured["size"] == 100
+
+
+@pytest.mark.unit
+def test_retired_datasource_id_is_remapped(monkeypatch):
+    """A retired datasource ID must not silently return zero scores.
+
+    Open Targets renamed 'ot_genetics_portal' to 'gwas_credible_sets' without
+    keeping the old name as an alias, so the stale ID matched nothing and the
+    tool returned a successful empty result that read as "no genetic evidence".
+    """
+    monkeypatch.setattr(gqt.time, "monotonic", lambda: 0.0)
+
+    def fake_execute(endpoint, query, variables):
+        return _page(
+            variables["index"],
+            variables["size"],
+            total=variables["size"],
+            datasource="gwas_credible_sets",
+        )
+
+    with patch.object(gqt, "execute_query", side_effect=fake_execute):
+        result = make_tool().run(
+            {
+                "efoId": "EFO_0000339",
+                "datasourceId": "ot_genetics_portal",
+                "pageSize": 5,
+            }
+        )
+
+    assert result["status"] == "success"
+    assert result["data"]["datasource"] == "gwas_credible_sets"
+    assert result["data"]["total_targets_with_scores"] == 5
+    assert "ot_genetics_portal" in result["data"]["datasource_rename_note"]
+
+
+@pytest.mark.unit
+def test_scores_are_sorted_strongest_first(monkeypatch):
+    """Truncated runs must still surface the strongest associations first."""
+    monkeypatch.setattr(gqt.time, "monotonic", lambda: 0.0)
+
+    def fake_execute(endpoint, query, variables):
+        page = _page(variables["index"], variables["size"], total=variables["size"])
+        rows = page["data"]["disease"]["associatedTargets"]["rows"]
+        for i, row in enumerate(rows):
+            row["datasourceScores"][0]["score"] = i / 10.0
+        return page
+
+    with patch.object(gqt, "execute_query", side_effect=fake_execute):
+        result = make_tool().run(
+            {
+                "efoId": "EFO_0000339",
+                "datasourceId": "clinical_precedence",
+                "pageSize": 5,
+            }
+        )
+
+    scores = [r["score"] for r in result["data"]["target_scores"]]
+    assert scores == sorted(scores, reverse=True)
+
+
+@pytest.mark.unit
+def test_unknown_datasource_reports_available_ids(monkeypatch):
+    """An empty result must say which datasource IDs the disease actually has."""
+    monkeypatch.setattr(gqt.time, "monotonic", lambda: 0.0)
+
+    def fake_execute(endpoint, query, variables):
+        return _page(
+            variables["index"],
+            variables["size"],
+            total=variables["size"],
+            datasource="europepmc",
+        )
+
+    with patch.object(gqt, "execute_query", side_effect=fake_execute):
+        result = make_tool().run(
+            {"efoId": "EFO_0000339", "datasourceId": "not_a_source", "pageSize": 5}
+        )
+
+    assert result["status"] == "success"
+    assert result["data"]["total_targets_with_scores"] == 0
+    assert result["data"]["available_datasources"] == ["europepmc"]


### PR DESCRIPTION
Round 22 of the role-play test harness. Three researcher personas (computational neuroscience / tauopathies, environmental toxicology / PFAS, clinical biochemical genetics / metabolomics) worked real research questions end-to-end; every reported issue was re-run through `tu run` before being queued, and most were discarded.

The theme of what survived verification: **a tool answers a well-formed question with a successful-looking empty or wrong result.** That reads to the caller as "this evidence does not exist" rather than "you asked the wrong way" — it ends the investigation instead of correcting it.

## Verified fixes

### 1. `HPA_get_rna_expression_in_specific_tissues` reported "No data" for tissues HPA does publish

Read HPA's tissue-*enrichment* summary (`RNA tissue specific nTPM`), which contains only the few tissues a gene is classified as enriched in — not the ~50-tissue panel. Every other tissue came back as `expression_level: "No data"`.

```
tu run HPA_get_rna_expression_in_specific_tissues '{"ensembl_id":"ENSG00000186868","tissue_names":["cerebral cortex","cerebellum","liver"]}'
```
- Before: `cerebral cortex -> matched_tissue "Not found", expression_level "No data"`, while HPA holds 147.9 nTPM for it (the sibling `HPA_get_rna_expression_by_source` returns it). `available_tissues_sample` listed only `["brain","skeletal muscle"]`.
- After: `cerebral cortex 147.9 (Very high)`, `cerebellum 139.1`, `liver 0.6`, each with the `source_field` it came from.

Same change also fixes a hard failure: `{"ensembl_id":"ENSG00000135823","tissue_names":["cerebral cortex","basal ganglia","midbrain","cerebellum"]}` (STX6, a PSP GWAS locus) previously errored with `"No RNA tissue expression data available for this gene"`; it now returns all four brain regions.

Now queries the per-tissue `t_RNA_<tissue>` columns — the same correction already applied to the sibling `HPAGetRnaExpressionBySourceTool` in Fix-R4A-2. An unmatched tissue now says the *name* was unrecognized rather than implying the gene is not expressed.

### 2. `disease_target_score` returned zero targets for a retired Open Targets datasource ID

Open Targets renamed `ot_genetics_portal` to `gwas_credible_sets` without keeping an alias, so the stale ID matched nothing and produced a successful empty result.

```
tu run disease_target_score '{"efoId":"MONDO_0019037","datasourceId":"ot_genetics_portal","pageSize":100}'
```
- Before: `total_targets_with_scores: 0`, empty `target_scores` — reading as "PSP has no genetic evidence".
- After: 23 targets, `datasource: "gwas_credible_sets"`, strongest first (MOBP 0.69, MAPT 0.62, STX6 0.57), plus a `datasource_rename_note` disclosing the substitution.

Three related changes to the same tool (and its nine datasource variants):
- The retired `chembl` -> `clinical_precedence` rename is handled the same way (already documented as confirmed-live in `opentarget_tools.json`).
- **Results are now sorted by score, strongest first.** The tool paginates under a 25s wall-clock budget, so a truncated run previously returned an arbitrary unordered subset — `tu run expression_atlas_disease_target_score '{"efoId":"MONDO_0019037","pageSize":15}'` returned 124 rows in API order with the top scorer buried; it now returns them sorted, so "the strongest targets" is actually obtainable.
- When a result is genuinely empty, the response now lists the datasource IDs the disease *does* have. Those IDs were already in the rows just scanned, so it costs nothing. `tu run disease_target_score '{"efoId":"MONDO_0019037","datasourceId":"not_a_real_source","pageSize":100}'` now returns `available_datasources: [clinical_precedence, europepmc, eva, expression_atlas, genomics_england, gwas_credible_sets, impc, uniprot_literature, uniprot_variants]` instead of a bare empty success.

### 3. RefMet name lookups failed on standard clinical metabolite names

`refmet/name/` is exact-match only, so names used in every clinical and HMDB context returned empty even when RefMet knows the compound under its own shorthand.

```
tu run MetabolomicsWorkbench_search_compound_by_name '{"input_value":"Octanoylcarnitine"}'
```
- Before: `{"status":"success","data":[],"message":"No results found. RefMet requires exact metabolite names..."}` — for the primary biomarker of MCAD deficiency.
- After: the full `CAR 8:0` record (CID 11953814, `RM0154093`, exact mass 287.209659) plus a `name_resolution_note` disclosing the resolution.

Falls back to RefMet's own `refmet/match/` synonym endpoint. Class-level terms still return the existing guidance message (`{"input_value":"ceramide"}` is unchanged), and the resolution is reported rather than applied silently.

### 4. `metabolights_search_studies` ignored its own query

The MetaboLights API accepts a `query` parameter and silently discards it, so every search returned the same first N accessions by ID.

```
tu run metabolights_search_studies '{"query":"acylcarnitine","size":5}'
```
- Before: `["MTBLS1","MTBLS2","MTBLS3",...]` — the numerically-first studies, identical for every query, with `status: "success"`.
- After: `["MTBLS12655","MTBLS14407","MTBLS13382","MTBLS13730","MTBLS10509"]`, `total_hits: 113`.

Routed through EBI Search, which indexes the same studies and honours the query. A no-hit search now says so and surfaces EBI's spelling suggestion. The tool's description previously documented the broken behaviour instead of fixing it; the now-dead pass-through paths in `_build_url`/`_build_params` and the client-side pagination branch were removed.

### 5. `AOPWiki_list_aops` had no way to search

The tool took no parameters and returned all ~600 AOPs, so finding the pathways for a chemical or endpoint meant pulling the whole list and grepping client-side.

```
tu run AOPWiki_list_aops '{"search":"thyroid"}'
```
- Before: no `search` parameter existed; the call returned every AOP.
- After: 20 thyroid AOPs including the two that matter for PFAS — 152 (transthyretin interference) and 8 (hepatic nuclear receptor induced TH catabolism).

Added to both `aopwiki_tool.py` and `data/aopwiki_tools.json` — the loader reads the JSON, so updating only the decorator config would have left the parameter undiscoverable in `tu info` even though it worked at runtime.

### 6. `openalex_literature_search` wrote non-JSON to stdout

A bare `print()` on the success path emitted `[OpenAlex] Retrieved N papers for keywords: '...'` ahead of the JSON, breaking `json.loads` for any programmatic consumer. No sibling literature tool does this. Routed to the module logger, along with two other stray prints in the same file.

## Test changes

`tests/unit/test_disease_target_score_pagination.py` used `chembl` as its fixture datasource — an ID retired upstream in favour of `clinical_precedence`, which the new remap correctly rewrites, so the fixture matched nothing. Moved to the current ID (the rename is already documented as confirmed-live in `opentarget_tools.json`) and added regression tests for the remap, the sort order, and the available-datasources hint.

## Verification

- `tu test` passes on every changed tool: `HPA_get_rna_expression_in_specific_tissues`, `disease_target_score`, `expression_atlas_disease_target_score`, `MetabolomicsWorkbench_search_compound_by_name`, `MetabolomicsWorkbench_get_refmet_info`, `metabolights_search_studies`, `metabolights_list_studies`, `AOPWiki_list_aops`, `AOPWiki_get_aop`, `openalex_literature_search` (15/15 examples).
- 213 targeted unit + integration tests covering every changed module pass.
- `ruff check` under the project config: clean. `ruff format --check`: no changed line is misformatted.
