### PR TITLE
Fix Round 23: results that look complete but silently are not

### DIFF
--- a/src/tooluniverse/ctg_tool.py
+++ b/src/tooluniverse/ctg_tool.py
@@ -24,7 +24,7 @@ def _phrase_quote_if_plain(value: str) -> str:
     return value
 
 
-def _restrict_to_area(value: str, area: str) -> str:
+def _restrict_to_area(value: str, areas: tuple) -> str:
     """Fix-R13B-1: CTG API v2's Essie search engine treats a bare
     query.intr/query.spons value as a match against the whole study
     record (brief summaries, arm descriptions, eligibility text, etc.)
@@ -40,10 +40,77 @@ def _restrict_to_area(value: str, area: str) -> str:
     phrase-quoting multi-word values, same as _phrase_quote_if_plain)
     fixes this -- but only for a plain value with no existing Essie
     syntax, since advanced users may already supply their own
-    AREA/boolean operators."""
+    AREA/boolean operators.
+
+    Fix-R23-1: restricting an intervention query to AREA[InterventionName]
+    *alone* went too far the other way. Registrants record brand names in
+    the separate InterventionOtherName (synonym) field, so a brand-name
+    query all but vanished while its generic returned a full set --
+    confirmed live: 'Eliquis' + atrial fibrillation matched 5 trials on
+    InterventionName vs. 43 once other-names are included, and 'Opdualag'
+    + melanoma went 2 -> 19. Searching both name fields recovers those
+    without reopening R13B-1's hole, since the noise it removed came from
+    description/arm-label text that neither name field contains (checked
+    against the unrestricted counts: vedolizumab 134 -> 142 vs. 215
+    unrestricted, apixaban 96 -> 108 vs. 189)."""
     if _ESSIE_OPERATOR_RE.search(value):
         return value
-    return f"AREA[{area}]{_phrase_quote_if_plain(value)}"
+    quoted = _phrase_quote_if_plain(value)
+    clauses = [f"AREA[{area}]{quoted}" for area in areas]
+    if len(clauses) == 1:
+        return clauses[0]
+    return "(" + " OR ".join(clauses) + ")"
+
+
+# Fix-R23-2: CTG API v2 rejects anything but its exact upper-snake enum
+# spellings, and it does so with a bare HTTP 400 whose remediation reads
+# "Retry the request / Check service status / Report issue if persistent" --
+# advice that is actively wrong when the caller simply typed
+# filter_status='recruiting' or filter_phase='Phase 3'. Both are the natural
+# spellings (and 'Phase 3' is how ClinicalTrials.gov renders it on screen), so
+# normalize them here and reject anything genuinely unknown at input with the
+# legal values named, rather than letting a user-input error come back dressed
+# as a service outage.
+_CTG_STATUS_VALUES = (
+    "ACTIVE_NOT_RECRUITING",
+    "APPROVED_FOR_MARKETING",
+    "AVAILABLE",
+    "COMPLETED",
+    "ENROLLING_BY_INVITATION",
+    "NO_LONGER_AVAILABLE",
+    "NOT_YET_RECRUITING",
+    "RECRUITING",
+    "SUSPENDED",
+    "TEMPORARILY_NOT_AVAILABLE",
+    "TERMINATED",
+    "UNKNOWN",
+    "WITHDRAWN",
+    "WITHHELD",
+)
+
+_CTG_PHASE_VALUES = (
+    "EARLY_PHASE1",
+    "NA",
+    "PHASE1",
+    "PHASE2",
+    "PHASE3",
+    "PHASE4",
+)
+
+
+def _canonicalize_enum(value: str, allowed: tuple):
+    """Map a loosely-spelled enum value onto its exact CTG spelling.
+
+    Comparison ignores case and every non-alphanumeric separator, so
+    'recruiting', 'Active, not recruiting' and 'Phase 3' all resolve.
+    Returns None when the value matches nothing, so the caller can raise a
+    validation error naming the legal set.
+    """
+
+    def _key(v):
+        return "".join(ch for ch in str(v).upper() if ch.isalnum())
+
+    return {_key(a): a for a in allowed}.get(_key(value))
 
 
 @register_tool("ClinicalTrialsTool")
@@ -185,8 +252,10 @@ class ClinicalTrialsTool(RESTfulTool):
     # Essie fields that get restricted via AREA[<name>] rather than a plain
     # value match (see _restrict_to_area). Keyed by the mapped API param name.
     _AREA_RESTRICTED_FIELDS = {
-        "query.intr": "InterventionName",
-        "query.spons": "LeadSponsorName",
+        # InterventionOtherName holds registrant-supplied synonyms, which is
+        # where brand names live (see Fix-R23-1 in _restrict_to_area).
+        "query.intr": ("InterventionName", "InterventionOtherName"),
+        "query.spons": ("LeadSponsorName",),
     }
 
     def _run_search(self, arguments):
@@ -224,7 +293,24 @@ class ClinicalTrialsTool(RESTfulTool):
                 continue
             if key == "filter_phase":
                 # CTG API v2 uses filter.advanced for phase, not filter.phase
-                phases = [p.strip() for p in value.split(",")]
+                phases = []
+                for raw in str(value).split(","):
+                    raw = raw.strip()
+                    if not raw:
+                        continue
+                    canonical = _canonicalize_enum(raw, _CTG_PHASE_VALUES)
+                    if canonical is None:
+                        return {
+                            "status": "error",
+                            "error": (
+                                f"Invalid filter_phase value '{raw}'. "
+                                f"Valid values are: {', '.join(_CTG_PHASE_VALUES)}. "
+                                "Comma-separate to combine (e.g. 'PHASE2,PHASE3')."
+                            ),
+                        }
+                    phases.append(canonical)
+                if not phases:
+                    continue
                 phase_clause = " OR ".join(f"AREA[Phase]{p}" for p in phases)
                 if len(phases) > 1:
                     phase_clause = f"({phase_clause})"
@@ -240,7 +326,30 @@ class ClinicalTrialsTool(RESTfulTool):
                 advanced_clauses.append(study_type_clause)
             elif key in _SEARCH_PARAM_MAP:
                 mapped_key = _SEARCH_PARAM_MAP[key]
-                if mapped_key == "query.cond" and isinstance(value, str):
+                if mapped_key == "filter.overallStatus":
+                    statuses = []
+                    raw_values = (
+                        value if isinstance(value, list) else str(value).split(",")
+                    )
+                    for raw in raw_values:
+                        raw = str(raw).strip()
+                        if not raw:
+                            continue
+                        canonical = _canonicalize_enum(raw, _CTG_STATUS_VALUES)
+                        if canonical is None:
+                            return {
+                                "status": "error",
+                                "error": (
+                                    f"Invalid status value '{raw}'. Valid values "
+                                    f"are: {', '.join(_CTG_STATUS_VALUES)}. "
+                                    "Comma-separate to combine."
+                                ),
+                            }
+                        statuses.append(canonical)
+                    if not statuses:
+                        continue
+                    value = ",".join(statuses)
+                elif mapped_key == "query.cond" and isinstance(value, str):
                     value = _phrase_quote_if_plain(value)
                 elif mapped_key in self._AREA_RESTRICTED_FIELDS and isinstance(
                     value, str
@@ -260,6 +369,20 @@ class ClinicalTrialsTool(RESTfulTool):
         studies = []
         for s in data.get("studies", []):
             proto = s.get("protocolSection", {})
+            # Fix-R23-3: the intervention list is capped at 5 for brevity, but
+            # it used to be sliced with no count and no flag -- so a study that
+            # genuinely matched the queried drug could come back listing five
+            # *other* interventions and read as a false positive (e.g.
+            # NCT03337698 is a real tiragolumab trial with 18 interventions,
+            # none of which survived the slice). Report the true count so a
+            # short list can be told apart from a truncated one.
+            all_interventions = [
+                iv.get("name")
+                for iv in proto.get("armsInterventionsModule", {}).get(
+                    "interventions", []
+                )
+                if iv.get("name")
+            ]
             studies.append(
                 {
                     "nct_id": proto.get("identificationModule", {}).get("nctId"),
@@ -275,13 +398,9 @@ class ClinicalTrialsTool(RESTfulTool):
                     "conditions": proto.get("conditionsModule", {}).get(
                         "conditions", []
                     ),
-                    "interventions": [
-                        iv.get("name")
-                        for iv in proto.get("armsInterventionsModule", {}).get(
-                            "interventions", []
-                        )
-                        if iv.get("name")
-                    ][:5],
+                    "interventions": all_interventions[:5],
+                    "intervention_count": len(all_interventions),
+                    "interventions_truncated": len(all_interventions) > 5,
                     "sponsor": (
                         proto.get("sponsorCollaboratorsModule", {}).get("leadSponsor")
                         or {}
@@ -588,6 +707,18 @@ class ClinicalTrialsSearchTool(ClinicalTrialsTool):
             "consider searching https://clinicaltrials.gov/ directly for "
             "NA-phase/observational studies."
         )
+        # Fix-R23-5: this note used to be attached only when the filter
+        # produced zero results, so a caller who got a healthy-looking list
+        # never learned that phase-1 and observational studies had been
+        # dropped from it -- exactly the studies a landscape scan must not
+        # miss. A non-empty result is just as filtered as an empty one, so
+        # disclose the filter whenever it was applied.
+        nonempty_phase_filter_note = (
+            "Results exclude phase-1-only, phase-NA, and observational studies "
+            "(this tool filters to phase 2/3/4 by default), so this is not the "
+            "complete set of matching trials on ClinicalTrials.gov. Use "
+            "ClinicalTrials_search_studies for an unfiltered search."
+        )
 
         # Fix-Round3-002: a well-formed query that legitimately matches zero
         # trials (empty `studies` list) is a success, not the error below --
@@ -597,8 +728,12 @@ class ClinicalTrialsSearchTool(ClinicalTrialsTool):
         # _simplify_output handles an empty list fine on its own.
         if response is not None and response and "studies" in response.keys():
             metadata = {"source": "ClinicalTrials.gov API v2"}
-            if phase_filter_applied and not response.get("studies"):
-                metadata["note"] = phase_filter_note
+            if phase_filter_applied:
+                metadata["note"] = (
+                    phase_filter_note
+                    if not response.get("studies")
+                    else nonempty_phase_filter_note
+                )
             return {
                 "status": "success",
                 "data": self._simplify_output(response),
@@ -846,6 +981,15 @@ class ClinicalTrialsDetailsTool(ClinicalTrialsTool):
         formatted_endpoint_url = self.endpoint_url
 
         responses = []
+        # Fix-R23-4: execute_RESTful_query returns a falsy value for every kind
+        # of failure -- HTTP error, timeout, undecodable JSON -- and each of
+        # those was dropped here without a trace. A transient upstream blip
+        # therefore surfaced as either a short result set (some IDs silently
+        # missing) or the "No relevant information found" message below, which
+        # reads as "this trial has no eligibility criteria" for a trial that
+        # demonstrably has them. Fetch failures and genuinely-absent data are
+        # different answers and must not share a response.
+        failed_ids = []
         for nct_id in nct_ids_list:
             formatted_endpoint_url = self._format_endpoint_url({"nctId": nct_id})
             response = execute_RESTful_query(
@@ -853,6 +997,8 @@ class ClinicalTrialsDetailsTool(ClinicalTrialsTool):
             )
             if response:
                 responses.append(response)
+            else:
+                failed_ids.append(nct_id)
 
         if query_type not in {"outcome", "safety"}:
             responses = [
@@ -880,12 +1026,36 @@ class ClinicalTrialsDetailsTool(ClinicalTrialsTool):
         # failure signal; a request that fetched real trials but simply
         # found no matching field data for them is a legitimate success.
         if not responses:
+            if failed_ids:
+                return {
+                    "status": "error",
+                    "error": (
+                        "Could not retrieve any of the requested studies from "
+                        f"ClinicalTrials.gov: {', '.join(failed_ids)}. This is a "
+                        "fetch failure (network error, timeout, or an "
+                        "unparseable API response), not a statement that these "
+                        "trials lack the requested data. Verify the NCT IDs and "
+                        "retry."
+                    ),
+                }
             return {
                 "status": "error",
                 "error": "No relevant information found for the given NCT IDs.",
             }
 
-        return {"status": "success", "data": responses}
+        result = {"status": "success", "data": responses}
+        if failed_ids:
+            result["metadata"] = {
+                "failed_nct_ids": failed_ids,
+                "note": (
+                    f"{len(failed_ids)} of {len(nct_ids_list)} requested studies "
+                    f"could not be retrieved ({', '.join(failed_ids)}) and are "
+                    "absent from `data`. These were fetch failures, not trials "
+                    "lacking the requested data -- retry them before concluding "
+                    "anything about them."
+                ),
+            }
+        return result
 
     def _simplify_output(self, study, query_type):
         """Manually extract generally most useful information"""

--- a/src/tooluniverse/data/reactome_interactors_tools.json
+++ b/src/tooluniverse/data/reactome_interactors_tools.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "ReactomeInteractors_get_protein_interactors",
-    "description": "Get protein-protein interaction partners for a specific protein from Reactome's IntAct-derived interaction data. Returns interactor accessions, gene names, confidence scores, and evidence counts. Interactions are curated from experimental data with molecular interaction (MI) scores. Example: get interactors for P04637 (TP53) returns 248 interactors including MDM2 (score 0.995, 119 evidences), EP300 (score 0.976), BRCA1 (score 0.944); for Q04206 (NF-kB p65/RELA) returns 105 interactors.",
+    "description": "Get protein-protein interaction partners for a specific protein from Reactome's IntAct-derived interaction data. Returns interactor accessions, gene names, confidence scores, and evidence counts, plus the true total number of interactors ('total_interactors') and how many were returned on this page ('returned_interactors'); when 'truncated' is true, re-run with a larger page_size to get them all. Interactions are curated from experimental data with molecular interaction (MI) scores. Example: P04637 (TP53) has 249 interactors including MDM2 (score 0.995, 119 evidences), EP300 (score 0.976), BRCA1 (score 0.944); Q04206 (NF-kB p65/RELA) has 106; P42345 (MTOR) has 22.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -14,7 +14,7 @@
             "integer",
             "null"
           ],
-          "description": "Maximum number of interactors to return (default: 20, max: 100)."
+          "description": "Maximum number of interactors to return on this page (default: 20). Not capped - pass a value >= total_interactors (e.g. 300 for P04637) to retrieve every interactor in one call."
         }
       },
       "required": [
@@ -52,7 +52,23 @@
                 "integer",
                 "null"
               ],
-              "description": "Total number of known interactors"
+              "description": "True total number of known interactors for this protein (from Reactome's interactors summary endpoint), independent of page_size. Falls back to the number returned on this page when the summary endpoint is unavailable, in which case total_is_exact is false."
+            },
+            "total_is_exact": {
+              "type": "boolean",
+              "description": "True when total_interactors is the authoritative total; false when it is only the count returned on this page"
+            },
+            "returned_interactors": {
+              "type": "integer",
+              "description": "Number of interactors actually returned in this response"
+            },
+            "truncated": {
+              "type": "boolean",
+              "description": "True when returned_interactors is less than total_interactors, i.e. page_size cut off the result set"
+            },
+            "note": {
+              "type": "string",
+              "description": "Human-readable explanation present when results were truncated or the true total could not be determined"
             },
             "interactors": {
               "type": "array",

--- a/src/tooluniverse/reactome_interactors_tool.py
+++ b/src/tooluniverse/reactome_interactors_tool.py
@@ -72,6 +72,30 @@ class ReactomeInteractorsTool(BaseTool):
         else:
             return {"status": "error", "error": f"Unknown endpoint: {self.endpoint}"}
 
+    def _fetch_total_interactor_count(self, accession: str):
+        """Return the true total interactor count, or None if unavailable.
+
+        Fix-R18B-2/Feature-23C-2: the ``count`` field of the interactors
+        ``/details`` response is the number of records on the page that was
+        requested, NOT the size of the full result set -- live-verified for
+        P04637, where page=1&pageSize=100 yields count=100 while
+        page=1&pageSize=300 yields count=249. The dedicated ``/summary``
+        endpoint is therefore the only cheap source of a real total
+        (live-verified: P04637 -> 249, P42345 -> 22). Returns None on any
+        failure so that a page count is never passed off as a total.
+        """
+        url = f"{REACTOME_BASE_URL}/interactors/static/molecule/{accession}/summary"
+        try:
+            response = requests.get(url, timeout=self.timeout)
+            response.raise_for_status()
+            entities = response.json().get("entities", [])
+        except (requests.exceptions.RequestException, ValueError, AttributeError):
+            return None
+        if not entities:
+            return None
+        count = entities[0].get("count")
+        return count if isinstance(count, int) else None
+
     def _get_interactors(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Get protein-protein interactors for a UniProt accession."""
         accession = arguments.get("accession", "")
@@ -84,22 +108,30 @@ class ReactomeInteractorsTool(BaseTool):
         page_size = arguments.get("page_size") or 20
 
         url = f"{REACTOME_BASE_URL}/interactors/static/molecule/{accession}/details"
-        # Fix-R18B-2: page=-1 tells Reactome's interactors API to ignore
-        # pagination and return every interactor regardless of pageSize --
-        # confirmed live (page=-1&pageSize=10 returned all 153 interactors
-        # for P31749; page=1&pageSize=10 correctly returned 10), directly
-        # contradicting this tool's own documented page_size contract.
-        params = {"page": 1, "pageSize": min(page_size, 100)}
+        # The requested page_size is passed through unclamped: Reactome honours
+        # any pageSize on this endpoint (live-verified: pageSize=300 for P04637
+        # returns all 249 interactors), so clamping here would silently truncate
+        # results the caller explicitly asked for.
+        params = {"page": 1, "pageSize": page_size}
 
         response = requests.get(url, params=params, timeout=self.timeout)
         response.raise_for_status()
         data = response.json()
 
+        total = self._fetch_total_interactor_count(accession)
+
         entities = data.get("entities", [])
         if not entities:
             return {
                 "status": "success",
-                "data": {"accession": accession, "interactors": [], "total": 0},
+                "data": {
+                    "accession": accession,
+                    "total_interactors": total if total is not None else 0,
+                    "total_is_exact": total is not None,
+                    "returned_interactors": 0,
+                    "truncated": bool(total),
+                    "interactors": [],
+                },
                 "metadata": {"source": "Reactome Interactors (IntAct)"},
             }
 
@@ -118,13 +150,33 @@ class ReactomeInteractorsTool(BaseTool):
         # Sort by score descending
         interactors.sort(key=lambda x: x.get("score") or 0, reverse=True)
 
+        returned = len(interactors)
+        truncated = total is not None and returned < total
+        result = {
+            "accession": entity.get("acc"),
+            "total_interactors": total if total is not None else returned,
+            "total_is_exact": total is not None,
+            "returned_interactors": returned,
+            "truncated": truncated,
+            "interactors": interactors,
+        }
+        if truncated:
+            result["note"] = (
+                f"Showing {returned} of {total} interactors "
+                f"(page_size={page_size}). Re-run with page_size={total} "
+                "to retrieve all of them."
+            )
+        elif total is None:
+            result["note"] = (
+                "The total interactor count is unavailable (Reactome summary "
+                "endpoint did not respond), so total_interactors reports the "
+                f"{returned} interactor(s) returned on this page and may be "
+                "incomplete."
+            )
+
         return {
             "status": "success",
-            "data": {
-                "accession": entity.get("acc"),
-                "total_interactors": entity.get("count"),
-                "interactors": interactors,
-            },
+            "data": result,
             "metadata": {
                 "source": "Reactome Interactors (IntAct)",
                 "resource": data.get("resource"),

--- a/src/tooluniverse/string_tool.py
+++ b/src/tooluniverse/string_tool.py
@@ -7,6 +7,13 @@ from .tool_registry import register_tool
 
 STRING_BASE_URL = "https://string-db.org/api"
 
+# Identifier-mapping endpoint. Only its responses carry the queryIndex ->
+# submitted-identifier correspondence used by _annotate_mapping_coverage.
+_STRING_IDS_ENDPOINT = "/json/get_string_ids"
+
+# Upper bound on the follow-up requests _classify_missing may issue.
+_MAX_MAPPING_PROBE_ROUNDS = 5
+
 # Categories whose STRING label differs from the value our schema advertises.
 # Every other enum value ('Process', 'Component', 'Function', 'KEGG',
 # 'WikiPathways', 'COMPARTMENTS', 'TISSUES', 'DISEASES') matches STRING exactly.
@@ -184,7 +191,154 @@ class STRINGRESTTool(BaseTool):
                 "data": rows,
                 "metadata": metadata,
             }
+
+        if self.endpoint_template == _STRING_IDS_ENDPOINT and isinstance(
+            api_response, list
+        ):
+            return self._annotate_mapping_coverage(api_response, arguments)
+
         return {"status": "success", "data": api_response}
+
+    @staticmethod
+    def _submitted_identifiers(arguments) -> List[str]:
+        """Recover the submitted identifier list in the order STRING indexed it.
+
+        `queryIndex` is a 0-based offset into the identifiers we posted, so the
+        list has to be rebuilt exactly as _build_params serialized it.
+        """
+        protein_ids = arguments.get("protein_ids")
+        if protein_ids is None:
+            protein_ids = arguments.get("identifiers", [])
+        if isinstance(protein_ids, list):
+            return [str(p) for p in protein_ids]
+        joined = str(protein_ids).replace("%0d", "\r").replace("\n", "\r")
+        return [part for part in joined.split("\r") if part.strip()]
+
+    def _annotate_mapping_coverage(self, records, arguments) -> Dict[str, Any]:
+        """Report which submitted identifiers STRING did not return.
+
+        STRING's /json/get_string_ids simply omits identifiers it does not
+        return -- no placeholder row, no warning -- so a batch of 500 gene
+        symbols could come back as 480 records with a plain "success" and the
+        caller would only notice by diffing the returned `queryIndex` values
+        against their own input. Silently shrinking the gene set skews every
+        downstream enrichment, and this tool's whole job is validating that
+        identifiers exist in STRING, so name the omissions explicitly.
+        """
+        submitted = self._submitted_identifiers(arguments)
+        # `limit` is matches-per-identifier here (up to 10), so several records
+        # can share one queryIndex -- correlate on distinct indices, not rows.
+        returned_indices = {
+            record["queryIndex"]
+            for record in records
+            if isinstance(record, dict) and isinstance(record.get("queryIndex"), int)
+        }
+
+        metadata: Dict[str, Any] = {
+            "submitted_count": len(submitted),
+            "mapped_count": len(returned_indices),
+        }
+
+        if not submitted or (records and not returned_indices):
+            # Nothing to correlate against (no queryIndex in the response);
+            # report the records as-is rather than inventing an omission list.
+            metadata["unmapped_count"] = 0
+            metadata["unmapped_identifiers"] = []
+            return {"status": "success", "data": records, "metadata": metadata}
+
+        missing = [
+            identifier
+            for index, identifier in enumerate(submitted)
+            if index not in returned_indices
+        ]
+
+        if not returned_indices:
+            metadata["unmapped_count"] = len(missing)
+            metadata["unmapped_identifiers"] = missing
+            error_msg = (
+                f"STRING could not map any of the {len(submitted)} submitted "
+                f"identifier(s): {', '.join(missing)}. Check the identifier "
+                "spelling and that `species` matches the organism."
+            )
+            metadata["unmapped_note"] = error_msg
+            return {
+                "status": "error",
+                "data": records,
+                "metadata": metadata,
+                "error": error_msg,
+            }
+
+        unmapped, duplicates = self._classify_missing(missing, arguments)
+        metadata["mapped_count"] = len(returned_indices) + len(duplicates)
+        metadata["unmapped_count"] = len(unmapped)
+        metadata["unmapped_identifiers"] = unmapped
+
+        if duplicates:
+            metadata["duplicate_identifiers"] = duplicates
+            metadata["duplicate_note"] = (
+                f"{len(duplicates)} submitted identifier(s) resolve to a STRING "
+                "protein that another submitted identifier already covers, and "
+                "STRING keeps only the last of each such group: "
+                f"{', '.join(duplicates)}. These are mapped, not missing."
+            )
+        if unmapped:
+            metadata["unmapped_note"] = (
+                f"{len(unmapped)} of {len(submitted)} submitted identifier(s) "
+                "could not be mapped by STRING and are absent from `data`: "
+                f"{', '.join(unmapped)}. Exclude them from downstream analyses "
+                "or supply an alternative identifier type."
+            )
+
+        return {"status": "success", "data": records, "metadata": metadata}
+
+    def _classify_missing(self, missing, arguments):
+        """Split absent identifiers into truly unmapped vs. collapsed duplicates.
+
+        An index absent from the response does not always mean STRING failed to
+        map it: STRING also de-duplicates by resolved protein, keeping only the
+        LAST identifier of every group that resolves to the same entry. Querying
+        ['TP53', 'P04637'] returns one record at queryIndex 1, so calling TP53
+        "not found in STRING" would be flatly wrong. Re-query the absent ones on
+        their own -- whatever STRING returns then was a collapsed duplicate,
+        whatever it still omits is genuinely unmapped. A round that resolves
+        nothing proves the remainder is unmappable, so this terminates quickly
+        (usually after one extra request, and none at all when nothing is
+        missing).
+        """
+        duplicates = []
+        remaining = list(missing)
+        # One round per alias-group member is needed in theory; cap the extra
+        # requests so a pathological input cannot fan out into a request storm.
+        for _ in range(min(len(missing), _MAX_MAPPING_PROBE_ROUNDS)):
+            if not remaining:
+                break
+            probe = self._make_request(
+                self._build_url(),
+                self._build_params({**arguments, "protein_ids": remaining}),
+            )
+            if not isinstance(probe, list):
+                # Probe failed (network/API error); stay conservative and treat
+                # the remainder as unmapped rather than claiming it mapped.
+                break
+            resolved = {
+                record["queryIndex"]
+                for record in probe
+                if isinstance(record, dict)
+                and isinstance(record.get("queryIndex"), int)
+            }
+            if not resolved:
+                break
+            duplicates.extend(
+                identifier
+                for index, identifier in enumerate(remaining)
+                if index in resolved
+            )
+            remaining = [
+                identifier
+                for index, identifier in enumerate(remaining)
+                if index not in resolved
+            ]
+        return remaining, duplicates
 
     @staticmethod
     def _label_partners(rows, arguments):

--- a/src/tooluniverse/tools/ReactomeInteractors_get_protein_interactors.py
+++ b/src/tooluniverse/tools/ReactomeInteractors_get_protein_interactors.py
@@ -24,7 +24,7 @@ def ReactomeInteractors_get_protein_interactors(
     accession : str
         UniProt accession number for the query protein. Examples: 'P04637' (TP53), 'Q...
     page_size : int | Any
-        Maximum number of interactors to return (default: 20, max: 100).
+        Maximum number of interactors to return on this page (default: 20)...
     stream_callback : Callable, optional
         Callback for streaming output
     use_cache : bool, default False

--- a/tests/unit/test_ctg_phrase_quoting.py
+++ b/tests/unit/test_ctg_phrase_quoting.py
@@ -23,6 +23,16 @@ trial with no vedolizumab intervention, and sponsor="Takeda" surfaced
 trials sponsored by Neurocrine Biosciences and Shire (confirmed live).
 Values are now wrapped in Essie's AREA[InterventionName] /
 AREA[LeadSponsorName] operators (still phrase-quoted when multi-word).
+
+Fix-R23-1: restricting to AREA[InterventionName] alone overcorrected --
+brand names are registered in the separate InterventionOtherName synonym
+field, so 'Eliquis' + atrial fibrillation matched 5 trials against 43 once
+other-names are searched too, and 'Opdualag' + melanoma 2 against 19. An
+intervention value is now matched against both name fields; the noise
+Fix-R13B-1 removed lived in description/arm-label text, which neither name
+field contains, so precision is retained (vedolizumab 134 -> 142, against
+215 unrestricted). Sponsor still restricts to the single LeadSponsorName
+field.
 """
 
 import json
@@ -75,23 +85,39 @@ def test_already_quoted_value_is_not_double_quoted():
     assert _phrase_quote_if_plain('"cervical cancer"') == '"cervical cancer"'
 
 
+_INTR_AREAS = ("InterventionName", "InterventionOtherName")
+
+
 def test_area_restricted_value_is_not_double_wrapped():
     assert (
-        _restrict_to_area("AREA[InterventionName]nivolumab", "InterventionName")
+        _restrict_to_area("AREA[InterventionName]nivolumab", _INTR_AREAS)
         == "AREA[InterventionName]nivolumab"
     )
 
 
-def test_single_word_value_is_area_restricted_without_quotes():
-    assert _restrict_to_area("nivolumab", "InterventionName") == (
-        "AREA[InterventionName]nivolumab"
+def test_single_area_value_is_restricted_without_quotes():
+    assert _restrict_to_area("Pfizer", ("LeadSponsorName",)) == (
+        "AREA[LeadSponsorName]Pfizer"
+    )
+
+
+def test_single_word_value_searches_both_intervention_name_fields():
+    assert _restrict_to_area("nivolumab", _INTR_AREAS) == (
+        "(AREA[InterventionName]nivolumab OR AREA[InterventionOtherName]nivolumab)"
     )
 
 
 def test_multiword_value_is_area_restricted_and_phrase_quoted():
-    assert _restrict_to_area("immunotherapy radiotherapy", "InterventionName") == (
-        'AREA[InterventionName]"immunotherapy radiotherapy"'
+    assert _restrict_to_area("immunotherapy radiotherapy", _INTR_AREAS) == (
+        '(AREA[InterventionName]"immunotherapy radiotherapy" OR '
+        'AREA[InterventionOtherName]"immunotherapy radiotherapy")'
     )
+
+
+def test_brand_name_reaches_synonym_field():
+    """Brand names live in InterventionOtherName; searching only
+    InterventionName is what made 'Eliquis' return almost nothing."""
+    assert "InterventionOtherName" in _restrict_to_area("Eliquis", _INTR_AREAS)
 
 
 def test_condition_and_intervention_are_quoted_in_live_request():
@@ -107,7 +133,10 @@ def test_condition_and_intervention_are_quoted_in_live_request():
 
     params = mock_get.call_args.kwargs["params"]
     assert params["query.cond"] == '"cervical cancer"'
-    assert params["query.intr"] == 'AREA[InterventionName]"immunotherapy radiotherapy"'
+    assert params["query.intr"] == (
+        '(AREA[InterventionName]"immunotherapy radiotherapy" OR '
+        'AREA[InterventionOtherName]"immunotherapy radiotherapy")'
+    )
 
 
 def test_sponsor_alias_maps_to_query_spons():

--- a/tests/unit/test_reactome_interactors_pagination.py
+++ b/tests/unit/test_reactome_interactors_pagination.py
@@ -3,6 +3,15 @@ page=-1 (a Reactome-specific "ignore pagination, return everything"
 signal), so the tool's own documented page_size parameter had zero effect
 -- confirmed live that page=-1&pageSize=10 returned all 153 interactors for
 P31749, while page=1&pageSize=10 correctly returned 10.
+
+Feature-23C-2: page_size was additionally clamped to 100, and
+total_interactors was read from the /details response's `count` field --
+which reports how many records that page returned, not the size of the
+full result set. So a page_size=300 request came back with
+total_interactors=100 and no indication anything had been dropped
+(live-verified for P04637: pageSize=100 -> count=100, pageSize=300 ->
+count=249). The clamp is gone and the true total now comes from the
+dedicated /summary endpoint, so these tests assert against two calls.
 """
 
 import sys
@@ -10,6 +19,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
 
@@ -24,23 +34,111 @@ def _tool():
     )
 
 
-def test_page_size_is_honored_via_correct_page_param():
-    tool = _tool()
+def _fake_reactome(total, returned, acc="P31749"):
+    """Mock Reactome's two endpoints: /summary gives the true total,
+    /details gives one page. Records the params each one was called with."""
     captured = {}
 
     def fake_get(url, params=None, **kwargs):
-        captured["params"] = params
         resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        if url.endswith("/summary"):
+            captured["summary_params"] = params
+            resp.json.return_value = {
+                "resource": "static",
+                "entities": [{"acc": acc, "count": total}],
+            }
+        else:
+            captured["details_params"] = params
+            resp.json.return_value = {
+                "resource": "IntAct",
+                "entities": [
+                    {
+                        "acc": acc,
+                        # `count` here is the page's own size, which is exactly
+                        # why it must not be reported as a total.
+                        "count": returned,
+                        "interactors": [
+                            {
+                                "acc": f"P{i}",
+                                "alias": None,
+                                "score": 0.5,
+                                "evidences": [],
+                            }
+                            for i in range(returned)
+                        ],
+                    }
+                ],
+            }
+        return resp
+
+    return fake_get, captured
+
+
+def test_page_size_is_honored_via_correct_page_param():
+    tool = _tool()
+    fake_get, captured = _fake_reactome(total=10, returned=10)
+
+    with patch(
+        "tooluniverse.reactome_interactors_tool.requests.get", side_effect=fake_get
+    ):
+        result = tool._get_interactors({"accession": "P31749", "page_size": 10})
+
+    assert captured["details_params"]["page"] == 1
+    assert captured["details_params"]["pageSize"] == 10
+    assert len(result["data"]["interactors"]) == 10
+
+
+def test_page_size_above_100_is_not_clamped():
+    tool = _tool()
+    fake_get, captured = _fake_reactome(total=249, returned=249, acc="P04637")
+
+    with patch(
+        "tooluniverse.reactome_interactors_tool.requests.get", side_effect=fake_get
+    ):
+        result = tool._get_interactors({"accession": "P04637", "page_size": 300})
+
+    assert captured["details_params"]["pageSize"] == 300
+    assert result["data"]["total_interactors"] == 249
+    assert result["data"]["returned_interactors"] == 249
+    assert result["data"]["truncated"] is False
+
+
+def test_truncated_page_reports_true_total_and_flags_truncation():
+    tool = _tool()
+    fake_get, _ = _fake_reactome(total=249, returned=20, acc="P04637")
+
+    with patch(
+        "tooluniverse.reactome_interactors_tool.requests.get", side_effect=fake_get
+    ):
+        result = tool._get_interactors({"accession": "P04637"})
+
+    data = result["data"]
+    # The /details page reported count=20; the total must come from /summary.
+    assert data["total_interactors"] == 249
+    assert data["returned_interactors"] == 20
+    assert data["truncated"] is True
+    assert data["total_is_exact"] is True
+    assert "249" in data["note"]
+
+
+def test_unavailable_summary_does_not_pass_page_count_off_as_total():
+    tool = _tool()
+
+    def fake_get(url, params=None, **kwargs):
+        resp = MagicMock()
+        if url.endswith("/summary"):
+            raise requests.exceptions.ConnectionError("summary down")
         resp.raise_for_status = MagicMock()
         resp.json.return_value = {
             "resource": "IntAct",
             "entities": [
                 {
                     "acc": "P31749",
-                    "count": 10,
+                    "count": 20,
                     "interactors": [
                         {"acc": f"P{i}", "alias": None, "score": 0.5, "evidences": []}
-                        for i in range(10)
+                        for i in range(20)
                     ],
                 }
             ],
@@ -50,8 +148,9 @@ def test_page_size_is_honored_via_correct_page_param():
     with patch(
         "tooluniverse.reactome_interactors_tool.requests.get", side_effect=fake_get
     ):
-        result = tool._get_interactors({"accession": "P31749", "page_size": 10})
+        result = tool._get_interactors({"accession": "P31749"})
 
-    assert captured["params"]["page"] == 1
-    assert captured["params"]["pageSize"] == 10
-    assert len(result["data"]["interactors"]) == 10
+    data = result["data"]
+    assert data["total_is_exact"] is False
+    assert data["returned_interactors"] == 20
+    assert "incomplete" in data["note"]


### PR DESCRIPTION
Round 23 of the role-play test harness. Three personas — cardiovascular pharmacoepidemiology, cancer immunotherapy clinical trials, and protein-interaction/pathway systems biology — reported 26 issues; 7 survived CLI verification and are fixed here.

All three personas independently hit the same shape of failure, and it is a different one from the last two rounds. Rounds 21 and 22 were about lookups that return *nothing* when the data is there. This round is about calls that return **something plausible while silently dropping part of the answer**. An empty result at least prompts the caller to look closer. A short-but-populated one does not — it gets used as if it were the whole answer.

## ClinicalTrials.gov (`ctg_tool.py`)

**Brand-name intervention searches nearly vanished.** Queries were restricted to `AREA[InterventionName]`, but registrants record brand names in the separate `InterventionOtherName` synonym field. Live counts:

| query | InterventionName only | both name fields | unrestricted |
|---|---|---|---|
| `Eliquis` + atrial fibrillation | 5 | **43** | 52 |
| `Opdualag` + melanoma | 2 | **19** | 22 |
| `vedolizumab` | 134 | **142** | 215 |
| `apixaban` + atrial fibrillation | 96 | **108** | 189 |

Searching both name fields recovers the brand-name hits without reopening the imprecision that motivated the original restriction — that noise came from description/arm-label text, which neither name field contains.

Before: `ClinicalTrials_search_by_intervention {"intervention":"Eliquis","condition":"atrial fibrillation","filter_phase":"PHASE3"}` → `total_count: 0`.
After: `total_count: 10`, including ARISTOTLE (NCT00412984).

**A failed per-study fetch was dropped without a trace.** `execute_RESTful_query` returns a falsy value for HTTP errors, timeouts and undecodable JSON alike, and the details loop discarded those silently. A transient blip surfaced either as a quietly short result set or as `"No relevant information found for the given NCT IDs."` — which reads as "this trial has no eligibility criteria" for a trial that demonstrably has them. Fetch failures and genuinely absent data no longer share a response; partial failures are now named in `metadata.failed_nct_ids`.

**Intervention lists were sliced to 5 with no count and no flag.** NCT03337698 is a real tiragolumab trial with 18 interventions, none of which survived the slice — it read as a false positive. Now reports `intervention_count` and `interventions_truncated`.

**`filter_status` / `filter_phase` were unvalidated.** The natural spellings `"recruiting"` and `"Phase 3"` produced a bare upstream HTTP 400 whose remediation advice — *retry, check service status, report if persistent* — is actively wrong for a typo. Both are now normalized case- and separator-insensitively, and a genuinely unknown value is rejected up front with the legal values named.

**The default phase-2-and-above gate was disclosed only on zero results**, so a caller with a healthy-looking list never learned that phase-1 and observational studies had been filtered out of it. A non-empty result is just as filtered as an empty one.

## Reactome interactors (`reactome_interactors_tool.py`)

`page_size` was clamped to 100, and `total_interactors` was read from the `/details` response's `count` field — which reports how many records *that page* returned, not the size of the full set. So `page_size=300` came back reporting `total_interactors: 100` with nothing indicating truncation, and the "total" changed with page size, breaking any pagination loop. Live: `pageSize=100` → `count=100`; `pageSize=300` → `count=249`.

The clamp is removed (Reactome honours larger page sizes) and the true total now comes from the dedicated `/summary` endpoint, with an explicit `truncated` flag and a note naming the `page_size` that would fetch everything. If `/summary` is unreachable, the page count is no longer passed off as a total (`total_is_exact: false`).

Before: `{"accession":"P04637","page_size":300}` → `total_interactors: 100`.
After: `total_interactors: 249, returned_interactors: 249, truncated: false` — matching the 249 the tool's own description advertises.

## STRING identifier mapping (`string_tool.py`)

Identifiers STRING could not map were simply absent from the response — no placeholder, no warning — so a batch of 500 gene symbols could return 480 records as a plain `success`, discoverable only by diffing `queryIndex` values by hand. Silently shrinking a gene set skews every downstream enrichment, and validating that identifiers exist in STRING is this tool's stated purpose. The submitted list is now reconciled against what came back, omissions are named in `metadata`, and mapping *nothing* is an error rather than an empty success.

Worth flagging, because the obvious fix here is wrong: absence does not prove failure. STRING also de-duplicates by resolved protein, keeping only the **last** identifier of each group — `["TP53","P04637"]` legitimately returns a single record at `queryIndex 1`. A naive check would have reported "TP53 could not be mapped", a confidently wrong claim about a real gene and worse than the original silent drop. Absent identifiers are therefore re-queried on their own (bounded, and only when something is actually missing) to separate collapsed duplicates from genuine misses.

## Verification

- `tests/unit` (the CI-blocking suite) green.
- Every fix re-run through the CLI with the persona's original arguments; before/after captured above.
- `tu test` passes for `ClinicalTrials_search_studies`, `ClinicalTrials_search_by_intervention`, `search_clinical_trials`, `get_clinical_trial_eligibility_criteria`, `ReactomeInteractors_get_protein_interactors`, `STRING_map_identifiers`.
- Two pre-existing test files asserted the old behaviour and were updated deliberately: `test_ctg_phrase_quoting.py` (the `AREA[]` construction) and `test_reactome_interactors_pagination.py` (which mocked a single HTTP call and is now split per endpoint, with added coverage for the true-total and degraded-`/summary` paths).
- Regression-checked that the STRING change does not touch the other tools sharing `STRINGRESTTool`.

19 of 26 reported issues were discarded as false positives or out of scope (73%) — including several where the tool was behaving correctly and the persona misread an honest empty result, and one where Reactome's static IntAct snapshot genuinely lacks the expected interactors (an upstream data-coverage matter, not a code defect).
