### PR TITLE
Fix Round 24: results that name the wrong entity while looking correct

### DIFF
--- a/src/tooluniverse/compound_disease_tool.py
+++ b/src/tooluniverse/compound_disease_tool.py
@@ -5,10 +5,42 @@ returning identifiers, associated genes, phenotypes, and prevalence data
 in a single call.
 """
 
+import re
 from typing import Any, Dict, List
 
 from .base_tool import BaseTool
 from .tool_registry import register_tool
+
+# Disease nomenclature mixes Roman and Arabic subtype numbers freely --
+# "Mucopolysaccharidosis type I" (query), "Mucopolysaccharidosis Type I"
+# (NCIT) and "Mucopolysaccharidosis type 1" (Orphanet) are one disease.
+_ROMAN_TO_ARABIC = {
+    "i": "1",
+    "ii": "2",
+    "iii": "3",
+    "iv": "4",
+    "v": "5",
+    "vi": "6",
+    "vii": "7",
+    "viii": "8",
+    "ix": "9",
+    "x": "10",
+}
+
+
+def _normalize_disease_label(text: str) -> str:
+    """Fold a disease name to a comparable form: lowercase, punctuation-free,
+    with Roman subtype numerals rewritten as Arabic."""
+    tokens = re.split(r"[^0-9a-z]+", (text or "").lower())
+    return " ".join(_ROMAN_TO_ARABIC.get(t, t) for t in tokens if t)
+
+
+def _labels_match(query: str, label: str) -> bool:
+    """True when `label` names the same disease the caller asked for."""
+    normalized_query = _normalize_disease_label(query)
+    return (
+        bool(normalized_query) and _normalize_disease_label(label) == normalized_query
+    )
 
 
 def _truncate_msg(msg: str, limit: int = 240) -> str:
@@ -61,7 +93,7 @@ class CompoundDiseaseProfileTool(BaseTool):
         r = _try_tool(
             "Orphanet", "Orphanet_search_diseases", {"query": disease, "language": "en"}
         )
-        sections["orphanet"] = self._parse_orphanet(r)
+        sections["orphanet"] = self._parse_orphanet(r, disease)
 
         # 2. OMIM
         r = _try_tool("OMIM", "OMIM_search", {"query": disease, "limit": 5})
@@ -97,22 +129,38 @@ class CompoundDiseaseProfileTool(BaseTool):
             },
         }
 
-    def _parse_orphanet(self, result: Any) -> Dict[str, Any]:
+    @staticmethod
+    def _entry_label(entry: Dict[str, Any]) -> str:
+        return entry.get(
+            "Preferred term", entry.get("preferred_term", entry.get("name", ""))
+        )
+
+    def _parse_orphanet(self, result: Any, query: str) -> Dict[str, Any]:
         if not isinstance(result, dict) or result.get("status") == "error":
             return {}
         data = result.get("data", {})
         results_list = data.get("results", data) if isinstance(data, dict) else data
-        if isinstance(results_list, list) and results_list:
-            entry = results_list[0] if isinstance(results_list[0], dict) else {}
-            return {
-                "orpha_code": str(entry.get("ORPHAcode", entry.get("orpha_code", ""))),
-                "name": entry.get(
-                    "Preferred term", entry.get("preferred_term", entry.get("name", ""))
-                ),
-                "prevalence": entry.get("prevalence", ""),
-                "inheritance": entry.get("inheritance", ""),
-            }
-        return {}
+        if not isinstance(results_list, list) or not results_list:
+            return {}
+        entries = [e for e in results_list if isinstance(e, dict)]
+        if not entries:
+            return {}
+        # Orphanet's search is ranked by its own relevance, not by name
+        # equality: "mucopolysaccharidosis type I" puts MPS VI (ORPHA:583)
+        # first and the real MPS I (ORPHA:579) fourth. Taking results[0]
+        # therefore stamped a different disease's ORPHA code onto the
+        # profile. Prefer the hit whose name actually matches the query.
+        exact = next(
+            (e for e in entries if _labels_match(query, self._entry_label(e))), None
+        )
+        entry = exact or entries[0]
+        return {
+            "orpha_code": str(entry.get("ORPHAcode", entry.get("orpha_code", ""))),
+            "name": self._entry_label(entry),
+            "prevalence": entry.get("prevalence", ""),
+            "inheritance": entry.get("inheritance", ""),
+            "match": "exact" if exact is not None else "approximate",
+        }
 
     def _parse_omim(self, result: Any) -> Dict[str, Any]:
         if not isinstance(result, dict):
@@ -216,11 +264,21 @@ class CompoundDiseaseProfileTool(BaseTool):
         return {"terms": terms}
 
     def _build_profile(self, disease: str, sections: Dict[str, Any]) -> Dict[str, Any]:
-        """Build a unified disease profile from all sources."""
+        """Build a unified disease profile from all sources.
+
+        `identifiers` is the block downstream callers treat as "the IDs for
+        this disease", so only cross-references whose own label names the
+        queried disease belong in it. Every source is a ranked search, and
+        their top hits routinely disagree: for "mucopolysaccharidosis type I"
+        the unfiltered version emitted Orphanet 583 (MPS VI), MeSH D009085
+        (MPS IV) and ORDO 217085 (MPS II severe) side by side under one
+        disease name. Non-matching hits stay visible in `per_source` -- they
+        are just not promoted to identifiers.
+        """
         profile: Dict[str, Any] = {"disease": disease, "identifiers": {}}
 
         orphanet = sections.get("orphanet", {})
-        if orphanet.get("orpha_code"):
+        if orphanet.get("orpha_code") and orphanet.get("match") == "exact":
             profile["identifiers"]["orphanet"] = orphanet["orpha_code"]
         if orphanet.get("prevalence"):
             profile["prevalence"] = orphanet["prevalence"]
@@ -234,7 +292,7 @@ class CompoundDiseaseProfileTool(BaseTool):
                 profile["identifiers"]["omim"] = mim
 
         ot = sections.get("opentargets", {})
-        if ot.get("efo_id"):
+        if ot.get("efo_id") and _labels_match(disease, ot.get("name", "")):
             profile["identifiers"]["efo"] = ot["efo_id"]
         if ot.get("description"):
             profile["description"] = ot["description"]
@@ -243,7 +301,11 @@ class CompoundDiseaseProfileTool(BaseTool):
         if ols.get("terms"):
             for term in ols["terms"]:
                 ont = term.get("ontology", "").lower()
-                if ont and term.get("id"):
+                if (
+                    ont
+                    and term.get("id")
+                    and _labels_match(disease, term.get("label", ""))
+                ):
                     profile["identifiers"][ont] = term["id"]
 
         disgenet = sections.get("disgenet", {})

--- a/src/tooluniverse/data/kegg_ext_tools.json
+++ b/src/tooluniverse/data/kegg_ext_tools.json
@@ -198,7 +198,7 @@
                         },
                         "dblinks": {
                             "type": "object",
-                            "description": "Cross-references to other databases (PubChem, ChEBI, DrugBank, etc.)"
+                            "description": "Cross-references to other databases (ChEBI, DrugBank, CAS, LIPIDMAPS, etc.). KEGG's PubChem cross-reference is a PubChem *substance* ID and is therefore returned as 'PubChem_SID' -- it is not a CID and must not be passed to CID-based tools. Resolve it first, e.g. PubChem PUG-REST /substance/sid/{sid}/cids."
                         }
                     }
                 },

--- a/src/tooluniverse/data/ncbi_variation_tools.json
+++ b/src/tooluniverse/data/ncbi_variation_tools.json
@@ -139,7 +139,7 @@
   },
   {
     "name": "NCBIVariation_rsid_lookup",
-    "description": "Look up a dbSNP rsID and retrieve variant details including GRCh38 genomic coordinates, associated genes, clinical significance (ClinVar), citations, and MANE Select transcript IDs. Accepts rsID with or without 'rs' prefix (e.g., 'rs429358' or '429358'). Returns structured summary of the variant.",
+    "description": "Look up a dbSNP rsID and retrieve variant details including GRCh38 genomic coordinates, associated genes, clinical significance (ClinVar), citations, and MANE Select transcript IDs. Each entry in 'grch38_placements' reports 'position' as a 1-based GRCh38 coordinate (matching ClinVar, Ensembl VEP and MyVariant) and keeps dbSNP's 0-based interbase SPDI offset in 'spdi_position'. Accepts rsID with or without 'rs' prefix (e.g., 'rs429358' or '429358'). Returns structured summary of the variant.",
     "parameter": {
       "type": "object",
       "properties": {

--- a/src/tooluniverse/kegg_ext_tool.py
+++ b/src/tooluniverse/kegg_ext_tool.py
@@ -32,6 +32,25 @@ _VARIANT_XREF_FIELDS = {
 }
 
 
+# KEGG deposits its compound/drug/disease records into PubChem as
+# *substances*, so a DBLINKS line "PubChem: 7805" carries a PubChem SID, not
+# a CID. Emitting it under the bare key "PubChem" invites callers to feed it
+# straight into a CID-based tool, which silently returns a different molecule
+# (SID 7805 = KEGG C05443 cholecalciferol, but CID 7805 = 1-bromo-4-
+# methylbenzene; SID 4808 = KEGG C01659 acrylamide, but CID 4808 is an
+# unrelated C36 compound). Verified live against PubChem PUG-REST:
+# /substance/sid/7805/cids -> 5280795 and /substance/sid/4808/cids -> 6579,
+# which are the real CIDs for those two compounds. Renaming the key makes the
+# namespace explicit at the point the value is produced.
+_DBLINK_KEY_RENAMES = {"PubChem": "PubChem_SID"}
+
+
+def _store_dblink(dblinks: Dict[str, str], raw_key: str, value: str) -> None:
+    """Record one KEGG DBLINKS entry under a namespace-explicit key."""
+    key = raw_key.strip()
+    dblinks[_DBLINK_KEY_RENAMES.get(key, key)] = value.strip()
+
+
 def _new_kegg_variation(mutation: str) -> Dict[str, Any]:
     """A fresh KEGG variant record with all cross-reference lists empty."""
     return {
@@ -418,7 +437,7 @@ class KEGGExtTool(BaseTool):
                 current_field = "DBLINKS"
                 parts = line[12:].strip().split(": ", 1)
                 if len(parts) == 2:
-                    result["dblinks"][parts[0].strip()] = parts[1].strip()
+                    _store_dblink(result["dblinks"], parts[0], parts[1])
             elif line.startswith("REMARK"):
                 result["remark"] = line[12:].strip()
                 current_field = None
@@ -439,7 +458,7 @@ class KEGGExtTool(BaseTool):
                 elif current_field == "DBLINKS":
                     parts = content.split(": ", 1)
                     if len(parts) == 2:
-                        result["dblinks"][parts[0].strip()] = parts[1].strip()
+                        _store_dblink(result["dblinks"], parts[0], parts[1])
             else:
                 # New field we don't specifically handle
                 current_field = None
@@ -716,7 +735,7 @@ class KEGGExtTool(BaseTool):
                 current_field = "DBLINKS"
                 parts = line[12:].strip().split(": ", 1)
                 if len(parts) == 2:
-                    result["dblinks"][parts[0].strip()] = parts[1].strip()
+                    _store_dblink(result["dblinks"], parts[0], parts[1])
             elif line.startswith("REFERENCE"):
                 current_field = "REFERENCE"
                 ref = line[12:].strip()
@@ -745,7 +764,7 @@ class KEGGExtTool(BaseTool):
                 elif current_field == "DBLINKS":
                     parts = content.split(": ", 1)
                     if len(parts) == 2:
-                        result["dblinks"][parts[0].strip()] = parts[1].strip()
+                        _store_dblink(result["dblinks"], parts[0], parts[1])
                 elif current_field == "REFERENCE":
                     result["references"].append(content)
             else:
@@ -914,7 +933,7 @@ class KEGGExtTool(BaseTool):
                 current_field = "DBLINKS"
                 parts = line[12:].strip().split(": ", 1)
                 if len(parts) == 2:
-                    result["dblinks"][parts[0].strip()] = parts[1].strip()
+                    _store_dblink(result["dblinks"], parts[0], parts[1])
             elif line.startswith("EFFICACY"):
                 current_field = "EFFICACY"
                 result["efficacy"] = line[12:].strip()
@@ -942,7 +961,7 @@ class KEGGExtTool(BaseTool):
                 elif current_field == "DBLINKS":
                     parts = content.split(": ", 1)
                     if len(parts) == 2:
-                        result["dblinks"][parts[0].strip()] = parts[1].strip()
+                        _store_dblink(result["dblinks"], parts[0], parts[1])
                 elif current_field == "EFFICACY":
                     result["efficacy"] = (result["efficacy"] or "") + " " + content
                 elif current_field == "PRODUCT":

--- a/src/tooluniverse/ncbi_variation_tool.py
+++ b/src/tooluniverse/ncbi_variation_tool.py
@@ -34,6 +34,50 @@ _ALFA_POP_FALLBACK = {
 }
 
 
+def _grch38_placement_from_spdi(spdi: Dict[str, Any]) -> Dict[str, Any]:
+    """Turn one dbSNP SPDI allele into a genome placement.
+
+    SPDI positions are 0-based interbase offsets, but this tool advertises
+    "GRCh38 genomic coordinates" and its output sits next to ClinVar, Ensembl
+    VEP and MyVariant results, all of which report 1-based positions. Passing
+    the SPDI offset through under the name `position` therefore reported every
+    variant one base 5' of where it is: rs121965019 (IDUA c.1205G>A) came back
+    as chr4:1002746 where the other three tools say 1002747, and the tool's
+    own documented example rs429358 as chr19:44908683 rather than 44908684.
+
+    `position` is now the 1-based coordinate; the untranslated SPDI offset is
+    kept alongside it so callers building SPDI strings do not lose it. For a
+    pure insertion there is no deleted base, so the 1-based anchor is the base
+    immediately 5' of the insertion point, which is the SPDI offset itself.
+    """
+    offset = spdi.get("position")
+    deleted = spdi.get("deleted_sequence")
+    position = offset
+    if isinstance(offset, int):
+        position = offset + 1 if deleted else offset
+    return {
+        "seq_id": spdi.get("seq_id"),
+        "position": position,
+        "coordinate_system": "1-based",
+        "spdi_position": offset,
+        "deleted_sequence": deleted,
+        "inserted_sequence": spdi.get("inserted_sequence"),
+    }
+
+
+def _dedupe_genes(genes):
+    """Collapse the per-placement gene rows dbSNP repeats for each allele."""
+    seen = set()
+    unique = []
+    for gene in genes:
+        key = (gene.get("gene_id"), gene.get("gene"))
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(gene)
+    return unique
+
+
 @register_tool("NCBIVariationTool")
 class NCBIVariationTool(BaseTool):
     """
@@ -226,16 +270,7 @@ class NCBIVariationTool(BaseTool):
                             spdi = allele.get("allele", {}).get("spdi", {})
                             if spdi:
                                 grch38_placements.append(
-                                    {
-                                        "seq_id": spdi.get("seq_id"),
-                                        "position": spdi.get("position"),
-                                        "deleted_sequence": spdi.get(
-                                            "deleted_sequence"
-                                        ),
-                                        "inserted_sequence": spdi.get(
-                                            "inserted_sequence"
-                                        ),
-                                    }
+                                    _grch38_placement_from_spdi(spdi)
                                 )
                         break
 
@@ -257,7 +292,7 @@ class NCBIVariationTool(BaseTool):
                                 }
                             )
                 if clinical:
-                    result["genes"] = clinical
+                    result["genes"] = _dedupe_genes(clinical)
 
                 # Extract clinical significance
                 for annot in allele_annots:

--- a/src/tooluniverse/orphanet_tool.py
+++ b/src/tooluniverse/orphanet_tool.py
@@ -49,6 +49,52 @@ def _encode_orphadata_gene_name(name: str) -> str:
     return urllib.parse.quote(name.replace("/", "-"), safe="")
 
 
+def _same_char_class(a: str, b: str) -> bool:
+    """True when two characters continue the same token (digit-digit or
+    letter-letter)."""
+    return (a.isdigit() and b.isdigit()) or (a.isalpha() and b.isalpha())
+
+
+def _name_contains_disease(candidate_name: str, disease_name: str) -> bool:
+    """True when `candidate_name` names a subtype of `disease_name`.
+
+    A plain substring test is wrong here: Orphanet's preferred terms are
+    numbered, so "Mucopolysaccharidosis type 1" (ORPHA:579, MPS I) is a
+    substring of "Mucopolysaccharidosis type 10" (ORPHA:662216, MPS X) and the
+    gene lookup for MPS I answered with ARSK -- the MPS X gene -- instead of
+    IDUA. The same collision hits "Familial hyperaldosteronism type I" vs
+    "type II/III/IV", "Mucolipidosis type II" vs "type III", "Achondroplasia"
+    vs "Pseudoachondroplasia" and "Neuroblastoma" vs "Ganglioneuroblastoma".
+
+    So require the occurrence to sit on token boundaries: the characters
+    flanking it may not continue the same class (digit or letter) as the
+    adjacent character of the disease name. Real subtype names are unaffected,
+    because they extend the parent name across a class change -- a space, a
+    comma or a letter after a digit ("Mucopolysaccharidosis type 4A",
+    "Mucopolysaccharidosis type 2, severe form", "Autosomal dominant
+    Charcot-Marie-Tooth disease type 2N").
+    """
+    disease_lower = (disease_name or "").lower()
+    candidate_lower = (candidate_name or "").lower()
+    if not disease_lower:
+        return False
+    start = 0
+    while True:
+        index = candidate_lower.find(disease_lower, start)
+        if index < 0:
+            return False
+        end = index + len(disease_lower)
+        before_ok = index == 0 or not _same_char_class(
+            candidate_lower[index - 1], disease_lower[0]
+        )
+        after_ok = end >= len(candidate_lower) or not _same_char_class(
+            candidate_lower[end], disease_lower[-1]
+        )
+        if before_ok and after_ok:
+            return True
+        start = index + 1
+
+
 @register_tool("OrphanetTool")
 class OrphanetTool(BaseTool):
     """
@@ -383,12 +429,13 @@ class OrphanetTool(BaseTool):
             if response.status_code != 200:
                 return [], True
             all_entries = response.json().get("data", {}).get("results", [])
-            disease_lower = disease_name.lower()
             return (
                 [
                     entry
                     for entry in all_entries
-                    if disease_lower in entry.get("Preferred term", "").lower()
+                    if _name_contains_disease(
+                        entry.get("Preferred term", ""), disease_name
+                    )
                     and str(entry.get("ORPHAcode", "")) != str(exclude_code)
                 ],
                 False,

--- a/src/tooluniverse/proteins_api_tool.py
+++ b/src/tooluniverse/proteins_api_tool.py
@@ -492,12 +492,19 @@ class ProteinsAPIRESTTool(BaseTool):
                 used_gene = "gene" in params
 
                 def _retry_params(use_gene: bool, keep_human: bool) -> Dict[str, Any]:
-                    p = {"format": params.get("format", "json")}
-                    if "size" in params:
-                        p["size"] = params["size"]
+                    # Carry the original request forward and change only the
+                    # field being retried. Rebuilding from scratch dropped
+                    # every scoping parameter the caller had supplied
+                    # (organism=/taxid=), so a wheat query silently retried
+                    # against all of UniProt and answered with an insect.
+                    p = {
+                        k: v for k, v in params.items() if k not in ("gene", "protein")
+                    }
                     p["gene" if use_gene else "protein"] = query
-                    if keep_human and auto_human:
-                        p["taxid"] = "9606"
+                    if not keep_human and auto_human:
+                        # Only the human default this tool added itself may be
+                        # dropped; a caller-supplied taxid stays.
+                        p.pop("taxid", None)
                     return p
 
                 # Order: swap field but keep human; then drop the human filter
@@ -523,7 +530,7 @@ class ProteinsAPIRESTTool(BaseTool):
                     if isinstance(retry_data, list) and len(retry_data) > 0:
                         data = retry_data
                         response = retry_resp
-                        widened_organism = "taxid" not in cand
+                        widened_organism = auto_human and "taxid" not in cand
                         break
 
             # Cap features per entry to avoid 25MB+ responses for heavily-annotated proteins

--- a/tests/integration/test_coding_api_integration.py
+++ b/tests/integration/test_coding_api_integration.py
@@ -20,6 +20,12 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 from tooluniverse import ToolUniverse  # noqa: E402
 from tooluniverse.generate_tools import main as generate_tools  # noqa: E402
 
+# Every generate_tools() call below must pass output_dir. Its default output
+# directory is the *committed* src/tooluniverse/tools/ tree, so calling it bare
+# — as these tests did, despite each site already allocating a temp dir and
+# commenting "Generate tools in temp directory" — rewrote 2,604 tracked wrapper
+# files as a side effect of running the integration suite.
+
 
 @pytest.mark.integration
 class TestCodingAPIIntegration(unittest.TestCase):
@@ -178,7 +184,7 @@ class TestSDKIntegration(unittest.TestCase):
         self.temp_dir = tempfile.mkdtemp()
         
         # Generate SDK for testing
-        generate_tools()
+        generate_tools(output_dir=Path(self.temp_dir))
         
         # Invalidate import caches to ensure newly generated modules are loaded
         # Remove all tooluniverse.tools modules from cache
@@ -287,7 +293,7 @@ class TestEndToEndIntegration(unittest.TestCase):
             pass
         
         # Step 2: Generate SDK
-        generate_tools()
+        generate_tools(output_dir=Path(self.temp_dir))
         
         # Step 3: Test SDK
         sys.path.insert(0, self.temp_dir)
@@ -327,7 +333,7 @@ class TestEndToEndIntegration(unittest.TestCase):
         
         # Test error handling in SDK mode
         # Generate tools in temp directory
-        generate_tools()
+        generate_tools(output_dir=Path(self.temp_dir))
         
         sys.path.insert(0, self.temp_dir)
         try:
@@ -379,7 +385,7 @@ class TestEndToEndIntegration(unittest.TestCase):
         
         # Test caching in SDK mode
         # Generate tools in temp directory
-        generate_tools()
+        generate_tools(output_dir=Path(self.temp_dir))
         
         sys.path.insert(0, self.temp_dir)
         try:

--- a/tests/unit/test_coding_api_generation_is_sandboxed.py
+++ b/tests/unit/test_coding_api_generation_is_sandboxed.py
@@ -1,0 +1,40 @@
+"""The integration suite must not regenerate the committed wrapper tree.
+
+tests/integration/test_coding_api_integration.py calls generate_tools() whose
+default output directory is src/tooluniverse/tools/ -- the tracked wrapper
+tree. Running the integration suite therefore rewrote 2,604 tracked files as a
+side effect, which is indistinguishable from a real change in `git status` and
+has already cost a fix round. Each call site allocates a temp dir; this guards
+that they actually use it.
+"""
+
+import ast
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+pytestmark = pytest.mark.unit
+
+TARGET = Path(__file__).parent.parent / "integration" / "test_coding_api_integration.py"
+
+
+def test_every_generate_tools_call_passes_an_output_dir():
+    tree = ast.parse(TARGET.read_text())
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "generate_tools"
+    ]
+
+    assert calls, "expected the integration test to exercise generate_tools"
+    for call in calls:
+        keywords = {kw.arg for kw in call.keywords}
+        assert "output_dir" in keywords, (
+            f"generate_tools() at line {call.lineno} would write into the "
+            "committed src/tooluniverse/tools/ tree"
+        )

--- a/tests/unit/test_disease_profile_identifier_match.py
+++ b/tests/unit/test_disease_profile_identifier_match.py
@@ -1,0 +1,108 @@
+"""gather_disease_profile must not mix several diseases into one identifier set.
+
+Every source behind the profile is a ranked search, and their top hits
+disagree. For "mucopolysaccharidosis type I" the profile used to emit Orphanet
+583 (MPS VI), MeSH D009085 (MPS IV) and ORDO 217085 (MPS II severe form)
+together under one disease name, because the first hit of each source was
+accepted without checking its label.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.compound_disease_tool import (
+    CompoundDiseaseProfileTool,
+    _labels_match,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return CompoundDiseaseProfileTool(
+        {"name": "gather_disease_profile", "type": "CompoundDiseaseProfileTool"}
+    )
+
+
+def test_roman_and_arabic_subtype_numbers_are_the_same_disease():
+    assert _labels_match("mucopolysaccharidosis type I", "Mucopolysaccharidosis type 1")
+    assert _labels_match("mucopolysaccharidosis type I", "Mucopolysaccharidosis Type I")
+
+
+def test_different_subtype_numbers_are_different_diseases():
+    assert not _labels_match(
+        "mucopolysaccharidosis type I", "Mucopolysaccharidosis type 6"
+    )
+    assert not _labels_match("mucopolysaccharidosis type I", "Mucopolysaccharidosis IV")
+
+
+def test_orphanet_hit_is_chosen_by_name_not_by_rank():
+    result = {
+        "status": "success",
+        "data": {
+            "results": [
+                {"ORPHAcode": 583, "Preferred term": "Mucopolysaccharidosis type 6"},
+                {"ORPHAcode": 579, "Preferred term": "Mucopolysaccharidosis type 1"},
+            ]
+        },
+    }
+
+    parsed = _tool()._parse_orphanet(result, "mucopolysaccharidosis type I")
+
+    assert parsed["orpha_code"] == "579"
+    assert parsed["match"] == "exact"
+
+
+def test_orphanet_without_a_name_match_is_flagged_and_not_promoted():
+    result = {
+        "status": "success",
+        "data": {
+            "results": [
+                {"ORPHAcode": 583, "Preferred term": "Mucopolysaccharidosis type 6"}
+            ]
+        },
+    }
+    tool = _tool()
+
+    parsed = tool._parse_orphanet(result, "mucopolysaccharidosis type I")
+    assert parsed["match"] == "approximate"
+
+    profile = tool._build_profile(
+        "mucopolysaccharidosis type I",
+        {"orphanet": parsed, "ols": {}, "opentargets": {}},
+    )
+    assert "orphanet" not in profile["identifiers"]
+
+
+def test_only_label_matching_ontology_terms_become_identifiers():
+    sections = {
+        "orphanet": {},
+        "opentargets": {},
+        "ols": {
+            "terms": [
+                {
+                    "id": "NCIT:C85053",
+                    "label": "Mucopolysaccharidosis Type I",
+                    "ontology": "ncit",
+                },
+                {
+                    "id": "mesh:D009085",
+                    "label": "Mucopolysaccharidosis IV",
+                    "ontology": "mesh",
+                },
+                {
+                    "id": "ORDO:217085",
+                    "label": "Mucopolysaccharidosis type 2, severe form",
+                    "ontology": "ordo",
+                },
+            ]
+        },
+    }
+
+    profile = _tool()._build_profile("mucopolysaccharidosis type I", sections)
+
+    assert profile["identifiers"] == {"ncit": "NCIT:C85053"}

--- a/tests/unit/test_kegg_dblinks_pubchem_namespace.py
+++ b/tests/unit/test_kegg_dblinks_pubchem_namespace.py
@@ -1,0 +1,34 @@
+"""KEGG DBLINKS PubChem values are substance IDs, and must say so.
+
+KEGG deposits its records into PubChem as substances, so C05443's
+"PubChem: 7805" is SID 7805 (cholecalciferol, CID 5280795). Emitting it under
+the bare key "PubChem" invited callers to pass it to a CID-based tool, which
+answers with CID 7805 -- 1-bromo-4-methylbenzene -- as a plain success.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.kegg_ext_tool import _store_dblink
+
+pytestmark = pytest.mark.unit
+
+
+def test_pubchem_is_labelled_as_a_substance_id():
+    dblinks = {}
+    _store_dblink(dblinks, "PubChem", " 7805 ")
+
+    assert dblinks == {"PubChem_SID": "7805"}
+    assert "PubChem" not in dblinks
+
+
+def test_other_cross_references_keep_their_own_namespace():
+    dblinks = {}
+    _store_dblink(dblinks, "ChEBI", "28940")
+    _store_dblink(dblinks, "CAS", "67-97-0")
+
+    assert dblinks == {"ChEBI": "28940", "CAS": "67-97-0"}

--- a/tests/unit/test_ncbi_variation_placement_coordinates.py
+++ b/tests/unit/test_ncbi_variation_placement_coordinates.py
@@ -1,0 +1,68 @@
+"""NCBIVariation_rsid_lookup reports 1-based GRCh38 positions.
+
+dbSNP SPDI offsets are 0-based interbase. Passing them through under the name
+`position` put every variant one base 5' of its real location while the tool
+advertised "GRCh38 genomic coordinates": rs121965019 (IDUA c.1205G>A) came back
+as chr4:1002746 where ClinVar, Ensembl VEP and MyVariant all say 1002747.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.ncbi_variation_tool import (
+    _dedupe_genes,
+    _grch38_placement_from_spdi,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_substitution_position_is_one_based():
+    placement = _grch38_placement_from_spdi(
+        {
+            "seq_id": "NC_000004.12",
+            "position": 1002746,
+            "deleted_sequence": "G",
+            "inserted_sequence": "A",
+        }
+    )
+
+    assert placement["position"] == 1002747
+    assert placement["coordinate_system"] == "1-based"
+    assert placement["spdi_position"] == 1002746
+
+
+def test_insertion_anchors_on_the_preceding_base():
+    placement = _grch38_placement_from_spdi(
+        {
+            "seq_id": "NC_000019.10",
+            "position": 44908683,
+            "deleted_sequence": "",
+            "inserted_sequence": "T",
+        }
+    )
+
+    assert placement["position"] == 44908683
+    assert placement["spdi_position"] == 44908683
+
+
+def test_missing_position_is_passed_through_unchanged():
+    placement = _grch38_placement_from_spdi(
+        {"seq_id": "NC_000019.10", "position": None, "deleted_sequence": "T"}
+    )
+
+    assert placement["position"] is None
+
+
+def test_genes_repeated_per_allele_are_collapsed():
+    genes = [
+        {"gene": "IDUA", "name": "alpha-L-iduronidase", "gene_id": 3425},
+        {"gene": "IDUA", "name": "alpha-L-iduronidase", "gene_id": 3425},
+        {"gene": "APOE", "name": "apolipoprotein E", "gene_id": 348},
+    ]
+
+    assert [g["gene"] for g in _dedupe_genes(genes)] == ["IDUA", "APOE"]

--- a/tests/unit/test_orphanet_subtype_name_boundary.py
+++ b/tests/unit/test_orphanet_subtype_name_boundary.py
@@ -1,0 +1,98 @@
+"""Orphanet_get_genes must not resolve a parent code to a numerically
+adjacent disease.
+
+Orphanet curates gene associations on subtype codes, so Orphanet_get_genes
+falls back to searching the Orphadata orphacode list for entries whose
+preferred term contains the parent's name. That test was a bare substring
+check, and Orphanet's terms are numbered: "Mucopolysaccharidosis type 1"
+(ORPHA:579, MPS I) is a substring of "Mucopolysaccharidosis type 10"
+(ORPHA:662216, MPS X). MPS I therefore reported ARSK -- the MPS X gene, on a
+different chromosome -- instead of IDUA, as a plain success.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.orphanet_tool import OrphanetTool, _name_contains_disease
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize(
+    "candidate",
+    [
+        "Mucopolysaccharidosis type 10",
+        "Mucopolysaccharidosis type 11",
+        "Familial hyperaldosteronism type II",
+        "Pseudoachondroplasia",
+        "Ganglioneuroblastoma",
+    ],
+)
+def test_rejects_names_that_only_extend_the_same_token(candidate):
+    parent = {
+        "Mucopolysaccharidosis type 10": "Mucopolysaccharidosis type 1",
+        "Mucopolysaccharidosis type 11": "Mucopolysaccharidosis type 1",
+        "Familial hyperaldosteronism type II": "Familial hyperaldosteronism type I",
+        "Pseudoachondroplasia": "Achondroplasia",
+        "Ganglioneuroblastoma": "Neuroblastoma",
+    }[candidate]
+    assert not _name_contains_disease(candidate, parent)
+
+
+@pytest.mark.parametrize(
+    "candidate,parent",
+    [
+        ("Mucopolysaccharidosis type 4A", "Mucopolysaccharidosis type 4"),
+        ("Mucopolysaccharidosis type 2, severe form", "Mucopolysaccharidosis type 2"),
+        ("Marfan syndrome type 1", "Marfan syndrome"),
+        ("Neonatal Marfan syndrome", "Marfan syndrome"),
+        (
+            "Autosomal dominant Charcot-Marie-Tooth disease type 2N",
+            "Charcot-Marie-Tooth disease",
+        ),
+        ("Classical Ehlers-Danlos syndrome", "Ehlers-Danlos syndrome"),
+    ],
+)
+def test_accepts_real_subtype_names(candidate, parent):
+    assert _name_contains_disease(candidate, parent)
+
+
+def _json_response(payload, status_code=200):
+    response = MagicMock()
+    response.status_code = status_code
+    response.json.return_value = payload
+    response.raise_for_status = MagicMock()
+    return response
+
+
+@patch("tooluniverse.orphanet_tool.requests.get")
+def test_mps_one_does_not_borrow_the_mps_ten_gene(mock_get):
+    tool = OrphanetTool({"name": "Orphanet_get_genes", "fields": {}})
+    name_resp = _json_response(
+        {"ORPHAcode": 579, "Preferred term": "Mucopolysaccharidosis type 1"}
+    )
+    direct_resp = _json_response({}, status_code=404)
+    list_resp = _json_response(
+        {
+            "data": {
+                "results": [
+                    {
+                        "ORPHAcode": 662216,
+                        "Preferred term": "Mucopolysaccharidosis type 10",
+                    }
+                ]
+            }
+        }
+    )
+    mock_get.side_effect = [name_resp, direct_resp, list_resp]
+
+    result = tool._get_genes({"orpha_code": "579"})
+
+    assert result["status"] == "success"
+    assert result["data"]["genes"] == []
+    assert "subtype_sources" not in result["data"]

--- a/tests/unit/test_proteins_api_organism_widening.py
+++ b/tests/unit/test_proteins_api_organism_widening.py
@@ -79,6 +79,28 @@ class TestOrganismWidening(unittest.TestCase):
         params = tool._build_params({"query": "blaKPC", "taxid": "573"})
         self.assertEqual(params.get("taxid"), "573")
 
+    def test_caller_supplied_organism_survives_the_field_swap_retry(self):
+        """A gene->protein retry must not drop the caller's organism filter.
+
+        Rebuilding the retry parameters from scratch dropped organism=/taxid=,
+        so a wheat query ("FT1" in Triticum aestivum) retried against all of
+        UniProt and answered with an assassin-bug protein under a note
+        claiming no organism had been supplied.
+        """
+        tool = _make_tool()
+        tool.session.get = MagicMock(
+            side_effect=[_resp(200, []), _resp(200, [{"accession": "X"}])]
+        )
+
+        result = tool.run({"query": "FT1", "organism": "Triticum aestivum", "size": 2})
+
+        self.assertEqual(result["status"], "success")
+        self.assertNotIn("note", result)
+        retry_params = tool.session.get.call_args_list[1].kwargs["params"]
+        self.assertEqual(retry_params.get("organism"), "Triticum aestivum")
+        self.assertEqual(retry_params.get("protein"), "FT1")
+        self.assertNotIn("gene", retry_params)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Round 24 of the test harness. Three researcher personas (plant/agricultural genomics, nutrition & dietary exposure, rare-disease diagnostics) reported 30 issues; each was re-run through the CLI against a clean `origin/main` checkout before being queued.

The theme this round is different from #493-#496: not "the lookup came back empty", but **the lookup came back full, well-formed, and about a different entity**. Nothing in these responses gave a caller a reason to doubt them.

## Fixes

### `Orphanet_get_genes` answered MPS I with the MPS X gene
`{"orpha_code":"579"}` (Mucopolysaccharidosis type 1) returned `ARSK` at 5q15 — the MPS type X gene — with `subtype_sources: [{orpha_code: 662216, name: "Mucopolysaccharidosis type 10"}]`. Orphanet curates gene associations on subtype codes, so the tool falls back to scanning Orphadata's orphacode list for terms containing the parent's name, using a bare substring test. Orphanet's terms are numbered, and `"Mucopolysaccharidosis type 1"` is a substring of `"Mucopolysaccharidosis type 10"`.

The match now has to sit on a token boundary. Measured over all 4,245 gene-associated orphacodes, this removes matches for 43 parent names, and every one is the same false positive: `"Familial hyperaldosteronism type I"` → `type II/III/IV`, `"Mucolipidosis type II"` → `type III`, `"Achondroplasia"` → `"Pseudoachondroplasia"`, `"Neuroblastoma"` → `"Ganglioneuroblastoma"`. Real subtypes are all retained — `"Mucopolysaccharidosis type 4A"`, `"Mucopolysaccharidosis type 2, severe form"`, `"Neonatal Marfan syndrome"`, all 16 Ehlers-Danlos subtypes, all 71 Charcot-Marie-Tooth subtypes.

- Before: `ORPHA:579 → ["ARSK"]`
- After: `ORPHA:579 → []`; 580 → `IDS`, 582 → `GALNS, GLB1`, 583 → `ARSB`, 558 → `TGFBR1, TGFBR2, FBN1` all unchanged

### `gather_disease_profile` merged three diseases into one identifier block
`{"disease":"mucopolysaccharidosis type I"}` returned `orphanet: 583` (MPS VI), `mesh: D009085` (MPS IV) and `ordo: ORDO:217085` (MPS II severe form) together under one disease name, with `per_source.orphanet.name` literally reading `"Mucopolysaccharidosis type 6"`. Every source is a ranked search and the code took each one's first hit; Orphanet ranks MPS VI first for that query and the real MPS I fourth.

Cross-references are now only promoted to `identifiers` when their own label names the queried disease, folding Roman and Arabic subtype numerals together so `"type I"` still matches Orphanet's `"type 1"`. Non-matching hits stay visible in `per_source` with a `match` flag rather than being presented as the disease's IDs.

- Before: `{"orphanet":"583","efo":"MONDO_0001586","ncit":"NCIT:C85053","mesh":"mesh:D009085","ordo":"ORDO:217085"}`
- After: `{"orphanet":"579","efo":"MONDO_0001586","ncit":"NCIT:C85053"}`
- `Hurler syndrome`, `cystic fibrosis` and `Marfan syndrome` keep every identifier they had (and gain a few) — no recall loss

### `proteins_api_search` dropped the caller's organism on retry
`{"query":"FT1","organism":"Triticum aestivum","size":2}` returned `A0A023EZA4_TRIIF` — *Triatoma infestans*, an assassin bug — as a success, with the note *"No human matches found; the search was automatically widened to all organisms. Pass an explicit 'organism' … to scope it."* The caller had passed one. When the first search comes back empty the tool retries under the other field, and the retry parameters were rebuilt from scratch keeping only `format`/`size`/query, so `organism=`/`taxid=` never survived. `{"query":"FT1","taxid":"4565"}` and `{"query":"FT1","taxid":"9606"}` returned byte-identical results.

The retry now carries the original parameters forward and changes only the field being retried. The human-default widening (Feature-69A-007) is unaffected — it may still drop the `taxid=9606` this tool injects itself, and only that.

- Before: 2 hits, first is *Triatoma infestans*, echoed URL `?format=json&size=2&protein=FT1`
- After: `count: 0`, no note, echoed URL `?gene=FT1&size=2&organism=Triticum+aestivum&format=json`
- `{"query":"blaKPC","size":3}` still widens and still emits the note; `{"query":"CYP2D6","size":2}` still human-first

### KEGG cross-references handed out a substance ID labelled as PubChem
`KEGG_get_compound {"compound_id":"C05443"}` returned `dblinks.PubChem: "7805"`. KEGG deposits its records into PubChem as *substances*, so that is SID 7805 — and CID 7805 is 1-bromo-4-methylbenzene, C7H7Br. Feeding it to `PubChem_get_compound_properties_by_CID` returns that molecule as a clean success. Same for acrylamide: C01659 links `4808`, and CID 4808 is an unrelated C36 compound.

Verified against PubChem PUG-REST: `/substance/sid/7805/cids` → `5280795` (cholecalciferol) and `/substance/sid/4808/cids` → `6579` (acrylamide). The key is now `PubChem_SID`, and the schema documents how to resolve it.

### `NCBIVariation_rsid_lookup` reported every variant one base off
`grch38_placements[].position` was dbSNP's 0-based interbase SPDI offset, emitted under a description promising GRCh38 genomic coordinates. `rs121965019` (IDUA c.1205G>A, p.Trp402Ter) came back as chr4:1002746 where `ClinVar_get_variant_details`, `EnsemblVEP_annotate_hgvs` and `MyVariant_query_variants` all say 1002747; the tool's own documented example `rs429358` reported 44908683 rather than 44908684.

`position` is now 1-based, `coordinate_system` states the convention, and the raw offset is kept as `spdi_position`. The per-allele duplicate gene rows (IDUA listed twice for a single-gene variant) are collapsed.

### The integration suite rewrote 2,604 committed files
`tests/integration/test_coding_api_integration.py` called `generate_tools()` with no `output_dir`. That default is the committed `src/tooluniverse/tools/` tree, so simply running the integration suite rewrote 2,604 tracked wrapper files — including 119 that lose their `dict[str, Any]` return annotation — leaving a diff indistinguishable from real work. Every call site already allocates a temp dir and is commented *"Generate tools in temp directory"*; it just was not passed. Guarded with an AST test so it cannot silently regress.

## Verification

- New: `tests/unit/test_orphanet_subtype_name_boundary.py`, `test_disease_profile_identifier_match.py`, `test_ncbi_variation_placement_coordinates.py`, `test_kegg_dblinks_pubchem_namespace.py`, `test_coding_api_generation_is_sandboxed.py`, plus a case added to `test_proteins_api_organism_widening.py` — 29 tests, all passing
- Pre-existing suites re-run green: `test_orphanet_gene_fetch_failure_visibility`, `test_orphanet_classification_hierarchy`, `test_orphanet_invalid_code_validation`, `test_orphanet_gene_name_slash_encoding`, `test_proteins_api_accession_routing`, `test_proteins_api_organism_widening`, `test_genomic_variation_archives_depth`, `tests/tools/test_orphanet_tool.py`
- `tests/unit` was green on `origin/main` before the change and stays green
- Every fix re-verified live through `tu run` with the original failing arguments

No overlap with #493, #494, #495 or #496 — none of them touch `orphanet_tool.py`, `compound_disease_tool.py`, `kegg_ext_tool.py`, `ncbi_variation_tool.py` or `proteins_api_tool.py`.
