### PR TITLE
Fix Round 25: results that look complete or point at the wrong culprit

### DIFF
--- a/src/tooluniverse/bgee_tool.py
+++ b/src/tooluniverse/bgee_tool.py
@@ -16,7 +16,12 @@ from typing import Dict, Any
 from .base_tool import BaseTool
 from .tool_registry import register_tool
 
-BGEE_BASE_URL = "https://www.bgee.org/api"
+# NOTE: the trailing slash is REQUIRED. Requests to "https://www.bgee.org/api"
+# (no slash) never reach the Bgee application -- they are intercepted by the
+# site's Cloudflare WAF and answered with an HTTP 403 challenge page
+# ("cf-mitigated: challenge"). Only "https://www.bgee.org/api/?..." is routed
+# to the API. This is independent of User-Agent and of any request header.
+BGEE_BASE_URL = "https://www.bgee.org/api/"
 
 
 @register_tool("BgeeTool")
@@ -54,13 +59,42 @@ class BgeeTool(BaseTool):
         except requests.exceptions.HTTPError as e:
             return {
                 "status": "error",
-                "error": f"Bgee API HTTP error: {e.response.status_code}",
+                "error": self._http_error_message(e),
             }
         except Exception as e:
             return {
                 "status": "error",
                 "error": f"Unexpected error querying Bgee: {str(e)}",
             }
+
+    def _http_error_message(self, exc: requests.exceptions.HTTPError) -> str:
+        """Build an actionable message from a failed Bgee HTTP response.
+
+        Bgee answers bad requests with a JSON body that carries a human
+        readable ``message`` (e.g. an unknown gene ID yields HTTP 404 with
+        ``"Page not found."``), so surface that instead of a bare status code.
+        """
+        response = exc.response
+        status = getattr(response, "status_code", None)
+        api_message = ""
+        try:
+            body = response.json()
+            if isinstance(body, dict):
+                api_message = str(body.get("message", "")).strip()
+        except (ValueError, AttributeError):
+            # non-JSON body (HTML error page) or no response attached
+            api_message = ""
+
+        message = f"Bgee API HTTP error: {status}"
+        if api_message:
+            message += f" - {api_message}"
+        if status == 404:
+            message += (
+                " (check that the gene ID is a valid Ensembl ID present in Bgee"
+                " for the requested species, e.g. gene_id=ENSG00000141510 with"
+                " species_id=9606)"
+            )
+        return message
 
     def _query(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Route to appropriate Bgee endpoint."""

--- a/src/tooluniverse/chebi_tool.py
+++ b/src/tooluniverse/chebi_tool.py
@@ -20,6 +20,15 @@ from .tool_registry import register_tool
 
 CHEBI_BASE_URL = "https://www.ebi.ac.uk/chebi/backend/api/public"
 
+# advanced_search is server-side paginated at 15 hits per page and exposes the
+# page number as a 1-indexed query-string parameter (`?page=1` is the first
+# page and is byte-identical to omitting the parameter; `?page=0` and any page
+# beyond `number_pages` return a non-JSON error body). `limit` is clamped to
+# 100, so at most ceil(100 / 15) == 7 pages are ever needed; the cap below is
+# a hard stop that protects against a server that stops honouring `page`.
+_SEARCH_PAGE_SIZE = 15
+_SEARCH_MAX_PAGES = 8
+
 _HTML_TAG_RE = re.compile(r"<[^>]+>")
 
 
@@ -202,7 +211,11 @@ class ChEBITool(BaseTool):
 
         if limit is None:
             limit = 10
-        limit = min(limit, 100)
+        try:
+            limit = int(limit)
+        except (TypeError, ValueError):
+            limit = 10
+        limit = max(0, min(limit, 100))
 
         # Use advanced_search endpoint for better relevance
         url = f"{CHEBI_BASE_URL}/advanced_search/"
@@ -212,35 +225,90 @@ class ChEBITool(BaseTool):
             },
             "stars": [2, 3],
         }
-        response = requests.post(
-            url,
-            json=payload,
-            headers={"Content-Type": "application/json", "Accept": "application/json"},
-            timeout=self.timeout,
-        )
-        response.raise_for_status()
-        raw = response.json()
+        headers = {"Content-Type": "application/json", "Accept": "application/json"}
 
-        results = raw.get("results", [])
+        # The endpoint returns only one page (15 hits) per request, so a single
+        # POST can never satisfy limit > 15. Walk successive pages until we have
+        # `limit` compounds or the result set is exhausted.
         compounds = []
-        for hit in results[:limit]:
-            source = hit.get("_source", {})
-            # Strip HTML tags from name (ChEBI stores stereochemistry as HTML)
-            raw_name = source.get("name", "")
-            clean_name = re.sub(r"<[^>]+>", "", raw_name)
-            compounds.append(
-                {
-                    "chebi_accession": source.get("chebi_accession", ""),
-                    "name": clean_name,
-                    "formula": source.get("formula", None),
-                    "mass": source.get("mass", None),
-                    "stars": source.get("stars", None),
-                }
-            )
+        total_matches = None
+        number_pages = None
+        page = 1
+        pages_fetched = 0
+        while page <= _SEARCH_MAX_PAGES:
+            try:
+                response = requests.post(
+                    url,
+                    json=payload,
+                    params={"page": page},
+                    headers=headers,
+                    timeout=self.timeout,
+                )
+                response.raise_for_status()
+                raw = response.json()
+            except Exception:
+                # Never discard the pages already in hand: a failure while
+                # fetching page N > 1 degrades to "fewer results than asked
+                # for", not to an error. Only a failed first page is fatal.
+                if page == 1:
+                    raise
+                break
+
+            pages_fetched += 1
+
+            if not isinstance(raw, dict):
+                break
+
+            # `total` / `number_pages` are informational and may be absent on
+            # some responses; fall back to single-page behaviour rather than
+            # crashing or looping forever.
+            if total_matches is None and isinstance(raw.get("total"), int):
+                total_matches = raw["total"]
+            if number_pages is None and isinstance(raw.get("number_pages"), int):
+                number_pages = raw["number_pages"]
+
+            results = raw.get("results", [])
+            if not isinstance(results, list):
+                results = []
+
+            for hit in results:
+                source = hit.get("_source", {}) if isinstance(hit, dict) else {}
+                if not isinstance(source, dict):
+                    source = {}
+                compounds.append(
+                    {
+                        "chebi_accession": source.get("chebi_accession", ""),
+                        # Strip HTML tags from name (ChEBI stores
+                        # stereochemistry as HTML).
+                        "name": _strip_html(source.get("name", "")),
+                        "formula": source.get("formula", None),
+                        "mass": source.get("mass", None),
+                        "stars": source.get("stars", None),
+                    }
+                )
+
+            if len(compounds) >= limit:
+                break
+            if not results:
+                break
+            if number_pages is not None:
+                if page >= number_pages:
+                    break
+            elif len(results) < _SEARCH_PAGE_SIZE:
+                # No page metadata and a short page: this was the last one.
+                break
+            page += 1
+
+        compounds = compounds[:limit]
 
         result = {
             "query": query,
+            # `result_count` keeps its original meaning: how many compounds are
+            # in `compounds`. `total_matches` is how many the query matches in
+            # ChEBI overall, so a caller can distinguish "10 of 116" from
+            # "10 exist". It is None when the API omits the count.
             "result_count": len(compounds),
+            "total_matches": total_matches,
             "compounds": compounds,
         }
 
@@ -251,6 +319,7 @@ class ChEBITool(BaseTool):
                 "source": "ChEBI",
                 "query": query,
                 "endpoint": "advanced_search",
+                "pages_fetched": pages_fetched,
             },
         }
 

--- a/src/tooluniverse/clinvar_tool.py
+++ b/src/tooluniverse/clinvar_tool.py
@@ -22,6 +22,105 @@ _CLINSIG_PROP_ALIASES = {
     "uncertain significance": "vus",
 }
 
+# The clinical-significance classes ClinVar's Entrez index ACTUALLY accepts.
+# Enumerated by live-probing every documented germline/oncogenicity class
+# through the exact clause this module builds
+# (`"clinsig <v>"[Filter] OR clinsig_<v>[prop]`, plus the alias above) against
+# db=clinvar with no other term, 2026-08. Only these returned a non-zero,
+# non-parenthesised (i.e. index-recognised) translation:
+#   pathogenic 256608 | likely pathogenic 165559 | uncertain significance
+#   2367938 | vus 2368057 | likely benign 1165994 | benign 281217 |
+#   established risk allele 6 | likely risk allele 119 | uncertain risk allele
+#   180 | drug response 2612 | not provided 7616 | other 2209 |
+#   risk factor 520
+# Documented-but-unindexed spellings ("Affects", "association", "protective",
+# "confers sensitivity", "Conflicting classifications of pathogenicity",
+# "Oncogenic", "Likely oncogenic", "Pathogenic, low penetrance", ...) all came
+# back 0 with Entrez wrapping the term in parentheses -- its signal for "this
+# term is not in the index". Accepting them would paste an unmatchable token
+# into the query and return a silent, filtered-to-nothing success, which is
+# exactly the failure this list exists to prevent.
+_CLINSIG_ACCEPTED = (
+    "Pathogenic",
+    "Likely pathogenic",
+    "Uncertain significance",
+    "VUS",
+    "Likely benign",
+    "Benign",
+    "Established risk allele",
+    "Likely risk allele",
+    "Uncertain risk allele",
+    "drug response",
+    "risk factor",
+    "not provided",
+    "other",
+)
+_CLINSIG_ACCEPTED_NORMALIZED = {v.lower() for v in _CLINSIG_ACCEPTED}
+
+
+def _normalize_clinsig(value: Any) -> list:
+    """Split a clinical-significance value on '/' and normalize each component
+    exactly the way the query builder does (lowercase, underscores/hyphens ->
+    spaces), so validation can never accept a spelling the builder would then
+    mangle. No accepted class contains a hyphen, and sibling variant tools emit
+    hyphenated spellings (dbSNP reports "risk-factor"), so folding them keeps a
+    chained call working instead of silently filtering to nothing."""
+    return [
+        re.sub(r"\s+", " ", re.sub(r"[_-]", " ", comp.strip().lower()))
+        for comp in str(value).split("/")
+        if comp.strip()
+    ]
+
+
+def _clinsig_query_clause(components: list) -> str:
+    """Build the Entrez clause for already-normalized clinsig components.
+
+    Single-word values are indexed under `"clinsig <v>"[Filter]`, compound ones
+    under `clinsig_<v_with_underscores>[prop]`, and a few classes under a
+    different NCBI token entirely (VUS); OR all applicable forms so a valid
+    class is never a silent false-empty. Multiple components (from a '/'
+    aggregate class) are OR'd into their union.
+    """
+    clauses = []
+    for comp in components:
+        forms = f'"clinsig {comp}"[Filter] OR clinsig_{comp.replace(" ", "_")}[prop]'
+        alias = _CLINSIG_PROP_ALIASES.get(comp)
+        if alias:
+            forms += f" OR clinsig_{alias}[prop]"
+        clauses.append(f"({forms})")
+    if not clauses:
+        return ""
+    return "(" + " OR ".join(clauses) + ")" if len(clauses) > 1 else clauses[0]
+
+
+def _invalid_clinsig_error(param_name: str, raw_value: Any, invalid: list) -> dict:
+    """Reject an unrecognised clinical-significance value at the input, naming
+    the offending PARAMETER.
+
+    Previously such a value was pasted straight into the Entrez term, matched
+    nothing, and the zero-result response then blamed the *gene* symbol -- so
+    `{"gene": "TP53", "clinical_significance": "Banana"}` told the caller to
+    go re-verify TP53, the one input that was never wrong.
+    """
+    return {
+        "status": "error",
+        "error": (
+            f"Unrecognized {param_name} value(s): "
+            + ", ".join(repr(i) for i in invalid)
+            + f" (from {str(raw_value)!r}). No filter was applied and no search "
+            "was run -- an unrecognized class matches nothing in ClinVar's "
+            "index, which would look like 'this gene has no such variants'. "
+            "ClinVar's clinical-significance index accepts only: "
+            + ", ".join(_CLINSIG_ACCEPTED)
+            + ". Case-insensitive; underscores are treated as spaces "
+            "(e.g. 'likely_pathogenic'). Combine two classes with '/' to search "
+            "their union (e.g. 'Pathogenic/Likely pathogenic')."
+        ),
+        "parameter": param_name,
+        "invalid_values": invalid,
+        "valid_values": list(_CLINSIG_ACCEPTED),
+    }
+
 
 class ClinVarRESTTool(BaseTool):
     """Base class for ClinVar REST API tools."""
@@ -184,8 +283,26 @@ class ClinVarSearchVariants(ClinVarRESTTool):
         # Normalize aliases before dispatch
         if not arguments.get("gene") and arguments.get("gene_symbol"):
             arguments = dict(arguments, gene=arguments["gene_symbol"])
+        _clnsig_param = "clinical_significance"
         if not arguments.get("clinical_significance") and arguments.get("significance"):
             arguments = dict(arguments, clinical_significance=arguments["significance"])
+            _clnsig_param = "significance"
+        # Validate the clinical-significance filter BEFORE anything is queried:
+        # an unrecognized class used to be pasted into the Entrez term, match
+        # nothing, and come back as a `status: success` with 0 results whose
+        # hint blamed the (perfectly valid) gene symbol instead.
+        clnsig_components = []
+        if str(arguments.get("clinical_significance") or "").strip():
+            clnsig_components = _normalize_clinsig(arguments["clinical_significance"])
+            invalid_clnsig = [
+                c for c in clnsig_components if c not in _CLINSIG_ACCEPTED_NORMALIZED
+            ]
+            if invalid_clnsig:
+                return _invalid_clinsig_error(
+                    _clnsig_param,
+                    arguments["clinical_significance"],
+                    invalid_clnsig,
+                )
         # An rsID (e.g. rs4244285) passed as `query` was aliased to `condition`
         # and searched as a DISEASE term ('rs4244285[dis]'), silently returning
         # 0 -- but ClinVar's free-text index DOES match a bare rsID (confirmed
@@ -373,26 +490,13 @@ class ClinVarSearchVariants(ClinVarRESTTool):
             # value. Treat "/" as OR and expand to the individual clinsig classes
             # (the clinically-actionable union), each via the proven
             # [Filter]-OR-[prop] path.
-            _raw_clnsig = str(arguments["clinical_significance"])
-            _components = [c.strip() for c in _raw_clnsig.split("/") if c.strip()]
-            compound_clnsig = len(_components) > 1
-            _clauses = []
-            for _comp in _components:
-                _c = _comp.lower().replace("_", " ")
-                _c_prop = _c.replace(" ", "_")
-                _forms = f'"clinsig {_c}"[Filter] OR clinsig_{_c_prop}[prop]'
-                # Some classes index under a different NCBI token (e.g. VUS);
-                # OR it in so a valid class is never a silent false-empty.
-                _alias = _CLINSIG_PROP_ALIASES.get(_c)
-                if _alias:
-                    _forms += f" OR clinsig_{_alias}[prop]"
-                _clauses.append(f"({_forms})")
-            if _clauses:
-                query_parts.append(
-                    "(" + " OR ".join(_clauses) + ")"
-                    if len(_clauses) > 1
-                    else _clauses[0]
-                )
+            # Values were normalized and validated against the live-verified
+            # accepted set up front (see _CLINSIG_ACCEPTED), so every component
+            # reaching here is known to exist in ClinVar's index.
+            compound_clnsig = len(clnsig_components) > 1
+            _clause = _clinsig_query_clause(clnsig_components)
+            if _clause:
+                query_parts.append(_clause)
 
         # Fix-R5D-1/R8C-1: a caller-supplied param that doesn't match any
         # recognized name/alias (e.g. "gene_name" instead of "gene") was
@@ -573,14 +677,58 @@ class ClinVarSearchVariants(ClinVarRESTTool):
             # the word, which would silently swap a false-empty for a
             # false-positive result set -- worse than reporting nothing.
             # Surface the ambiguity instead of guessing.
-            response_data["zero_result_hint"] = (
-                f"No ClinVar records matched gene '{arguments['gene']}'. "
-                "ClinVar's gene index only recognizes the current official "
-                "HGNC symbol (e.g. 'DMD', not the protein name 'dystrophin' "
-                "or an outdated/misspelled symbol) -- verify the symbol "
-                "(e.g. via HGNC_search_genes or NCBIDatasets_get_gene) "
-                "before concluding this gene has no reported variants."
+            #
+            # ...but only blame the GENE when the gene is actually what failed.
+            # When other filters narrowed the query, a 0 count says nothing
+            # about the symbol, and the hint used to send callers off to
+            # re-verify a symbol that was never the problem. Establish the
+            # facts with one cheap count-only query on the bare gene term
+            # before attributing the empty result to anything.
+            other_filters = [
+                name
+                for name, present in (
+                    ("condition", bool(arguments.get("condition"))),
+                    ("variant_id", "variant_id" in arguments),
+                    ("variant_name", bool(arguments.get("variant_name"))),
+                    ("rsid", bool(arguments.get("rsid"))),
+                    ("raw_term", bool(arguments.get("raw_term"))),
+                    (_clnsig_param, bool(clnsig_components)),
+                )
+                if present
+            ]
+            gene_only_count = (
+                self._count_for_term(f"{gene}[gene]") if other_filters else None
             )
+            if other_filters and gene_only_count is None:
+                response_data["zero_result_hint"] = (
+                    f"No ClinVar records matched gene '{arguments['gene']}' "
+                    f"combined with {', '.join(other_filters)}. The gene symbol "
+                    "could not be checked on its own (follow-up query failed), "
+                    "so it is unknown whether the symbol or the other filter(s) "
+                    "produced the empty result -- retry with the filters removed "
+                    "to tell them apart."
+                )
+            elif gene_only_count:
+                response_data["gene_only_match_count"] = gene_only_count
+                response_data["zero_result_hint"] = (
+                    f"The gene symbol '{arguments['gene']}' is fine: it matches "
+                    f"{gene_only_count} ClinVar record(s) on its own. The empty "
+                    f"result comes from the other filter(s) -- "
+                    f"{', '.join(other_filters)} -- which no record for this gene "
+                    "satisfies. Relax or correct them (or drop them to see the "
+                    "gene's full record set) rather than re-checking the symbol."
+                )
+            else:
+                if gene_only_count is not None:
+                    response_data["gene_only_match_count"] = gene_only_count
+                response_data["zero_result_hint"] = (
+                    f"No ClinVar records matched gene '{arguments['gene']}'. "
+                    "ClinVar's gene index only recognizes the current official "
+                    "HGNC symbol (e.g. 'DMD', not the protein name 'dystrophin' "
+                    "or an outdated/misspelled symbol) -- verify the symbol "
+                    "(e.g. via HGNC_search_genes or NCBIDatasets_get_gene) "
+                    "before concluding this gene has no reported variants."
+                )
         if compound_clnsig:
             response_data["clinical_significance_note"] = (
                 "The '/' in the requested clinical_significance was treated as OR: "
@@ -589,6 +737,23 @@ class ClinVarSearchVariants(ClinVarRESTTool):
                 "'Pathogenic/Likely pathogenic' review class."
             )
         return {"status": "success", "data": response_data}
+
+    def _count_for_term(self, term: str) -> "int | None":
+        """Count-only eSearch for `term` (retmax=0, no summaries fetched).
+
+        Used to establish, rather than assume, which input caused an empty
+        result. Best-effort: returns None on any failure, never raises.
+        """
+        try:
+            result = self._make_request(
+                self.endpoint,
+                {"db": "clinvar", "term": term, "retmode": "json", "retmax": 0},
+            )
+            if result.get("status") != "success":
+                return None
+            return int(result["data"]["esearchresult"]["count"])
+        except (KeyError, TypeError, ValueError, AttributeError):
+            return None
 
     def _resolve_deprecated_gene_symbol(self, gene: str) -> Optional[str]:
         """Look up `gene` in NCBI's own gene database (which tracks
@@ -759,7 +924,21 @@ def clinvar_variants_overlapping(
     hi = int(end) + int(margin)
     term = f"{chrom}[chr] AND {lo}:{hi}[{tag}]"
     if significance:
-        term += f' AND "{significance}"[clinsig]'
+        # [clinsig] is not a ClinVar eSearch field -- Entrez silently degraded
+        # it to [All Fields] (confirmed live: chr17 BRCA1 window, 15508 hits
+        # unfiltered vs 13782 with '"Pathogenic"[clinsig]', i.e. a free-text
+        # match that also keeps "Likely pathogenic" and "Conflicting
+        # classifications of pathogenicity" records). Use the same verified
+        # [Filter]/[prop] clause the gene search uses. Values are validated by
+        # the caller against _CLINSIG_ACCEPTED.
+        components = (
+            significance
+            if isinstance(significance, list)
+            else _normalize_clinsig(significance)
+        )
+        clause = _clinsig_query_clause(components)
+        if clause:
+            term += f" AND {clause}"
 
     es = session.get(
         "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi",
@@ -843,6 +1022,25 @@ class ClinVarSearchByRegion(ClinVarRESTTool):
                 "status": "error",
                 "error": "Provide chrom/start/end, or region like 'chr7:155593770-155593780'.",
             }
+        # Same input validation as ClinVar_search_variants: an unrecognized
+        # class must not reach the query, where it would silently filter the
+        # region's variants down to nothing under a `status: success`.
+        clnsig_param = (
+            "clinical_significance"
+            if arguments.get("clinical_significance")
+            else "significance"
+        )
+        raw_clnsig = arguments.get("clinical_significance") or arguments.get(
+            "significance"
+        )
+        clnsig_components = []
+        if str(raw_clnsig or "").strip():
+            clnsig_components = _normalize_clinsig(raw_clnsig)
+            invalid_clnsig = [
+                c for c in clnsig_components if c not in _CLINSIG_ACCEPTED_NORMALIZED
+            ]
+            if invalid_clnsig:
+                return _invalid_clinsig_error(clnsig_param, raw_clnsig, invalid_clnsig)
         try:
             result = clinvar_variants_overlapping(
                 self.session,
@@ -851,8 +1049,7 @@ class ClinVarSearchByRegion(ClinVarRESTTool):
                 int(end),
                 assembly=arguments.get("assembly", "GRCh37"),
                 margin=int(arguments.get("margin", 2_000_000)),
-                significance=arguments.get("clinical_significance")
-                or arguments.get("significance"),
+                significance=clnsig_components or None,
                 max_results=int(arguments.get("max_results", 50)),
                 timeout=self.timeout,
             )

--- a/src/tooluniverse/data/chebi_tools.json
+++ b/src/tooluniverse/data/chebi_tools.json
@@ -112,7 +112,7 @@
   },
   {
     "name": "ChEBI_search",
-    "description": "Search the ChEBI database for chemical entities by name, formula, or keyword. Uses Elasticsearch-powered full-text search across compound names, synonyms, definitions, and formulas. Returns matching compounds with IDs, names, formulas, and masses. Note: smiles and inchikey are not available from the search endpoint (use ChEBI_get_compound for structural data). Compound names are HTML-stripped. ChEBI contains 195,000+ chemical entities of biological interest.",
+    "description": "Search the ChEBI database for chemical entities by name, formula, or keyword. Uses Elasticsearch-powered full-text search across compound names, synonyms, definitions, and formulas. Returns matching compounds with IDs, names, formulas, and masses. Note: smiles and inchikey are not available from the search endpoint (use ChEBI_get_compound for structural data). Compound names are HTML-stripped. ChEBI contains 195,000+ chemical entities of biological interest. The underlying API paginates at 15 hits per page; this tool fetches as many pages as needed to satisfy 'limit' and reports the full size of the match set as 'total_matches'.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -125,7 +125,7 @@
             "integer",
             "null"
           ],
-          "description": "Maximum number of results to return. Default: 10. Max: 100."
+          "description": "Maximum number of compounds to return. Default: 10. Max: 100. Values above 15 are served by fetching additional API pages, so they cost extra requests."
         }
       },
       "required": [
@@ -155,7 +155,15 @@
               "type": "string"
             },
             "result_count": {
-              "type": "integer"
+              "type": "integer",
+              "description": "Number of compounds actually returned in 'compounds' (at most 'limit')."
+            },
+            "total_matches": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Total number of compounds in ChEBI matching the query, which may be far larger than result_count. Null when the API does not report a count. Compare against result_count to tell '10 returned of 116 matching' from 'only 10 exist'."
             },
             "compounds": {
               "type": "array",

--- a/src/tooluniverse/data/clinvar_tools.json
+++ b/src/tooluniverse/data/clinvar_tools.json
@@ -41,7 +41,7 @@
                 },
                 "clinical_significance": {
                     "type": "string",
-                    "description": "Filter by clinical significance (e.g., 'Pathogenic', 'Likely pathogenic', 'Benign', 'Uncertain significance', 'VUS'). Applied client-side after retrieval."
+                    "description": "Filter by clinical significance. Must be one of the classes ClinVar's index actually recognizes: 'Pathogenic', 'Likely pathogenic', 'Uncertain significance', 'VUS', 'Likely benign', 'Benign', 'Established risk allele', 'Likely risk allele', 'Uncertain risk allele', 'drug response', 'risk factor', 'not provided', 'other'. Case-insensitive; underscores/hyphens are treated as spaces. Combine two classes with '/' to search their union (e.g. 'Pathogenic/Likely pathogenic'). Any other value is rejected with an error rather than silently filtering the results to nothing."
                 },
                 "gene_symbol": {
                     "type": [
@@ -55,7 +55,7 @@
                         "string",
                         "null"
                     ],
-                    "description": "Alias for clinical_significance (e.g., \"pathogenic\", \"benign\", \"uncertain_significance\")."
+                    "description": "Alias for clinical_significance (e.g., \"pathogenic\", \"benign\", \"uncertain_significance\"). Same accepted value set and same validation as clinical_significance."
                 },
                 "query": {
                     "type": [

--- a/src/tooluniverse/data/opentarget_tools.json
+++ b/src/tooluniverse/data/opentarget_tools.json
@@ -5182,20 +5182,33 @@
     },
     {
         "name": "OpenTargets_get_target_expression_by_ensemblID",
-        "description": "Retrieve baseline expression summary statistics for a target across tissues and cell types (GTEx, Tabula Sapiens, and other bulk/single-cell sources) by Ensembl gene ID. Each row gives the data source, tissue (and cell type for single-cell data), value unit, and min/q1/median/q3/max distribution stats plus specificity/distribution scores. Well-studied targets can return hundreds to thousands of rows across sources; filter client-side by datasourceId if needed. Use to profile where a target is normally expressed.",
+        "description": "Retrieve baseline expression summary statistics for a target across tissues and cell types (GTEx, Tabula Sapiens, and other bulk/single-cell sources) by Ensembl gene ID. Each row gives the data source, tissue (and cell type for single-cell data), value unit, and min/q1/median/q3/max distribution stats plus specificity/distribution scores. Results are PAGINATED: a target typically has ~1400 rows across sources and only `size` of them are returned per call (default 250, max 3000 per the API). `baselineExpression.count` is the total, `baselineExpression.returned` is how many came back, and `baselineExpression.truncated` is true when rows remain unfetched; a truncation note is added to metadata. Rows from a given datasource are interleaved throughout the full result, so a partial page is NOT a complete view of any one source — set size=3000 to retrieve every row before filtering client-side by datasourceId. Use to profile where a target is normally expressed.",
         "parameter": {
             "type": "object",
             "properties": {
                 "ensemblId": {
                     "type": "string",
                     "description": "Ensembl gene ID of the target (e.g., 'ENSG00000146648' for EGFR)."
+                },
+                "size": {
+                    "type": "integer",
+                    "description": "Number of expression rows to return per page (default 250, max 3000). Targets carry ~1400 rows spread across all datasources, so use size=3000 to fetch the complete profile in one call; values above 3000 are clamped because the API rejects them.",
+                    "default": 250,
+                    "minimum": 1,
+                    "maximum": 3000
+                },
+                "index": {
+                    "type": "integer",
+                    "description": "0-based page index (default 0). Use with `size` to walk the remaining rows when `baselineExpression.truncated` is true.",
+                    "default": 0,
+                    "minimum": 0
                 }
             },
             "required": [
                 "ensemblId"
             ]
         },
-        "query_schema": "\n      query targetExpression($ensemblId: String!) {\n        target(ensemblId: $ensemblId) {\n          id\n          approvedSymbol\n          baselineExpression {\n            count\n            rows {\n              datasourceId\n              datatypeId\n              unit\n              min\n              q1\n              median\n              q3\n              max\n              specificity_score\n              distribution_score\n              tissueBiosample { biosampleId biosampleName }\n              celltypeBiosample { biosampleId biosampleName }\n            }\n          }\n        }\n      }\n    ",
+        "query_schema": "\n      query targetExpression($ensemblId: String!, $index: Int = 0, $size: Int = 250) {\n        target(ensemblId: $ensemblId) {\n          id\n          approvedSymbol\n          baselineExpression(page: {index: $index, size: $size}) {\n            count\n            rows {\n              datasourceId\n              datatypeId\n              unit\n              min\n              q1\n              median\n              q3\n              max\n              specificity_score\n              distribution_score\n              tissueBiosample { biosampleId biosampleName }\n              celltypeBiosample { biosampleId biosampleName }\n            }\n          }\n        }\n      }\n    ",
         "label": [
             "Target",
             "Expression",
@@ -5228,7 +5241,28 @@
                                     "type": "object",
                                     "properties": {
                                         "count": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Total expression rows available for this target across all pages."
+                                        },
+                                        "returned": {
+                                            "type": "integer",
+                                            "description": "Number of rows actually present in `rows` for this page."
+                                        },
+                                        "truncated": {
+                                            "type": "boolean",
+                                            "description": "True when `returned` plus the rows skipped by `index` is less than `count`, i.e. rows remain unfetched. Re-query with a larger `size` or a higher `index`."
+                                        },
+                                        "page": {
+                                            "type": "object",
+                                            "description": "The pagination actually applied to this request.",
+                                            "properties": {
+                                                "index": {
+                                                    "type": "integer"
+                                                },
+                                                "size": {
+                                                    "type": "integer"
+                                                }
+                                            }
                                         },
                                         "rows": {
                                             "type": "array",

--- a/src/tooluniverse/data/xml_tools.json
+++ b/src/tooluniverse/data/xml_tools.json
@@ -2632,8 +2632,14 @@
         "synonyms": "db:synonyms/db:synonym",
         "cas_number": "db:cas-number",
         "unii": "db:unii",
-        "molecular_formula": "db:experimental-properties/db:property[db:kind='Molecular Formula']/db:value",
-        "molecular_weight": "db:experimental-properties/db:property[db:kind='Molecular Weight']/db:value",
+        "molecular_formula": [
+          "db:calculated-properties/db:property[db:kind='Molecular Formula']/db:value",
+          "db:experimental-properties/db:property[db:kind='Molecular Formula']/db:value"
+        ],
+        "molecular_weight": [
+          "db:calculated-properties/db:property[db:kind='Molecular Weight']/db:value",
+          "db:experimental-properties/db:property[db:kind='Molecular Weight']/db:value"
+        ],
         "melting_point": "db:experimental-properties/db:property[db:kind='Melting Point']/db:value",
         "water_solubility": "db:experimental-properties/db:property[db:kind='Water Solubility']/db:value",
         "isoelectric_point": "db:experimental-properties/db:property[db:kind='Isoelectric Point']/db:value",

--- a/src/tooluniverse/graphql_tool.py
+++ b/src/tooluniverse/graphql_tool.py
@@ -17,6 +17,12 @@ logger = logging.getLogger(__name__)
 # issues hundreds of sequential requests and can run for many minutes.
 _DISEASE_TARGET_SCORE_TIME_BUDGET_S = 25.0
 
+# OpenTargets rejects a baselineExpression page size above 3000 with a
+# "pagination error" (probed live against the v4 API: size=3000 succeeds,
+# size=5000 returns "the size must be between 0 and 3000"). Clamp rather than
+# let a caller's optimistic size turn into an opaque API failure.
+_OT_EXPRESSION_MAX_PAGE_SIZE = 3000
+
 
 def validate_query(query_str, schema_str):
     try:
@@ -362,7 +368,57 @@ class OpentargetTool(GraphQLTool):
                     "Try passing efoId directly (e.g. MONDO_0005011 for Crohn disease).",
                 }
 
+        # OpenTargets_get_target_expression_by_ensemblID paginates
+        # baselineExpression. Pin the effective page here (clamped to what the
+        # API accepts) so the post-processing below can report "N of COUNT"
+        # instead of leaving the caller to compare `count` against len(rows).
+        _is_expression_tool = (
+            self.tool_config.get("name")
+            == "OpenTargets_get_target_expression_by_ensemblID"
+        )
+        if _is_expression_tool:
+            _size = arguments.get("size")
+            if not isinstance(_size, int) or isinstance(_size, bool) or _size < 1:
+                _size = self.parameters.get("size", {}).get("default", 250)
+            arguments["size"] = min(int(_size), _OT_EXPRESSION_MAX_PAGE_SIZE)
+            _index = arguments.get("index")
+            if not isinstance(_index, int) or isinstance(_index, bool) or _index < 0:
+                _index = 0
+            arguments["index"] = int(_index)
+
         result = super().run(arguments)
+
+        # Make baselineExpression truncation explicit. The API's default page
+        # size is 25 and the query previously passed no `page` argument at all,
+        # so a target with 1409 rows returned 25 of them with `count: 1409` as
+        # the only (easily missed) hint -- e.g. for NLRP7 (ENSG00000167634) the
+        # 25 delivered rows held exactly one GTEx tissue and omitted testis,
+        # its highest-expressing GTEx tissue. Report returned/truncated/page
+        # so a caller can tell "250 of 1409" from "1409 of 1409" directly.
+        if _is_expression_tool and result.get("status") == "success":
+            _target = result.get("data", {}).get("target") or {}
+            _expr = _target.get("baselineExpression")
+            if isinstance(_expr, dict):
+                _rows = _expr.get("rows")
+                _returned = len(_rows) if isinstance(_rows, list) else 0
+                _count = _expr.get("count")
+                _index = arguments.get("index", 0)
+                _size = arguments.get("size", 250)
+                _expr["returned"] = _returned
+                _expr["page"] = {"index": _index, "size": _size}
+                _fetched_through = _index * _size + _returned
+                _truncated = isinstance(_count, int) and _fetched_through < _count
+                _expr["truncated"] = _truncated
+                if _truncated:
+                    result.setdefault("metadata", {})["note"] = (
+                        f"PARTIAL RESULT: {_returned} of {_count} baseline "
+                        f"expression rows returned (page index={_index}, "
+                        f"size={_size}). Rows from any one datasource (e.g. "
+                        "gtex) are interleaved across the full result, so this "
+                        "page is not a complete view of any single source. "
+                        f"Re-query with size={_OT_EXPRESSION_MAX_PAGE_SIZE} to "
+                        "get every row, or advance `index` to page through."
+                    )
 
         # Add note when IntOGen evidence count is 0 (Feature-122B-002).
         # Fix-R31D-3: this note is IntOGen-specific but was applied to every

--- a/src/tooluniverse/molecule_2d_tool.py
+++ b/src/tooluniverse/molecule_2d_tool.py
@@ -147,17 +147,19 @@ class Molecule2DTool(VisualizationTool):
         """Resolve molecule name to SMILES using PubChem."""
         try:
             # Use PubChem PUG REST API
+            # PubChem renamed "IsomericSMILES" to "SMILES"; accept either key
+            # so the resolver keeps working against both response shapes.
             url = (
                 f"https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/name/"
-                f"{name}/property/IsomericSMILES/JSON"
+                f"{name}/property/SMILES/JSON"
             )
             response = requests.get(url, timeout=10)
             if response.status_code == 200:
                 data = response.json()
                 if "PropertyTable" in data and "Properties" in data["PropertyTable"]:
                     props = data["PropertyTable"]["Properties"]
-                    if props and "IsomericSMILES" in props[0]:
-                        return props[0]["IsomericSMILES"]
+                    if props:
+                        return props[0].get("SMILES") or props[0].get("IsomericSMILES")
         except Exception:
             pass
         return None

--- a/src/tooluniverse/pubmed_tool.py
+++ b/src/tooluniverse/pubmed_tool.py
@@ -8,6 +8,67 @@ from .http_utils import request_with_retry
 from .tool_registry import register_tool
 
 
+def _clean_doi(value: Any) -> str:
+    """Normalize a raw DOI string: drop any display prefix and trailing dot."""
+    text = str(value or "").strip()
+    if text[:4].lower() == "doi:":
+        text = text[4:].strip()
+    return text.rstrip(".")
+
+
+def _doi_from_articleids(articleids: Any) -> str:
+    """Pull the DOI out of an esummary ``articleids`` list.
+
+    This is the structured, canonical location: NCBI stores a bare
+    ``{"idtype": "doi", "value": "10.x/y"}`` entry with no display prefix
+    and no other identifier mixed in.
+    """
+    for aid in articleids or []:
+        if isinstance(aid, dict) and aid.get("idtype") == "doi":
+            doi = _clean_doi(aid.get("value"))
+            if doi:
+                return doi
+    return ""
+
+
+def _doi_from_elocationid(elocationid: Any) -> str:
+    """Pull the DOI out of an esummary ``elocationid`` display string.
+
+    Handles ``"doi: 10.1234/abc"`` and the mixed preprint form
+    ``"pii: 2026.02.14.705936. doi: 10.64898/2026.02.14.705936"``.
+    """
+    text = str(elocationid or "")
+    lowered = text.lower()
+    if "doi:" not in lowered:
+        return ""
+    # Take the first token after "doi:" that contains '/' (valid DOI structure).
+    doi_part = text[lowered.index("doi:") + 4 :].strip()
+    for token in doi_part.split():
+        if "/" in token:
+            return token.rstrip(".")
+    return ""
+
+
+def _extract_doi(article_data: dict[str, Any]) -> str:
+    """Extract the DOI from a PubMed esummary record.
+
+    Fix-R25: the DOI used to be parsed *only* out of ``elocationid``, which
+    NCBI leaves empty for essentially every record published before ~2008 --
+    so ``doi``/``doi_url`` came back null for the whole older literature even
+    though the DOI was sitting in ``articleids`` in the very same response
+    (confirmed live for PMIDs 15720521, 17354009, 15500562, 14765742,
+    14627096, 5794093). ``articleids`` is preferred over ``elocationid``
+    because it is the structured field: it is populated for both old and new
+    records, its value needs no parsing, and it can never be confused with the
+    ``pii`` that NCBI packs into the same ``elocationid`` display string.
+    ``elocationid`` is kept as a fallback for records that carry one but no
+    ``doi`` articleid.
+    """
+    return _doi_from_articleids(
+        article_data.get("articleids")
+    ) or _doi_from_elocationid(article_data.get("elocationid"))
+
+
 @register_tool("PubMedRESTTool")
 class PubMedRESTTool(BaseRESTTool):
     """Generic REST tool for PubMed E-utilities (efetch, elink).
@@ -163,19 +224,7 @@ class PubMedRESTTool(BaseRESTTool):
             pub_date = article_data.get("pubdate", "")
             pub_year = pub_date.split()[0] if pub_date else ""
 
-            elocationid = article_data.get("elocationid", "")
-            # Extract DOI: handle formats like "doi: 10.1234/abc" and mixed
-            # "pii: 2026.02.14.705936. 10.64898/2026.02.14.705936" (preprints).
-            doi = ""
-            if "doi:" in elocationid:
-                # Find the "doi:" token and extract what follows it
-                doi_part = elocationid[elocationid.index("doi:") + 4 :].strip()
-                # Take the first token that contains '/' (valid DOI structure)
-                for token in doi_part.split():
-                    if "/" in token:
-                        doi = token.rstrip(".")
-                        break
-            doi = doi or None
+            doi = _extract_doi(article_data) or None
 
             journal = article_data.get(
                 "fulljournalname", article_data.get("source", "")
@@ -379,13 +428,30 @@ class PubMedRESTTool(BaseRESTTool):
             journal_el = art.find("Journal")
             journal = _text(journal_el, "Title") or _text(journal_el, "ISOAbbreviation")
 
-            doi = next(
-                (
-                    eid.text
-                    for eid in art.findall("ELocationID")
-                    if eid.get("EIdType") == "doi" and eid.text
-                ),
-                "",
+            # Fix-R25: same root cause as the esummary path -- older records
+            # (verified live for PMID 15720521) carry no <ELocationID> at all
+            # while still listing the DOI in <PubmedData><ArticleIdList>.
+            # Unlike esummary's free-text `elocationid`, the XML ELocationID is
+            # explicitly typed (EIdType="doi") and needs no parsing, so it stays
+            # the primary source here and ArticleIdList is added as a fallback.
+            doi = _clean_doi(
+                next(
+                    (
+                        eid.text
+                        for eid in art.findall("ELocationID")
+                        if eid.get("EIdType") == "doi" and eid.text
+                    ),
+                    "",
+                )
+            ) or _clean_doi(
+                next(
+                    (
+                        aid.text
+                        for aid in article_el.findall(".//ArticleIdList/ArticleId")
+                        if aid.get("IdType") == "doi" and aid.text
+                    ),
+                    "",
+                )
             )
 
             pd = art.find(".//PubDate")

--- a/src/tooluniverse/tools/ChEBI_search.py
+++ b/src/tooluniverse/tools/ChEBI_search.py
@@ -24,7 +24,7 @@ def ChEBI_search(
     query : str
         Search query string - compound name, synonym, formula, or keyword. Examples: ...
     limit : int | Any
-        Maximum number of results to return. Default: 10. Max: 100.
+        Maximum number of compounds to return. Default: 10. Max: 100. Values above 15...
     stream_callback : Callable, optional
         Callback for streaming output
     use_cache : bool, default False

--- a/src/tooluniverse/tools/OpenTargets_get_target_expression_by_ensemblID.py
+++ b/src/tooluniverse/tools/OpenTargets_get_target_expression_by_ensemblID.py
@@ -1,7 +1,7 @@
 """
 OpenTargets_get_target_expression_by_ensemblID
 
-Retrieve baseline RNA and protein expression for a target across ~119 tissues and cell types (Hum...
+Retrieve baseline expression summary statistics for a target across tissues and cell types (GTEx,...
 """
 
 from typing import Any, Optional, Callable
@@ -10,18 +10,24 @@ from ._shared_client import get_shared_client
 
 def OpenTargets_get_target_expression_by_ensemblID(
     ensemblId: str,
+    size: Optional[int] = 250,
+    index: Optional[int] = 0,
     *,
     stream_callback: Optional[Callable[[str], None]] = None,
     use_cache: bool = False,
     validate: bool = True,
 ) -> Any:
     """
-    Retrieve baseline RNA and protein expression for a target across ~119 tissues and cell types (Hum...
+    Retrieve baseline expression summary statistics for a target across tissues and cell types (GTEx,...
 
     Parameters
     ----------
     ensemblId : str
         Ensembl gene ID of the target (e.g., 'ENSG00000146648' for EGFR).
+    size : int
+        Number of expression rows to return per page (default 250, max 3000). Targets...
+    index : int
+        0-based page index (default 0). Use with `size` to walk the remaining rows wh...
     stream_callback : Callable, optional
         Callback for streaming output
     use_cache : bool, default False
@@ -36,7 +42,11 @@ def OpenTargets_get_target_expression_by_ensemblID(
     # Handle mutable defaults to avoid B006 linting error
 
     # Strip None values so optional parameters don't trigger schema validation errors
-    _args = {k: v for k, v in {"ensemblId": ensemblId}.items() if v is not None}
+    _args = {
+        k: v
+        for k, v in {"ensemblId": ensemblId, "size": size, "index": index}.items()
+        if v is not None
+    }
     return get_shared_client().run_one_function(
         {
             "name": "OpenTargets_get_target_expression_by_ensemblID",

--- a/src/tooluniverse/xml_tool.py
+++ b/src/tooluniverse/xml_tool.py
@@ -29,7 +29,10 @@ class XMLDatasetTool(BaseTool):
         self.namespaces: Dict[str, str] = tool_config.get("settings").get(
             "namespaces", {}
         )
-        self.field_mappings: Dict[str, str] = tool_config.get("settings").get(
+        # Values may be a single XPath string, a LIST of XPath strings (tried
+        # in order, first non-empty wins -- see _extract_field_value), or a
+        # dict describing a nested structure (see _extract_record_data).
+        self.field_mappings: Dict[str, Any] = tool_config.get("settings").get(
             "field_mappings", {}
         )  # Dict of fields we're interested in extracting from each record
         self.filter_field: Optional[str] = tool_config.get("settings").get(
@@ -143,8 +146,27 @@ class XMLDatasetTool(BaseTool):
 
         return data
 
-    def _extract_field_value(self, element: ET.Element, xpath_expr: str) -> str:
-        """Extract field value using XPath expression."""
+    def _extract_field_value(self, element: ET.Element, xpath_expr: Any) -> str:
+        """Extract field value using XPath expression.
+
+        Fix Round 25: `xpath_expr` may also be a LIST of XPath strings, which
+        are tried in order and the first non-empty result returned. Some
+        source datasets file the same logical field under different parents
+        depending on the record -- DrugBank puts Molecular Formula/Weight
+        under <calculated-properties> for small molecules but under
+        <experimental-properties> for biotech/peptide entries, so a single
+        XPath silently yields "" for one whole class of records. Note that
+        ElementTree/lxml's findall() does not accept `|` XPath unions, so a
+        list of expressions (rather than one union expression) is the right
+        shape here.
+        """
+        if isinstance(xpath_expr, (list, tuple)):
+            for candidate in xpath_expr:
+                value = self._extract_field_value(element, candidate)
+                if value:
+                    return value
+            return ""
+
         try:
             # Handle attribute extraction with /@
             if "/@" in xpath_expr:

--- a/tests/unit/test_bgee_base_url_trailing_slash.py
+++ b/tests/unit/test_bgee_base_url_trailing_slash.py
@@ -1,0 +1,155 @@
+"""Bgee requests must target ``https://www.bgee.org/api/`` (with trailing slash).
+
+Regression: the tool built its URL from ``https://www.bgee.org/api`` (no
+trailing slash).  Requests to that path never reach the Bgee application -- the
+site's Cloudflare WAF answers them with an HTTP 403 challenge page
+(``cf-mitigated: challenge``), so every Bgee tool, including the documented
+``Bgee_get_gene_expression`` example (ENSG00000141510 / 9606), returned
+"Bgee API HTTP error: 403".  The same query with the trailing slash returns
+HTTP 200 and 145 expression calls.  Bisection showed this is independent of
+User-Agent (python-requests, curl and a browser UA all 403 without the slash
+and all 200 with it) and of the Accept header.
+
+Also covers the error path: Bgee reports an unknown gene ID as HTTP 404 with a
+JSON body carrying a ``message``, which must be surfaced instead of a bare
+status code.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+pytestmark = pytest.mark.unit
+
+
+def _make_tool(endpoint):
+    from tooluniverse.bgee_tool import BgeeTool
+
+    return BgeeTool(
+        {
+            "name": f"Bgee_{endpoint}",
+            "type": "BgeeTool",
+            "fields": {"endpoint": endpoint},
+        }
+    )
+
+
+class TestBgeeBaseUrl(unittest.TestCase):
+    def test_module_base_url_has_trailing_slash(self):
+        import tooluniverse.bgee_tool as mod
+
+        self.assertEqual(mod.BGEE_BASE_URL, "https://www.bgee.org/api/")
+        self.assertTrue(mod.BGEE_BASE_URL.endswith("/"))
+
+    def test_gene_expression_request_uses_trailing_slash(self):
+        tool = _make_tool("gene_expression")
+        with patch("tooluniverse.bgee_tool.requests.get") as get:
+            resp = MagicMock()
+            resp.raise_for_status.return_value = None
+            resp.json.return_value = {
+                "code": 200,
+                "status": "SUCCESS",
+                "data": {
+                    "requestedDataTypes": ["RNA-Seq"],
+                    "calls": [
+                        {
+                            "condition": {
+                                "anatEntity": {
+                                    "id": "UBERON:0003053",
+                                    "name": "ventricular zone",
+                                }
+                            },
+                            "expressionScore": {
+                                "expressionScore": "95.11",
+                                "expressionScoreConfidence": "high",
+                            },
+                            "expressionState": "expressed",
+                            "expressionQuality": "gold",
+                            "dataTypesWithData": ["RNA-Seq"],
+                        }
+                    ],
+                },
+            }
+            get.return_value = resp
+            result = tool.run({"gene_id": "ENSG00000141510", "species_id": "9606"})
+
+        url = get.call_args.args[0]
+        self.assertEqual(url, "https://www.bgee.org/api/")
+        self.assertTrue(
+            url.endswith("/"),
+            "Bgee URL must keep its trailing slash or Cloudflare returns 403",
+        )
+        self.assertEqual(
+            get.call_args.kwargs["params"],
+            {
+                "page": "gene",
+                "action": "expression",
+                "gene_id": "ENSG00000141510",
+                "species_id": "9606",
+                "display_type": "json",
+            },
+        )
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["data"][0]["tissue_name"], "ventricular zone")
+
+    def test_all_endpoints_use_trailing_slash(self):
+        cases = {
+            "gene_search": {"query": "TP53"},
+            "gene_expression": {"gene_id": "ENSG00000141510", "species_id": "9606"},
+            "species_list": {},
+        }
+        for endpoint, args in cases.items():
+            with self.subTest(endpoint=endpoint):
+                tool = _make_tool(endpoint)
+                with patch("tooluniverse.bgee_tool.requests.get") as get:
+                    resp = MagicMock()
+                    resp.raise_for_status.return_value = None
+                    resp.json.return_value = {"code": 200, "data": {}}
+                    get.return_value = resp
+                    tool.run(args)
+                self.assertEqual(get.call_args.args[0], "https://www.bgee.org/api/")
+
+
+class TestBgeeHttpErrorMessage(unittest.TestCase):
+    def test_unknown_gene_404_surfaces_api_message(self):
+        tool = _make_tool("gene_expression")
+        with patch("tooluniverse.bgee_tool.requests.get") as get:
+            resp = MagicMock()
+            resp.status_code = 404
+            resp.json.return_value = {
+                "code": 404,
+                "status": "ERROR",
+                "message": "Page not found.",
+                "data": {"exceptionType": "PageNotFoundException"},
+            }
+            resp.raise_for_status.side_effect = requests.exceptions.HTTPError(
+                response=resp
+            )
+            get.return_value = resp
+            result = tool.run({"gene_id": "ENSG99999999999", "species_id": "9606"})
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("404", result["error"])
+        self.assertIn("Page not found.", result["error"])
+        self.assertIn("Ensembl", result["error"])
+
+    def test_http_error_without_json_body_still_reports_status(self):
+        tool = _make_tool("species_list")
+        with patch("tooluniverse.bgee_tool.requests.get") as get:
+            resp = MagicMock()
+            resp.status_code = 500
+            resp.json.side_effect = ValueError("no json")
+            resp.raise_for_status.side_effect = requests.exceptions.HTTPError(
+                response=resp
+            )
+            get.return_value = resp
+            result = tool.run({})
+
+        self.assertEqual(result["status"], "error")
+        self.assertEqual(result["error"], "Bgee API HTTP error: 500")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_clinvar_invalid_clinsig_blamed_gene.py
+++ b/tests/unit/test_clinvar_invalid_clinsig_blamed_gene.py
@@ -1,0 +1,217 @@
+"""Unit test: an unrecognized clinical_significance is rejected at the input,
+and the zero-result hint stops blaming the gene for a filter's empty result.
+
+Regression: `{"gene": "TP53", "clinical_significance": "Banana"}` pasted the
+bogus class straight into the Entrez term, matched nothing, and returned
+`status: success` with total_count 0 plus a hint telling the caller to
+re-verify the gene symbol -- TP53, which matches thousands of records on its
+own. The only trace of the real culprit was buried in query_translation.
+
+Pins three things:
+  * an unrecognized value (via either parameter spelling) is an ERROR that
+    names the parameter and lists the accepted classes, and never reaches the
+    network;
+  * every accepted class still builds its verified [Filter]/[prop] clause;
+  * the genuine gene-symbol hint still fires unchanged for an unknown gene.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from tooluniverse.clinvar_tool import (
+    _CLINSIG_ACCEPTED,
+    ClinVarSearchByRegion,
+    ClinVarSearchVariants,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return ClinVarSearchVariants({"name": "ClinVar_search_variants"})
+
+
+def _run(arguments, count="0"):
+    """Run the tool with the network stubbed; returns (result, mock)."""
+    tool = _tool()
+    with patch.object(
+        ClinVarSearchVariants,
+        "_make_request",
+        return_value={
+            "status": "success",
+            "data": {"esearchresult": {"count": count, "idlist": []}},
+        },
+    ) as mock_request:
+        result = tool.run(arguments)
+    return result, mock_request
+
+
+# --- 1. invalid values are rejected up front -------------------------------
+
+
+@pytest.mark.parametrize("param", ["clinical_significance", "significance"])
+def test_invalid_value_is_an_error_naming_the_parameter(param):
+    result, mock_request = _run({"gene": "TP53", param: "Banana"})
+
+    assert result["status"] == "error"
+    assert result["parameter"] == param
+    # The offending parameter is named; the (valid) gene symbol is not blamed.
+    assert param in result["error"]
+    assert "banana" in result["error"].lower()
+    assert "HGNC" not in result["error"]
+    assert "verify the symbol" not in result["error"]
+    # The accepted classes are listed so the caller can self-correct.
+    for accepted in ("Pathogenic", "Likely benign", "risk factor"):
+        assert accepted in result["error"]
+    assert "Pathogenic" in result["valid_values"]
+    # ...and no query was ever sent.
+    mock_request.assert_not_called()
+
+
+def test_invalid_component_of_a_slash_value_is_rejected():
+    result, mock_request = _run(
+        {"gene": "TP53", "clinical_significance": "Pathogenic/Bananas"}
+    )
+    assert result["status"] == "error"
+    assert result["invalid_values"] == ["bananas"]
+    mock_request.assert_not_called()
+
+
+def test_invalid_value_never_reports_success_with_zero_results():
+    result, _ = _run({"gene": "TP53", "clinical_significance": "probably bad"})
+    assert result["status"] != "success"
+    assert "data" not in result
+
+
+# --- 2. every accepted class still builds its verified clause --------------
+
+
+@pytest.mark.parametrize("value", _CLINSIG_ACCEPTED)
+def test_accepted_values_still_query(value):
+    result, mock_request = _run({"gene": "BRCA2", "clinical_significance": value})
+    assert result["status"] == "success"
+    term = mock_request.call_args_list[0][0][1]["term"]
+    normalized = value.lower()
+    assert f'"clinsig {normalized}"[Filter]' in term
+    assert f"clinsig_{normalized.replace(' ', '_')}[prop]" in term
+
+
+@pytest.mark.parametrize(
+    "spelling", ["Pathogenic", "pathogenic", "PATHOGENIC", " Pathogenic "]
+)
+def test_case_and_whitespace_spellings_accepted(spelling):
+    result, _ = _run({"gene": "BRCA2", "clinical_significance": spelling})
+    assert result["status"] == "success"
+
+
+@pytest.mark.parametrize("spelling", ["risk_factor", "risk-factor", "Risk Factor"])
+def test_underscore_and_hyphen_spellings_map_to_the_indexed_token(spelling):
+    result, mock_request = _run({"gene": "HFE", "clinical_significance": spelling})
+    assert result["status"] == "success"
+    assert "clinsig_risk_factor[prop]" in mock_request.call_args_list[0][0][1]["term"]
+
+
+def test_alias_and_canonical_parameter_build_the_same_query():
+    _, canonical = _run({"gene": "NLRP7", "clinical_significance": "Pathogenic"})
+    _, alias = _run({"gene": "NLRP7", "significance": "Pathogenic"})
+    assert (
+        canonical.call_args_list[0][0][1]["term"]
+        == alias.call_args_list[0][0][1]["term"]
+    )
+
+
+# --- 3. the gene-symbol hint is preserved, but only when it's earned -------
+
+
+def test_unknown_gene_with_no_filter_still_gets_the_gene_symbol_hint():
+    result, _mock_request = _run({"gene": "NOTAGENE123"})
+
+    hint = result["data"]["zero_result_hint"]
+    assert "No ClinVar records matched gene 'NOTAGENE123'" in hint
+    assert "HGNC" in hint
+    assert "HGNC_search_genes" in hint
+    # No filters were supplied, so no evidence query is needed to say this.
+    assert "gene_only_match_count" not in result["data"]
+
+
+def test_unknown_gene_with_a_filter_still_blames_the_gene():
+    """The bare-gene probe also returns 0 -> the symbol really is the problem."""
+    result, _ = _run({"gene": "NOTAGENE123", "clinical_significance": "Pathogenic"})
+
+    hint = result["data"]["zero_result_hint"]
+    assert "No ClinVar records matched gene 'NOTAGENE123'" in hint
+    assert "HGNC" in hint
+    assert result["data"]["gene_only_match_count"] == 0
+
+
+def _dispatching_run(arguments, probe_response):
+    """Run with a stub that answers the bare-gene evidence probe (retmax=0)
+    with `probe_response` and everything else with an empty result set."""
+    empty = {
+        "status": "success",
+        "data": {"esearchresult": {"count": "0", "idlist": []}},
+    }
+
+    def responder(_endpoint, params=None, **_kwargs):
+        params = params or {}
+        if params.get("retmax") == 0:
+            return probe_response
+        return empty
+
+    tool = _tool()
+    with patch.object(
+        ClinVarSearchVariants, "_make_request", side_effect=responder
+    ) as mock_request:
+        result = tool.run(arguments)
+    return result, mock_request
+
+
+def test_valid_gene_with_a_filter_blames_the_filter_not_the_gene():
+    """The bare-gene probe returns hits -> the filter emptied the result."""
+    result, mock_request = _dispatching_run(
+        {"gene": "NLRP7", "clinical_significance": "Established risk allele"},
+        {
+            "status": "success",
+            "data": {"esearchresult": {"count": "434", "idlist": []}},
+        },
+    )
+
+    hint = result["data"]["zero_result_hint"]
+    assert result["data"]["gene_only_match_count"] == 434
+    assert "'NLRP7' is fine" in hint
+    assert "clinical_significance" in hint
+    # It must NOT tell the caller to go re-verify a symbol that matched 434.
+    assert "HGNC" not in hint
+    assert "outdated/misspelled" not in hint
+    # The probe is count-only and reuses the gene term.
+    probes = [
+        call[0][1]
+        for call in mock_request.call_args_list
+        if (call[0][1] or {}).get("retmax") == 0
+    ]
+    assert [p["term"] for p in probes] == ["NLRP7[gene]"]
+
+
+def test_hint_is_hedged_when_the_evidence_probe_fails():
+    result, _ = _dispatching_run(
+        {"gene": "NLRP7", "clinical_significance": "Pathogenic"},
+        {"status": "error", "error": "boom"},
+    )
+
+    hint = result["data"]["zero_result_hint"]
+    assert "could not be checked" in hint
+    assert "HGNC" not in hint
+
+
+# --- 4. the sibling region search shares the validation --------------------
+
+
+def test_region_search_rejects_an_invalid_significance():
+    tool = ClinVarSearchByRegion({"name": "ClinVar_search_by_region"})
+    result = tool.run(
+        {"region": "chr7:155593770-155593780", "clinical_significance": "Banana"}
+    )
+    assert result["status"] == "error"
+    assert result["parameter"] == "clinical_significance"
+    assert "banana" in result["error"].lower()

--- a/tests/unit/test_opentargets_expression_pagination.py
+++ b/tests/unit/test_opentargets_expression_pagination.py
@@ -1,0 +1,161 @@
+"""OpenTargets_get_target_expression_by_ensemblID must paginate, and must say so.
+
+Regression: the tool's GraphQL query called ``baselineExpression { ... }`` with
+no ``page`` argument, so the OpenTargets default page size of 25 applied
+silently. For NLRP7 (ENSG00000167634) the response advertised
+``count: 1409`` and delivered 25 rows -- the remaining 1384 were unreachable
+because the tool exposed no pagination parameter at all. Those 25 rows held
+exactly one GTEx tissue and omitted testis (median 7.53), the gene's
+highest-expressing GTEx tissue, so the truncated answer was well-formed,
+confident and biologically wrong.
+
+The fix wires ``page: {index: $index, size: $size}`` into the query (default
+size 250, API maximum 3000) and annotates the response with
+``returned`` / ``truncated`` / ``page`` so a caller can tell "250 of 1409"
+from "1409 of 1409" without counting array elements.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import tooluniverse
+from tooluniverse.graphql_tool import OpentargetTool
+
+pytestmark = pytest.mark.unit
+
+TOOL_NAME = "OpenTargets_get_target_expression_by_ensemblID"
+_CONFIG = Path(tooluniverse.__file__).parent / "data" / "opentarget_tools.json"
+
+
+def _tool_config():
+    for entry in json.loads(_CONFIG.read_text()):
+        if isinstance(entry, dict) and entry.get("name") == TOOL_NAME:
+            return entry
+    raise AssertionError(f"{TOOL_NAME} not found in {_CONFIG}")
+
+
+def _mock_post(payload):
+    resp = MagicMock()
+    resp.ok = True
+    resp.status_code = 200
+    resp.json.return_value = payload
+    return resp
+
+
+def _expression_payload(count, n_rows):
+    return {
+        "data": {
+            "target": {
+                "id": "ENSG00000167634",
+                "approvedSymbol": "NLRP7",
+                "baselineExpression": {
+                    "count": count,
+                    "rows": [
+                        {
+                            "datasourceId": "gtex",
+                            "median": 1.0,
+                            "tissueBiosample": {"biosampleName": f"tissue{i}"},
+                        }
+                        for i in range(n_rows)
+                    ],
+                },
+            }
+        }
+    }
+
+
+def test_query_paginates_baseline_expression():
+    """The shipped GraphQL string must pass a page argument, not rely on the
+    API's silent default of 25."""
+    query = _tool_config()["query_schema"]
+    assert "baselineExpression(page:" in query.replace(" (", "(")
+    assert "$index" in query and "$size" in query
+    # A bare `baselineExpression {` (no page argument) is the defect.
+    assert "baselineExpression {" not in query
+
+
+def test_size_and_index_parameters_are_exposed():
+    props = _tool_config()["parameter"]["properties"]
+    assert props["size"]["type"] == "integer"
+    # Default must be materially better than the API's silent 25.
+    assert props["size"]["default"] == 250
+    # 3000 is the API's hard ceiling (probed live: 5000 -> pagination error).
+    assert props["size"]["maximum"] == 3000
+    assert props["index"]["type"] == "integer"
+    assert props["index"]["default"] == 0
+
+
+def test_return_schema_advertises_partialness_fields():
+    target_props = _tool_config()["return_schema"]["oneOf"][0]["properties"]["target"][
+        "properties"
+    ]
+    expr_props = target_props["baselineExpression"]["properties"]
+    assert expr_props["returned"]["type"] == "integer"
+    assert expr_props["truncated"]["type"] == "boolean"
+    assert "page" in expr_props
+
+
+def test_description_documents_pagination():
+    description = _tool_config()["description"]
+    assert "truncated" in description
+    assert "3000" in description
+
+
+def test_partial_response_is_flagged():
+    tool = OpentargetTool(_tool_config())
+    with patch("tooluniverse.graphql_tool.requests.post") as post:
+        post.return_value = _mock_post(_expression_payload(1409, 250))
+        result = tool.run({"ensemblId": "ENSG00000167634"})
+
+    # The default page size must reach the API, not the API's own default of 25.
+    sent = post.call_args.kwargs["json"]["variables"]
+    assert sent["size"] == 250
+    assert sent["index"] == 0
+
+    expr = result["data"]["target"]["baselineExpression"]
+    assert expr["count"] == 1409
+    assert expr["returned"] == 250
+    assert expr["truncated"] is True
+    assert expr["page"] == {"index": 0, "size": 250}
+    note = result["metadata"]["note"]
+    assert "250 of 1409" in note
+
+
+def test_complete_response_is_not_flagged_as_truncated():
+    """A target whose rows all fit in one page must not claim truncation."""
+    tool = OpentargetTool(_tool_config())
+    with patch("tooluniverse.graphql_tool.requests.post") as post:
+        post.return_value = _mock_post(_expression_payload(42, 42))
+        result = tool.run({"ensemblId": "ENSG00000167634"})
+
+    expr = result["data"]["target"]["baselineExpression"]
+    assert expr["returned"] == 42
+    assert expr["truncated"] is False
+    assert "note" not in result.get("metadata", {})
+
+
+def test_later_page_accounts_for_skipped_rows():
+    """returned=700 at index=1 means 1400 rows seen, so 1409 is still partial,
+    while index=1 of a 500-row page covering the tail is complete."""
+    tool = OpentargetTool(_tool_config())
+    with patch("tooluniverse.graphql_tool.requests.post") as post:
+        post.return_value = _mock_post(_expression_payload(1409, 700))
+        partial = tool.run({"ensemblId": "ENSG00000167634", "size": 700, "index": 1})
+    assert partial["data"]["target"]["baselineExpression"]["truncated"] is True
+
+    with patch("tooluniverse.graphql_tool.requests.post") as post:
+        post.return_value = _mock_post(_expression_payload(900, 400))
+        done = tool.run({"ensemblId": "ENSG00000167634", "size": 500, "index": 1})
+    assert done["data"]["target"]["baselineExpression"]["truncated"] is False
+
+
+def test_oversized_page_is_clamped_to_api_maximum():
+    """The API rejects size > 3000 outright; clamp instead of forwarding it."""
+    tool = OpentargetTool(_tool_config())
+    with patch("tooluniverse.graphql_tool.requests.post") as post:
+        post.return_value = _mock_post(_expression_payload(1409, 1409))
+        tool.run({"ensemblId": "ENSG00000167634", "size": 99999})
+    assert post.call_args.kwargs["json"]["variables"]["size"] == 3000

--- a/tests/unit/test_pubmed_doi_articleids_fallback.py
+++ b/tests/unit/test_pubmed_doi_articleids_fallback.py
@@ -1,0 +1,237 @@
+"""Regression guard for Fix-R25: PubMed_search_articles returned
+doi=None/doi_url=None for essentially every article published before ~2008.
+
+The DOI was parsed *only* out of the esummary ``elocationid`` display string,
+which NCBI leaves empty for older records -- even though the very same
+response carries the DOI in the structured ``articleids`` list, two keys away
+(confirmed live for PMIDs 15720521, 17354009, 15500562, 14765742, 14627096).
+``articleids`` is now the primary source, with the ``elocationid`` parse kept
+as a fallback. The same defect existed on the efetch XML path, where older
+records carry no <ELocationID> but do list the DOI in <ArticleIdList>.
+
+All assertions below run against synthetic payloads -- no network.
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+import tooluniverse
+from tooluniverse.pubmed_tool import PubMedRESTTool
+
+pytestmark = pytest.mark.unit
+
+DATA_DIR = Path(tooluniverse.__file__).parent / "data"
+
+
+def _tool():
+    return PubMedRESTTool(
+        {
+            "name": "PubMed_search_articles",
+            "type": "PubMedRESTTool",
+            "fields": {
+                "db": "pubmed",
+                "retmode": "json",
+                "endpoint": "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi",
+            },
+            "parameter": {"type": "object", "properties": {}, "required": []},
+        }
+    )
+
+
+def _summarize(record, pmid="15720521"):
+    """Run one synthetic esummary record through _fetch_summaries."""
+    tool = _tool()
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {"result": {"uids": [pmid], pmid: record}}
+
+    with (
+        patch.object(tool, "_enforce_rate_limit"),
+        patch("tooluniverse.pubmed_tool.request_with_retry", return_value=resp),
+    ):
+        result = tool._fetch_summaries([pmid])
+
+    assert result["status"] == "success"
+    return result["data"][0]
+
+
+def _record(**overrides):
+    base = {
+        "uid": "15720521",
+        "pubdate": "2005 Feb",
+        "title": "Development of a PCR-based diagnostic test",
+        "authors": [{"name": "Geyer J"}],
+        "fulljournalname": "J Vet Pharmacol Ther",
+        "pubtype": ["Journal Article"],
+        "elocationid": "",
+        "articleids": [],
+    }
+    base.update(overrides)
+    return base
+
+
+def test_old_record_doi_comes_from_articleids():
+    """Empty elocationid + articleids doi entry -> DOI is populated."""
+    article = _summarize(
+        _record(
+            elocationid="",
+            articleids=[
+                {"idtype": "pubmed", "value": "15720521"},
+                {"idtype": "doi", "value": "10.1111/j.1365-2885.2004.00625.x"},
+                {"idtype": "pii", "value": "JVP625"},
+            ],
+        )
+    )
+
+    assert article["doi"] == "10.1111/j.1365-2885.2004.00625.x"
+    assert article["doi_url"] == "https://doi.org/10.1111/j.1365-2885.2004.00625.x"
+
+
+def test_articleids_doi_is_not_double_prefixed():
+    """The fallback must not leave/insert a 'doi:' prefix in the value."""
+    article = _summarize(
+        _record(articleids=[{"idtype": "doi", "value": "10.2460/javma.2003.223.1453"}])
+    )
+
+    assert article["doi"] == "10.2460/javma.2003.223.1453"
+    assert not article["doi"].lower().startswith("doi:")
+    assert article["doi_url"].count("https://doi.org/") == 1
+
+
+def test_modern_record_with_populated_elocationid_is_unchanged():
+    """A record where both sources agree still yields the clean DOI."""
+    article = _summarize(
+        _record(
+            elocationid="doi: 10.1002/jat.70166",
+            articleids=[
+                {"idtype": "pubmed", "value": "41837342"},
+                {"idtype": "pmc", "value": "PMC13136416"},
+                {"idtype": "doi", "value": "10.1002/jat.70166"},
+            ],
+        )
+    )
+
+    assert article["doi"] == "10.1002/jat.70166"
+    assert article["doi_url"] == "https://doi.org/10.1002/jat.70166"
+
+
+def test_elocationid_still_used_when_articleids_lacks_doi():
+    """Pre-existing behaviour: parse elocationid when there is no doi id."""
+    article = _summarize(
+        _record(
+            elocationid="pii: 2026.02.14.705936. doi: 10.64898/2026.02.14.705936",
+            articleids=[{"idtype": "pmc", "value": "PMC13136416"}],
+        )
+    )
+
+    assert article["doi"] == "10.64898/2026.02.14.705936"
+    assert "pii" not in article["doi"]
+    assert article["doi_url"] == "https://doi.org/10.64898/2026.02.14.705936"
+
+
+def test_record_with_no_doi_anywhere_returns_none():
+    """A genuinely DOI-less record (e.g. PMID 13678080) stays None, not ''."""
+    article = _summarize(
+        _record(elocationid="", articleids=[{"idtype": "pubmed", "value": "13678080"}])
+    )
+
+    assert article["doi"] is None
+    assert article["doi_url"] is None
+
+
+def test_malformed_articleids_do_not_crash():
+    """Blank/missing doi values fall through safely instead of yielding ''."""
+    article = _summarize(
+        _record(
+            elocationid="",
+            articleids=[
+                {"idtype": "doi"},
+                {"idtype": "doi", "value": ""},
+                {"idtype": "doi", "value": None},
+            ],
+        )
+    )
+
+    assert article["doi"] is None
+    assert article["doi_url"] is None
+
+
+def test_efetch_xml_doi_falls_back_to_articleidlist():
+    """Older efetch XML has no <ELocationID> but does list a doi ArticleId."""
+    xml = """<?xml version="1.0"?>
+<PubmedArticleSet><PubmedArticle>
+  <MedlineCitation>
+    <PMID>15720521</PMID>
+    <Article>
+      <Journal><Title>J Vet Pharmacol Ther</Title></Journal>
+      <ArticleTitle>PCR-based diagnostic test</ArticleTitle>
+    </Article>
+  </MedlineCitation>
+  <PubmedData><ArticleIdList>
+    <ArticleId IdType="pubmed">15720521</ArticleId>
+    <ArticleId IdType="doi">10.1111/j.1365-2885.2004.00625.x</ArticleId>
+  </ArticleIdList></PubmedData>
+</PubmedArticle></PubmedArticleSet>"""
+
+    resp = MagicMock()
+    resp.text = xml
+    resp.url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi"
+    parsed = _tool()._parse_efetch_xml(resp)
+
+    assert parsed["status"] == "success"
+    assert parsed["data"]["doi"] == "10.1111/j.1365-2885.2004.00625.x"
+    assert (
+        parsed["data"]["doi_url"] == "https://doi.org/10.1111/j.1365-2885.2004.00625.x"
+    )
+
+
+def test_efetch_xml_elocationid_still_wins_and_no_doi_stays_none():
+    """ELocationID remains primary; a record with neither source stays None."""
+    with_eloc = """<?xml version="1.0"?>
+<PubmedArticleSet><PubmedArticle>
+  <MedlineCitation><PMID>41837342</PMID><Article>
+    <Journal><Title>J Appl Toxicol</Title></Journal>
+    <ArticleTitle>Modern article</ArticleTitle>
+    <ELocationID EIdType="doi">10.1002/jat.70166</ELocationID>
+  </Article></MedlineCitation>
+</PubmedArticle></PubmedArticleSet>"""
+
+    resp = MagicMock()
+    resp.text = with_eloc
+    resp.url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi"
+    assert _tool()._parse_efetch_xml(resp)["data"]["doi"] == "10.1002/jat.70166"
+
+    without_any = """<?xml version="1.0"?>
+<PubmedArticleSet><PubmedArticle>
+  <MedlineCitation><PMID>13678080</PMID><Article>
+    <Journal><Title>Old Journal</Title></Journal>
+    <ArticleTitle>No DOI anywhere</ArticleTitle>
+  </Article></MedlineCitation>
+  <PubmedData><ArticleIdList>
+    <ArticleId IdType="pubmed">13678080</ArticleId>
+  </ArticleIdList></PubmedData>
+</PubmedArticle></PubmedArticleSet>"""
+
+    resp2 = MagicMock()
+    resp2.text = without_any
+    resp2.url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi"
+    data = _tool()._parse_efetch_xml(resp2)["data"]
+    assert data["doi"] is None
+    assert data["doi_url"] is None
+
+
+def test_search_tool_config_still_declares_doi_fields():
+    """The tool contract advertising doi/doi_url is resolved via the package
+    directory, not a cwd-relative path."""
+    config_path = DATA_DIR / "pubmed_tools.json"
+    assert config_path.is_file(), f"missing {config_path}"
+
+    configs = json.loads(config_path.read_text())
+    search = next(c for c in configs if c["name"] == "PubMed_search_articles")
+    assert search["type"] == "PubMedRESTTool"

--- a/tests/unit/test_xml_tool_multi_xpath_field.py
+++ b/tests/unit/test_xml_tool_multi_xpath_field.py
@@ -1,0 +1,196 @@
+"""Regression guard for Fix Round 25: a flat `field_mappings` value may be a
+LIST of XPath expressions, tried in order with the first non-empty result winning.
+
+drugbank_get_drug_chemistry_by_drug_name_or_drugbank_id mapped
+molecular_formula/molecular_weight only to
+<experimental-properties>, but DrugBank files those two properties under
+<calculated-properties> for small molecules -- so the two fields the tool's own
+description promises came back "" for EVERY small molecule (confirmed live:
+{"drug_name": "Ivermectin"} returned molecular_formula="" while melting_point
+and water_solubility were populated). Biotech/peptide records genuinely do carry
+them under <experimental-properties>, so the fix must consult both sections.
+ElementTree/lxml findall() does not support `|` XPath unions, hence a list.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+NS = {"db": "http://www.drugbank.ca"}
+
+# Two records mirroring the real dataset's two shapes: a small molecule with
+# the properties under <calculated-properties>, and a biotech entry with them
+# under <experimental-properties>.
+SAMPLE_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<drugbank xmlns="http://www.drugbank.ca">
+  <drug type="small molecule">
+    <drugbank-id primary="true">DB00602</drugbank-id>
+    <name>Ivermectin</name>
+    <experimental-properties>
+      <property><kind>Melting Point</kind><value>155 &#176;C</value></property>
+    </experimental-properties>
+    <calculated-properties>
+      <property><kind>Molecular Formula</kind><value>C95H146O28</value></property>
+      <property><kind>Molecular Weight</kind><value>1736.185</value></property>
+    </calculated-properties>
+  </drug>
+  <drug type="biotech">
+    <drugbank-id primary="true">DB00001</drugbank-id>
+    <name>Lepirudin</name>
+    <experimental-properties>
+      <property><kind>Molecular Formula</kind><value>C287H440N80O111S6</value></property>
+      <property><kind>Molecular Weight</kind><value>6979.0</value></property>
+    </experimental-properties>
+  </drug>
+</drugbank>
+"""
+
+CALCULATED = "db:calculated-properties/db:property[db:kind='{}']/db:value"
+EXPERIMENTAL = "db:experimental-properties/db:property[db:kind='{}']/db:value"
+
+
+def _make_tool(tmp_path, formula_mapping, weight_mapping):
+    from tooluniverse.xml_tool import XMLDatasetTool
+
+    xml_path = tmp_path / "drugbank_sample.xml"
+    xml_path.write_text(SAMPLE_XML, encoding="utf-8")
+
+    return XMLDatasetTool(
+        {
+            "name": "drugbank_get_drug_chemistry_by_drug_name_or_drugbank_id",
+            "parameter": {
+                "type": "object",
+                "properties": {"query": {"type": "string"}},
+                "required": ["query"],
+            },
+            "settings": {
+                "local_dataset_path": str(xml_path),
+                "namespaces": NS,
+                "record_xpath": "db:drug",
+                "search_fields": ["drug_name", "drugbank_id"],
+                "field_mappings": {
+                    "drug_name": "db:name",
+                    "drugbank_id": "db:drugbank-id[@primary='true']",
+                    "molecular_formula": formula_mapping,
+                    "molecular_weight": weight_mapping,
+                    "melting_point": EXPERIMENTAL.format("Melting Point"),
+                },
+            },
+        }
+    )
+
+
+def _lookup(tool, query):
+    result = tool.run({"query": query})
+    assert result["status"] == "success", result
+    records = result["data"]["results"]
+    assert len(records) == 1, records
+    return records[0]
+
+
+@pytest.fixture
+def tool(tmp_path):
+    """A tool configured the way the shipped config now is: list-valued."""
+    return _make_tool(
+        tmp_path,
+        [
+            CALCULATED.format("Molecular Formula"),
+            EXPERIMENTAL.format("Molecular Formula"),
+        ],
+        [
+            CALCULATED.format("Molecular Weight"),
+            EXPERIMENTAL.format("Molecular Weight"),
+        ],
+    )
+
+
+def test_small_molecule_falls_to_calculated_properties(tool):
+    """The bug: this record has NO experimental Molecular Formula at all."""
+    record = _lookup(tool, "Ivermectin")
+    assert record["molecular_formula"] == "C95H146O28"
+    assert record["molecular_weight"] == "1736.185"
+    # The fields that already worked must be untouched.
+    assert record["melting_point"] == "155 °C"
+
+
+def test_biotech_still_resolves_via_experimental_fallback(tool):
+    """Second XPath in the list wins when the first yields nothing."""
+    record = _lookup(tool, "Lepirudin")
+    assert record["molecular_formula"] == "C287H440N80O111S6"
+    assert record["molecular_weight"] == "6979.0"
+
+
+def test_plain_string_mapping_behaviour_is_unchanged(tmp_path):
+    """A str value must behave exactly as before -- including yielding ''."""
+    tool = _make_tool(
+        tmp_path,
+        EXPERIMENTAL.format("Molecular Formula"),
+        EXPERIMENTAL.format("Molecular Weight"),
+    )
+    assert _lookup(tool, "Ivermectin")["molecular_formula"] == ""
+    assert _lookup(tool, "Lepirudin")["molecular_formula"] == "C287H440N80O111S6"
+
+
+def test_list_mapping_yields_empty_string_when_no_xpath_matches(tmp_path):
+    tool = _make_tool(
+        tmp_path,
+        [CALCULATED.format("Nonexistent"), EXPERIMENTAL.format("Nonexistent")],
+        [CALCULATED.format("Nonexistent")],
+    )
+    record = _lookup(tool, "Ivermectin")
+    assert record["molecular_formula"] == ""
+    assert record["molecular_weight"] == ""
+
+
+def test_list_valued_mapping_still_lands_in_default_search_fields(tmp_path):
+    """search_fields defaults to list(field_mappings.keys()); a list value
+    must not break that, nor the config echo in get_dataset_info()."""
+    from tooluniverse.xml_tool import XMLDatasetTool
+
+    xml_path = tmp_path / "drugbank_sample.xml"
+    xml_path.write_text(SAMPLE_XML, encoding="utf-8")
+    tool = XMLDatasetTool(
+        {
+            "name": "t",
+            "settings": {
+                "local_dataset_path": str(xml_path),
+                "namespaces": NS,
+                "record_xpath": "db:drug",
+                "field_mappings": {
+                    "molecular_formula": [
+                        CALCULATED.format("Molecular Formula"),
+                        EXPERIMENTAL.format("Molecular Formula"),
+                    ]
+                },
+            },
+        }
+    )
+    assert tool.search_fields == ["_text", "molecular_formula"]
+    info = tool.get_dataset_info()
+    assert isinstance(info["field_mappings"]["molecular_formula"], list)
+    # get_dataset_info() feeds JSON responses; a list value must serialize.
+    json.dumps(info["field_mappings"])
+
+
+def test_shipped_config_lists_calculated_before_experimental():
+    # Resolve via the installed package rather than the process cwd, so the
+    # test does not depend on pytest being invoked from the repository root.
+    import tooluniverse
+
+    config_path = Path(tooluniverse.__file__).parent / "data" / "xml_tools.json"
+    with open(config_path) as f:
+        tools = json.load(f)
+    settings = next(
+        t
+        for t in tools
+        if t["name"] == "drugbank_get_drug_chemistry_by_drug_name_or_drugbank_id"
+    )["settings"]
+    for field, kind in (
+        ("molecular_formula", "Molecular Formula"),
+        ("molecular_weight", "Molecular Weight"),
+    ):
+        mapping = settings["field_mappings"][field]
+        assert mapping == [CALCULATED.format(kind), EXPERIMENTAL.format(kind)], field


### PR DESCRIPTION
Seven tools that returned a well-formed, successful-looking response while quietly omitting — or misattributing — the thing that was asked for. Every one was reproduced through the CLI before any code was touched, and every root cause was confirmed against real upstream data rather than inferred.

Three came from persona sweeps in domains this harness had not covered before (veterinary/comparative biology, reproductive & developmental genetics, microbiome/metagenomics); four were carry-forwards re-verified from scratch.

---

## 1. DrugBank chemistry lookups returned no formula or weight

`drugbank_get_drug_chemistry_by_drug_name_or_drugbank_id` advertises "molecular formula, weight, and structure" and returned `""` for both on **every small molecule**, sitting next to a correctly populated `melting_point` and `water_solubility` — so the blanks read as "DrugBank has no value" rather than "we looked in the wrong element".

DrugBank files Molecular Formula/Weight under `<calculated-properties>` for small molecules, and under `<experimental-properties>` only for biotech entries. The config mapped both fields at the experimental section alone. Dumping DB00602 from the cached dataset confirms it: `calculated-properties` holds `Molecular Formula = C95H146O28`, while `experimental-properties` holds only Water Solubility and Melting Point.

Swapping one hard-coded section for the other would just move the blanks onto the biologics, so instead a flat `field_mappings` value may now be a **list of XPath expressions, tried in order, first non-empty wins**. `ElementTree.findall()` does not accept `|` unions, which is why a list is the right shape. Single-string mappings and the nested `parent_path` branch are byte-identical.

```
$ tu run drugbank_get_drug_chemistry_by_drug_name_or_drugbank_id '{"drug_name": "Ivermectin"}'
before: "molecular_formula": "",           "molecular_weight": ""
after:  "molecular_formula": "C95H146O28", "molecular_weight": "1736.185"
```
Aspirin (DB00945) `C9H8O4` / `180.1574`; the biotech entry Lepirudin still resolves `C287H440N80O111S6` through the second list element, exercising the fallback.

## 2. `ChEBI_search` silently capped every result set at 15

The tool accepted `limit` up to 100, then returned at most 15 compounds regardless, reporting `result_count: 15` with nothing marking the answer as partial. The EBI `advanced_search` endpoint paginates at 15 hits/page and reports the true size in `total`/`number_pages`; the tool issued one POST and discarded both. A survey of "flavonoid" therefore looked like 15 hits when ChEBI holds 116 — an 8x undercount that reads as a complete answer.

It now walks successive pages until `limit` is satisfied or the set is exhausted, and surfaces the API's count as **`total_matches`**, so a caller can tell "10 returned of 116 matching" from "only 10 exist". `result_count` keeps its existing meaning. A failure fetching page N > 1 degrades to fewer results instead of discarding pages already in hand; absent page metadata degrades to the previous single-page behaviour rather than looping.

```
$ tu run ChEBI_search '{"query": "flavonoid", "limit": 40}'
before: result_count 15
after:  result_count 40, total_matches 116, 3 requests
```
`limit=5` still costs one request; the default of 10 is unchanged; `limit=100` returns 100 unique accessions in 7 requests.

## 3. `visualize_molecule_2d` could not resolve any molecule name

`_resolve_molecule_name()` returned `None` for every input, making the `molecule_name` parameter inert — the tool was drivable only by explicit SMILES/InChI.

PubChem PUG-REST renamed its SMILES properties (`IsomericSMILES` → `SMILES`, `CanonicalSMILES` → `ConnectivitySMILES`). Requesting the legacy name still works, but the response comes back keyed by the **new** name, and the code tested for the legacy key before reading it, so the lookup always fell through:

```
$ curl ".../compound/name/aspirin/property/IsomericSMILES/JSON"
{"PropertyTable":{"Properties":[{"CID":2244,"SMILES":"CC(=O)OC1=CC=CC=C1C(=O)O"}]}}
```

Now requests the current name and reads either key, matching the convention `metabolite_tool.py` already uses. aspirin and caffeine resolve; an unknown name still returns `None`.

## 4. PubMed results dropped the DOI for pre-2008 literature

`PubMed_search_articles` returned `"doi": null` for essentially every article published before ~2008 — a null that reads as "no DOI was assigned" rather than "we only looked in one place". For the canine MDR1 question that stripped DOIs from the entire foundational Mealey/Geyer-era literature while modern papers looked fine.

The esummary parser read the DOI only from `elocationid`, then iterated `articleids` matching just `idtype == "pmc"`, never `idtype == "doi"`. NCBI leaves `elocationid` empty for older records but always lists the DOI in `articleids`:

```
15720521 | eloc=''                        | articleids doi = 10.1111/j.1365-2885.2004.00625.x
17354009 | eloc=''                        | articleids doi = 10.1007/s00204-007-0193-6
41837342 | eloc='doi: 10.1002/jat.70166'  | articleids doi = 10.1002/jat.70166
```

The structured `articleids` entry is now primary and `elocationid` the fallback: it is populated for both eras, its value is bare rather than the mixed `pii: … doi: …` free text, and it needs no parsing heuristic. The same defect in the efetch XML path is fixed alongside it — PMID 15720521's efetch record has no `<ELocationID>` at all but does carry `<ArticleId IdType="doi">`.

Six previously-null PMIDs now resolve (back to a 1969 record); a modern record is unchanged with no `doi: ` prefix leaking in; an article genuinely without a DOI still returns `None`.

## 5. Every Bgee call failed with HTTP 403, including its own example

All three Bgee tools were unusable — `Bgee_get_gene_expression` returned `HTTP error: 403` even for the exact gene its description advertises.

**The obvious hypothesis — a blocked `python-requests` user agent — is wrong.** `BGEE_BASE_URL` lacked a trailing slash, so requests built `https://www.bgee.org/api?page=…`, and bgee.org's Cloudflare edge challenges that path before it ever reaches the application. Bisected against the tool's exact URL and params:

| Request | python-requests UA | curl UA | Chrome UA |
|---|---|---|---|
| `/api?page=…` | 403 | 403 | 403 |
| `/api/?page=…` | 200 | 200 | — |

The 403 carries `cf-mitigated: challenge` / `server: cloudflare`; a bare `GET /api/` returns Bgee's *own* JSON 404 envelope, proving the slashed path reaches the app and the slashless one does not. One character repairs all three tools, which shared the constant. HTTP failures now also surface Bgee's own JSON message, so an invalid gene ID explains itself.

## 6. OpenTargets expression returned 25 of ~1400 rows as if complete

`OpenTargets_get_target_expression_by_ensemblID` reported `count: 1409` and returned 25 rows, with no pagination parameter at all — the other 1384 unreachable. The GraphQL query asked for `baselineExpression` without a `page` argument, so the API's default page size of 25 applied silently. The description even advised filtering client-side by `datasourceId`, which is impossible when 98% of rows never arrive.

The 25 are not a representative sample. For NLRP7 they held exactly one GTEx tissue (pituitary gland, median 0.01) and omitted **testis at 7.53 — the gene's highest-expressing GTEx tissue**. The result was a confident, well-formed expression profile that inverts the answer.

Now passes an explicit page, exposes `size` (default 250) and `index`, and makes partial-ness explicit rather than leaving the caller to compare `count` against `len(rows)`: the response carries `returned`, `truncated` and the `page` actually applied, plus a metadata note when rows remain. Because rows from one datasource are interleaved across the whole result, that note says so — a partial page is not a complete view of any single source.

Live-probed rather than assumed: max `size` is 3000 (`size=5000` → *"the size must be between 0 and 3000"*), and `$index: Int!` with a default is rejected by this server, so the query uses nullable variables. `size=3000` returns all 1409 with `truncated: false`; testis is reachable at the default 250.

## 7. ClinVar blamed the gene when the significance filter was invalid

`ClinVar_search_variants` pasted an unrecognised `clinical_significance` straight into the Entrez term, returned `status: success` with zero results, and then told the user to go re-verify their gene symbol:

```
$ tu run ClinVar_search_variants '{"gene":"TP53","max_results":3,"clinical_significance":"Banana"}'
"total_count": 0,
"query_translation": "TP53[gene] AND (\"clinsig banana\"[Filter] OR clinsig_banana[prop])",
"zero_result_hint": "No ClinVar records matched gene 'TP53'. …verify the symbol…"
```

TP53 is about as valid as a gene symbol gets. The hint pointed at the one input that was never the problem, while the real culprit was visible only to someone who thought to read `query_translation`.

Validated at the input instead of diagnosed after the fact: an unrecognised class is now rejected before any search runs, with the accepted list in the message. A silently-wrong filter reporting success is the actual defect — rewording the hint would have left it in place. The genuine gene-symbol hint still fires unchanged for a real unknown symbol, and valid filters are untouched: NLRP7 still returns 434 unfiltered and 34 for `Pathogenic`, matching NCBI's own esearch count.

---

## Verification

- `pytest tests/unit` — green before and after, **0 regressions**. New tests added for six of the seven fixes (56 new assertions across five files), all network-free.
- `ruff check` on every modified module: finding counts identical to their `HEAD` baselines — **zero new lint findings**. `ruff format --check` clean on all changed files.
- `git status --short src/tooluniverse/tools/` — **0**. The bulk generator was never run; the two affected wrappers were produced per-tool and match generator output byte-for-byte, including the `[:77]`/`[:97]` docstring truncations.
- Every fix was re-run through the CLI with its original failing arguments.

## Overlap with open PRs #493–#497

Checked before queuing anything. Deliberately **not** fixed here because a sibling PR already owns the file and the symptom:

- UniProt `organism` rejecting non-model species with HTTP 400 — #494 rewrites exactly this path (routes names to `organism_name:`).
- HPA `..._in_specific_tissues` reading the tissue-*enrichment* summary instead of the full panel — #495 fixes precisely this.
- openFDA `limit` not clamped to its documented max — #493 owns `openfda_tool.py`.

The one shared file is `data/opentarget_tools.json`, which #494 also edits — but only its `OpenTargets_get_evidence_by_datasource` entry. This PR's diff there is two hunks, both inside the expression tool's entry; the two do not overlap. `graphql_tool.py` is touched by #494/#495 as well; the change here is one new constant plus a name-gated block, so a rebase conflict would be small and mechanical if those merge first.
