### PR TITLE
Consolidate test-harness fixes: rounds 20-25 (6 PRs, 12 commits)

### DIFF
--- a/src/tooluniverse/aopwiki_tool.py
+++ b/src/tooluniverse/aopwiki_tool.py
@@ -42,11 +42,23 @@ def _aopwiki_not_found(result: Any) -> bool:
             "List Adverse Outcome Pathways (AOPs) from AOPWiki. Returns AOP IDs, "
             "titles, and short names. AOPs describe causal chains from molecular "
             "initiating events through key events to adverse outcomes, used in "
-            "toxicology and risk assessment."
+            "toxicology and risk assessment. Pass `search` to keep only AOPs whose "
+            "title or short name contains a keyword (e.g. 'thyroid', 'PPAR', "
+            "'steatosis') -- AOPWiki publishes ~600 AOPs, so an unfiltered list is "
+            "rarely what you want. Use AOPWiki_get_aop on a returned ID for its key "
+            "events, stressor chemicals, and causal relationships."
         ),
         "parameter": {
             "type": "object",
-            "properties": {},
+            "properties": {
+                "search": {
+                    "type": "string",
+                    "description": (
+                        "Case-insensitive keyword to filter AOPs by title or short "
+                        "name. Omit to return every AOP."
+                    ),
+                },
+            },
         },
         "settings": {"base_url": _BASE, "timeout": 30},
     },
@@ -85,7 +97,33 @@ class AOPWikiListTool:
         except Exception as e:
             return {"status": "error", "error": f"AOPWiki API error: {e}"}
 
-        return {"status": "success", "data": aops}
+        # AOPWiki's /aops.json has no server-side keyword filter, so filter the
+        # fetched list here rather than making callers pull ~600 AOPs and grep.
+        search = str(arguments.get("search") or "").strip().lower()
+        if not search:
+            return {"status": "success", "data": aops}
+
+        matches = [
+            a
+            for a in aops
+            if search in str(a.get("title") or "").lower()
+            or search in str(a.get("short_name") or "").lower()
+        ]
+        result = {
+            "status": "success",
+            "data": matches,
+            "count": len(matches),
+            "total_aops": len(aops),
+            "search": arguments.get("search"),
+        }
+        if not matches:
+            result["note"] = (
+                f"No AOP title or short name contains '{arguments.get('search')}'. "
+                f"Searched all {len(aops)} AOPs. Try a broader keyword (AOPWiki "
+                "titles use terms like 'thyroid', 'PPAR', 'steatosis', "
+                "'neurotoxicity'), or omit `search` to list every AOP."
+            )
+        return result
 
 
 @register_tool(

--- a/src/tooluniverse/bgee_tool.py
+++ b/src/tooluniverse/bgee_tool.py
@@ -16,7 +16,12 @@ from typing import Dict, Any
 from .base_tool import BaseTool
 from .tool_registry import register_tool
 
-BGEE_BASE_URL = "https://www.bgee.org/api"
+# NOTE: the trailing slash is REQUIRED. Requests to "https://www.bgee.org/api"
+# (no slash) never reach the Bgee application -- they are intercepted by the
+# site's Cloudflare WAF and answered with an HTTP 403 challenge page
+# ("cf-mitigated: challenge"). Only "https://www.bgee.org/api/?..." is routed
+# to the API. This is independent of User-Agent and of any request header.
+BGEE_BASE_URL = "https://www.bgee.org/api/"
 
 
 @register_tool("BgeeTool")
@@ -54,13 +59,42 @@ class BgeeTool(BaseTool):
         except requests.exceptions.HTTPError as e:
             return {
                 "status": "error",
-                "error": f"Bgee API HTTP error: {e.response.status_code}",
+                "error": self._http_error_message(e),
             }
         except Exception as e:
             return {
                 "status": "error",
                 "error": f"Unexpected error querying Bgee: {str(e)}",
             }
+
+    def _http_error_message(self, exc: requests.exceptions.HTTPError) -> str:
+        """Build an actionable message from a failed Bgee HTTP response.
+
+        Bgee answers bad requests with a JSON body that carries a human
+        readable ``message`` (e.g. an unknown gene ID yields HTTP 404 with
+        ``"Page not found."``), so surface that instead of a bare status code.
+        """
+        response = exc.response
+        status = getattr(response, "status_code", None)
+        api_message = ""
+        try:
+            body = response.json()
+            if isinstance(body, dict):
+                api_message = str(body.get("message", "")).strip()
+        except (ValueError, AttributeError):
+            # non-JSON body (HTML error page) or no response attached
+            api_message = ""
+
+        message = f"Bgee API HTTP error: {status}"
+        if api_message:
+            message += f" - {api_message}"
+        if status == 404:
+            message += (
+                " (check that the gene ID is a valid Ensembl ID present in Bgee"
+                " for the requested species, e.g. gene_id=ENSG00000141510 with"
+                " species_id=9606)"
+            )
+        return message
 
     def _query(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Route to appropriate Bgee endpoint."""

--- a/src/tooluniverse/bindingdb_tool.py
+++ b/src/tooluniverse/bindingdb_tool.py
@@ -12,6 +12,7 @@ single id or a semicolon-delimited list — so we route every operation
 through the plural endpoint.
 """
 
+import re
 from typing import Any, Dict, List
 
 import requests
@@ -22,6 +23,21 @@ from .tool_registry import register_tool
 
 BASE_URL = "https://www.bindingdb.org/rest"
 DEFAULT_TIMEOUT = 30
+
+
+def _error_detail(resp: "requests.Response") -> str:
+    """Readable one-line summary of an error response body.
+
+    BindingDB serves Tomcat's HTML error page on failures, and echoing its
+    first 200 characters put a doctype and a stylesheet fragment in front of
+    the caller instead of anything diagnostic.
+    """
+    body = (resp.text or "").strip()
+    if "<html" in body[:200].lower() or body[:20].lower().startswith("<!doctype"):
+        title = re.search(r"<title>(.*?)</title>", body, re.IGNORECASE | re.DOTALL)
+        summary = title.group(1).strip() if title else "HTML error page"
+        return f"upstream returned an HTML error page ({summary})"
+    return body[:200] or "empty response body"
 
 
 def _http_get(
@@ -45,7 +61,7 @@ def _http_get(
     except requests.exceptions.ConnectionError as e:
         return {"_err": f"BindingDB connection failed: {e}"}
     if resp.status_code != 200:
-        return {"_err": f"BindingDB HTTP {resp.status_code}: {resp.text[:200]}"}
+        return {"_err": f"BindingDB HTTP {resp.status_code}: {_error_detail(resp)}"}
     try:
         return resp.json()
     except ValueError as e:
@@ -154,7 +170,24 @@ class BindingDBTool(BaseTool):
             timeout=self.timeout,
         )
         if "_err" in result:
-            return {"status": "error", "error": result["_err"]}
+            error = result["_err"]
+            # getLigandsByPDBs is currently answering 500 for every input, valid
+            # ids included (confirmed for 6OIM and 2RH1, with and without the
+            # cutoff parameter; the singular getLigandsByPDB is a 404 while
+            # getLigandsByUniprots answers 200). A bare relay of the upstream
+            # status leaves the caller unable to tell "this structure has no
+            # binding data" from "this whole lookup route is down", so name the
+            # route that does work.
+            if "HTTP 5" in error:
+                error += (
+                    ". BindingDB's PDB lookup endpoint is failing for all "
+                    "structures, not just this one. Map the PDB entry to a "
+                    "UniProt accession with PDBeSIFTS_get_pdb_to_uniprot and "
+                    "query BindingDB_get_ligands_by_uniprot instead, or use "
+                    "get_binding_affinity_by_pdb_id for RCSB's own curated "
+                    "affinity data."
+                )
+            return {"status": "error", "error": error}
         return {
             "status": "success",
             "data": {"pdbs": ids, "cutoff": cutoff, "affinities": _affinities(result)},

--- a/src/tooluniverse/bvbrc_tool.py
+++ b/src/tooluniverse/bvbrc_tool.py
@@ -584,6 +584,21 @@ class BVBRCTool(BaseTool):
         if not taxon_id:
             return {"status": "error", "error": "taxon_id parameter is required"}
 
+        # /taxonomy/{id} is an NCBI-taxid lookup, so a species name reaches
+        # BV-BRC as a nonexistent path and comes back as a bare "HTTP error:
+        # 404" that says nothing about why. Reject the name here and name the
+        # tool that turns it into an id.
+        if not str(taxon_id).strip().isdigit():
+            return {
+                "status": "error",
+                "error": (
+                    f"taxon_id must be a numeric NCBI taxonomy ID (e.g. 573 for "
+                    f"Klebsiella pneumoniae), but got '{taxon_id}'. To look a "
+                    f"species up by name, call BVBRC_search_taxonomy with "
+                    f"keyword='{taxon_id}' and use the taxon_id it returns."
+                ),
+            }
+
         url = f"{BVBRC_BASE_URL}/taxonomy/{taxon_id}"
         headers = {"Accept": "application/json"}
         response = requests.get(url, headers=headers, timeout=self.timeout)

--- a/src/tooluniverse/chebi_tool.py
+++ b/src/tooluniverse/chebi_tool.py
@@ -20,6 +20,15 @@ from .tool_registry import register_tool
 
 CHEBI_BASE_URL = "https://www.ebi.ac.uk/chebi/backend/api/public"
 
+# advanced_search is server-side paginated at 15 hits per page and exposes the
+# page number as a 1-indexed query-string parameter (`?page=1` is the first
+# page and is byte-identical to omitting the parameter; `?page=0` and any page
+# beyond `number_pages` return a non-JSON error body). `limit` is clamped to
+# 100, so at most ceil(100 / 15) == 7 pages are ever needed; the cap below is
+# a hard stop that protects against a server that stops honouring `page`.
+_SEARCH_PAGE_SIZE = 15
+_SEARCH_MAX_PAGES = 8
+
 _HTML_TAG_RE = re.compile(r"<[^>]+>")
 
 
@@ -202,7 +211,11 @@ class ChEBITool(BaseTool):
 
         if limit is None:
             limit = 10
-        limit = min(limit, 100)
+        try:
+            limit = int(limit)
+        except (TypeError, ValueError):
+            limit = 10
+        limit = max(0, min(limit, 100))
 
         # Use advanced_search endpoint for better relevance
         url = f"{CHEBI_BASE_URL}/advanced_search/"
@@ -212,35 +225,90 @@ class ChEBITool(BaseTool):
             },
             "stars": [2, 3],
         }
-        response = requests.post(
-            url,
-            json=payload,
-            headers={"Content-Type": "application/json", "Accept": "application/json"},
-            timeout=self.timeout,
-        )
-        response.raise_for_status()
-        raw = response.json()
+        headers = {"Content-Type": "application/json", "Accept": "application/json"}
 
-        results = raw.get("results", [])
+        # The endpoint returns only one page (15 hits) per request, so a single
+        # POST can never satisfy limit > 15. Walk successive pages until we have
+        # `limit` compounds or the result set is exhausted.
         compounds = []
-        for hit in results[:limit]:
-            source = hit.get("_source", {})
-            # Strip HTML tags from name (ChEBI stores stereochemistry as HTML)
-            raw_name = source.get("name", "")
-            clean_name = re.sub(r"<[^>]+>", "", raw_name)
-            compounds.append(
-                {
-                    "chebi_accession": source.get("chebi_accession", ""),
-                    "name": clean_name,
-                    "formula": source.get("formula", None),
-                    "mass": source.get("mass", None),
-                    "stars": source.get("stars", None),
-                }
-            )
+        total_matches = None
+        number_pages = None
+        page = 1
+        pages_fetched = 0
+        while page <= _SEARCH_MAX_PAGES:
+            try:
+                response = requests.post(
+                    url,
+                    json=payload,
+                    params={"page": page},
+                    headers=headers,
+                    timeout=self.timeout,
+                )
+                response.raise_for_status()
+                raw = response.json()
+            except Exception:
+                # Never discard the pages already in hand: a failure while
+                # fetching page N > 1 degrades to "fewer results than asked
+                # for", not to an error. Only a failed first page is fatal.
+                if page == 1:
+                    raise
+                break
+
+            pages_fetched += 1
+
+            if not isinstance(raw, dict):
+                break
+
+            # `total` / `number_pages` are informational and may be absent on
+            # some responses; fall back to single-page behaviour rather than
+            # crashing or looping forever.
+            if total_matches is None and isinstance(raw.get("total"), int):
+                total_matches = raw["total"]
+            if number_pages is None and isinstance(raw.get("number_pages"), int):
+                number_pages = raw["number_pages"]
+
+            results = raw.get("results", [])
+            if not isinstance(results, list):
+                results = []
+
+            for hit in results:
+                source = hit.get("_source", {}) if isinstance(hit, dict) else {}
+                if not isinstance(source, dict):
+                    source = {}
+                compounds.append(
+                    {
+                        "chebi_accession": source.get("chebi_accession", ""),
+                        # Strip HTML tags from name (ChEBI stores
+                        # stereochemistry as HTML).
+                        "name": _strip_html(source.get("name", "")),
+                        "formula": source.get("formula", None),
+                        "mass": source.get("mass", None),
+                        "stars": source.get("stars", None),
+                    }
+                )
+
+            if len(compounds) >= limit:
+                break
+            if not results:
+                break
+            if number_pages is not None:
+                if page >= number_pages:
+                    break
+            elif len(results) < _SEARCH_PAGE_SIZE:
+                # No page metadata and a short page: this was the last one.
+                break
+            page += 1
+
+        compounds = compounds[:limit]
 
         result = {
             "query": query,
+            # `result_count` keeps its original meaning: how many compounds are
+            # in `compounds`. `total_matches` is how many the query matches in
+            # ChEBI overall, so a caller can distinguish "10 of 116" from
+            # "10 exist". It is None when the API omits the count.
             "result_count": len(compounds),
+            "total_matches": total_matches,
             "compounds": compounds,
         }
 
@@ -251,6 +319,7 @@ class ChEBITool(BaseTool):
                 "source": "ChEBI",
                 "query": query,
                 "endpoint": "advanced_search",
+                "pages_fetched": pages_fetched,
             },
         }
 

--- a/src/tooluniverse/chem_tool.py
+++ b/src/tooluniverse/chem_tool.py
@@ -390,8 +390,13 @@ class ChEMBLRESTTool(BaseTool):
             # Correct approach: query /activity.json?molecule_chembl_id=X and
             # deduplicate the target fields from the activity records.
             if tool_name == "ChEMBL_get_molecule_targets":
-                mol_id = arguments.get("molecule_chembl_id__exact") or arguments.get(
-                    "molecule_chembl_id"
+                mol_id = (
+                    arguments.get("molecule_chembl_id__exact")
+                    or arguments.get("molecule_chembl_id")
+                    # ChEMBL_get_molecule names this same identifier `chembl_id`,
+                    # so chaining its output into this tool otherwise failed
+                    # parameter validation on the ID you just looked up.
+                    or arguments.get("chembl_id")
                 )
                 if mol_id:
                     activity_url = self.base_url + "/activity.json"

--- a/src/tooluniverse/clinvar_tool.py
+++ b/src/tooluniverse/clinvar_tool.py
@@ -22,6 +22,105 @@ _CLINSIG_PROP_ALIASES = {
     "uncertain significance": "vus",
 }
 
+# The clinical-significance classes ClinVar's Entrez index ACTUALLY accepts.
+# Enumerated by live-probing every documented germline/oncogenicity class
+# through the exact clause this module builds
+# (`"clinsig <v>"[Filter] OR clinsig_<v>[prop]`, plus the alias above) against
+# db=clinvar with no other term, 2026-08. Only these returned a non-zero,
+# non-parenthesised (i.e. index-recognised) translation:
+#   pathogenic 256608 | likely pathogenic 165559 | uncertain significance
+#   2367938 | vus 2368057 | likely benign 1165994 | benign 281217 |
+#   established risk allele 6 | likely risk allele 119 | uncertain risk allele
+#   180 | drug response 2612 | not provided 7616 | other 2209 |
+#   risk factor 520
+# Documented-but-unindexed spellings ("Affects", "association", "protective",
+# "confers sensitivity", "Conflicting classifications of pathogenicity",
+# "Oncogenic", "Likely oncogenic", "Pathogenic, low penetrance", ...) all came
+# back 0 with Entrez wrapping the term in parentheses -- its signal for "this
+# term is not in the index". Accepting them would paste an unmatchable token
+# into the query and return a silent, filtered-to-nothing success, which is
+# exactly the failure this list exists to prevent.
+_CLINSIG_ACCEPTED = (
+    "Pathogenic",
+    "Likely pathogenic",
+    "Uncertain significance",
+    "VUS",
+    "Likely benign",
+    "Benign",
+    "Established risk allele",
+    "Likely risk allele",
+    "Uncertain risk allele",
+    "drug response",
+    "risk factor",
+    "not provided",
+    "other",
+)
+_CLINSIG_ACCEPTED_NORMALIZED = {v.lower() for v in _CLINSIG_ACCEPTED}
+
+
+def _normalize_clinsig(value: Any) -> list:
+    """Split a clinical-significance value on '/' and normalize each component
+    exactly the way the query builder does (lowercase, underscores/hyphens ->
+    spaces), so validation can never accept a spelling the builder would then
+    mangle. No accepted class contains a hyphen, and sibling variant tools emit
+    hyphenated spellings (dbSNP reports "risk-factor"), so folding them keeps a
+    chained call working instead of silently filtering to nothing."""
+    return [
+        re.sub(r"\s+", " ", re.sub(r"[_-]", " ", comp.strip().lower()))
+        for comp in str(value).split("/")
+        if comp.strip()
+    ]
+
+
+def _clinsig_query_clause(components: list) -> str:
+    """Build the Entrez clause for already-normalized clinsig components.
+
+    Single-word values are indexed under `"clinsig <v>"[Filter]`, compound ones
+    under `clinsig_<v_with_underscores>[prop]`, and a few classes under a
+    different NCBI token entirely (VUS); OR all applicable forms so a valid
+    class is never a silent false-empty. Multiple components (from a '/'
+    aggregate class) are OR'd into their union.
+    """
+    clauses = []
+    for comp in components:
+        forms = f'"clinsig {comp}"[Filter] OR clinsig_{comp.replace(" ", "_")}[prop]'
+        alias = _CLINSIG_PROP_ALIASES.get(comp)
+        if alias:
+            forms += f" OR clinsig_{alias}[prop]"
+        clauses.append(f"({forms})")
+    if not clauses:
+        return ""
+    return "(" + " OR ".join(clauses) + ")" if len(clauses) > 1 else clauses[0]
+
+
+def _invalid_clinsig_error(param_name: str, raw_value: Any, invalid: list) -> dict:
+    """Reject an unrecognised clinical-significance value at the input, naming
+    the offending PARAMETER.
+
+    Previously such a value was pasted straight into the Entrez term, matched
+    nothing, and the zero-result response then blamed the *gene* symbol -- so
+    `{"gene": "TP53", "clinical_significance": "Banana"}` told the caller to
+    go re-verify TP53, the one input that was never wrong.
+    """
+    return {
+        "status": "error",
+        "error": (
+            f"Unrecognized {param_name} value(s): "
+            + ", ".join(repr(i) for i in invalid)
+            + f" (from {str(raw_value)!r}). No filter was applied and no search "
+            "was run -- an unrecognized class matches nothing in ClinVar's "
+            "index, which would look like 'this gene has no such variants'. "
+            "ClinVar's clinical-significance index accepts only: "
+            + ", ".join(_CLINSIG_ACCEPTED)
+            + ". Case-insensitive; underscores are treated as spaces "
+            "(e.g. 'likely_pathogenic'). Combine two classes with '/' to search "
+            "their union (e.g. 'Pathogenic/Likely pathogenic')."
+        ),
+        "parameter": param_name,
+        "invalid_values": invalid,
+        "valid_values": list(_CLINSIG_ACCEPTED),
+    }
+
 
 class ClinVarRESTTool(BaseTool):
     """Base class for ClinVar REST API tools."""
@@ -184,8 +283,26 @@ class ClinVarSearchVariants(ClinVarRESTTool):
         # Normalize aliases before dispatch
         if not arguments.get("gene") and arguments.get("gene_symbol"):
             arguments = dict(arguments, gene=arguments["gene_symbol"])
+        _clnsig_param = "clinical_significance"
         if not arguments.get("clinical_significance") and arguments.get("significance"):
             arguments = dict(arguments, clinical_significance=arguments["significance"])
+            _clnsig_param = "significance"
+        # Validate the clinical-significance filter BEFORE anything is queried:
+        # an unrecognized class used to be pasted into the Entrez term, match
+        # nothing, and come back as a `status: success` with 0 results whose
+        # hint blamed the (perfectly valid) gene symbol instead.
+        clnsig_components = []
+        if str(arguments.get("clinical_significance") or "").strip():
+            clnsig_components = _normalize_clinsig(arguments["clinical_significance"])
+            invalid_clnsig = [
+                c for c in clnsig_components if c not in _CLINSIG_ACCEPTED_NORMALIZED
+            ]
+            if invalid_clnsig:
+                return _invalid_clinsig_error(
+                    _clnsig_param,
+                    arguments["clinical_significance"],
+                    invalid_clnsig,
+                )
         # An rsID (e.g. rs4244285) passed as `query` was aliased to `condition`
         # and searched as a DISEASE term ('rs4244285[dis]'), silently returning
         # 0 -- but ClinVar's free-text index DOES match a bare rsID (confirmed
@@ -373,26 +490,13 @@ class ClinVarSearchVariants(ClinVarRESTTool):
             # value. Treat "/" as OR and expand to the individual clinsig classes
             # (the clinically-actionable union), each via the proven
             # [Filter]-OR-[prop] path.
-            _raw_clnsig = str(arguments["clinical_significance"])
-            _components = [c.strip() for c in _raw_clnsig.split("/") if c.strip()]
-            compound_clnsig = len(_components) > 1
-            _clauses = []
-            for _comp in _components:
-                _c = _comp.lower().replace("_", " ")
-                _c_prop = _c.replace(" ", "_")
-                _forms = f'"clinsig {_c}"[Filter] OR clinsig_{_c_prop}[prop]'
-                # Some classes index under a different NCBI token (e.g. VUS);
-                # OR it in so a valid class is never a silent false-empty.
-                _alias = _CLINSIG_PROP_ALIASES.get(_c)
-                if _alias:
-                    _forms += f" OR clinsig_{_alias}[prop]"
-                _clauses.append(f"({_forms})")
-            if _clauses:
-                query_parts.append(
-                    "(" + " OR ".join(_clauses) + ")"
-                    if len(_clauses) > 1
-                    else _clauses[0]
-                )
+            # Values were normalized and validated against the live-verified
+            # accepted set up front (see _CLINSIG_ACCEPTED), so every component
+            # reaching here is known to exist in ClinVar's index.
+            compound_clnsig = len(clnsig_components) > 1
+            _clause = _clinsig_query_clause(clnsig_components)
+            if _clause:
+                query_parts.append(_clause)
 
         # Fix-R5D-1/R8C-1: a caller-supplied param that doesn't match any
         # recognized name/alias (e.g. "gene_name" instead of "gene") was
@@ -573,14 +677,58 @@ class ClinVarSearchVariants(ClinVarRESTTool):
             # the word, which would silently swap a false-empty for a
             # false-positive result set -- worse than reporting nothing.
             # Surface the ambiguity instead of guessing.
-            response_data["zero_result_hint"] = (
-                f"No ClinVar records matched gene '{arguments['gene']}'. "
-                "ClinVar's gene index only recognizes the current official "
-                "HGNC symbol (e.g. 'DMD', not the protein name 'dystrophin' "
-                "or an outdated/misspelled symbol) -- verify the symbol "
-                "(e.g. via HGNC_search_genes or NCBIDatasets_get_gene) "
-                "before concluding this gene has no reported variants."
+            #
+            # ...but only blame the GENE when the gene is actually what failed.
+            # When other filters narrowed the query, a 0 count says nothing
+            # about the symbol, and the hint used to send callers off to
+            # re-verify a symbol that was never the problem. Establish the
+            # facts with one cheap count-only query on the bare gene term
+            # before attributing the empty result to anything.
+            other_filters = [
+                name
+                for name, present in (
+                    ("condition", bool(arguments.get("condition"))),
+                    ("variant_id", "variant_id" in arguments),
+                    ("variant_name", bool(arguments.get("variant_name"))),
+                    ("rsid", bool(arguments.get("rsid"))),
+                    ("raw_term", bool(arguments.get("raw_term"))),
+                    (_clnsig_param, bool(clnsig_components)),
+                )
+                if present
+            ]
+            gene_only_count = (
+                self._count_for_term(f"{gene}[gene]") if other_filters else None
             )
+            if other_filters and gene_only_count is None:
+                response_data["zero_result_hint"] = (
+                    f"No ClinVar records matched gene '{arguments['gene']}' "
+                    f"combined with {', '.join(other_filters)}. The gene symbol "
+                    "could not be checked on its own (follow-up query failed), "
+                    "so it is unknown whether the symbol or the other filter(s) "
+                    "produced the empty result -- retry with the filters removed "
+                    "to tell them apart."
+                )
+            elif gene_only_count:
+                response_data["gene_only_match_count"] = gene_only_count
+                response_data["zero_result_hint"] = (
+                    f"The gene symbol '{arguments['gene']}' is fine: it matches "
+                    f"{gene_only_count} ClinVar record(s) on its own. The empty "
+                    f"result comes from the other filter(s) -- "
+                    f"{', '.join(other_filters)} -- which no record for this gene "
+                    "satisfies. Relax or correct them (or drop them to see the "
+                    "gene's full record set) rather than re-checking the symbol."
+                )
+            else:
+                if gene_only_count is not None:
+                    response_data["gene_only_match_count"] = gene_only_count
+                response_data["zero_result_hint"] = (
+                    f"No ClinVar records matched gene '{arguments['gene']}'. "
+                    "ClinVar's gene index only recognizes the current official "
+                    "HGNC symbol (e.g. 'DMD', not the protein name 'dystrophin' "
+                    "or an outdated/misspelled symbol) -- verify the symbol "
+                    "(e.g. via HGNC_search_genes or NCBIDatasets_get_gene) "
+                    "before concluding this gene has no reported variants."
+                )
         if compound_clnsig:
             response_data["clinical_significance_note"] = (
                 "The '/' in the requested clinical_significance was treated as OR: "
@@ -589,6 +737,23 @@ class ClinVarSearchVariants(ClinVarRESTTool):
                 "'Pathogenic/Likely pathogenic' review class."
             )
         return {"status": "success", "data": response_data}
+
+    def _count_for_term(self, term: str) -> "int | None":
+        """Count-only eSearch for `term` (retmax=0, no summaries fetched).
+
+        Used to establish, rather than assume, which input caused an empty
+        result. Best-effort: returns None on any failure, never raises.
+        """
+        try:
+            result = self._make_request(
+                self.endpoint,
+                {"db": "clinvar", "term": term, "retmode": "json", "retmax": 0},
+            )
+            if result.get("status") != "success":
+                return None
+            return int(result["data"]["esearchresult"]["count"])
+        except (KeyError, TypeError, ValueError, AttributeError):
+            return None
 
     def _resolve_deprecated_gene_symbol(self, gene: str) -> Optional[str]:
         """Look up `gene` in NCBI's own gene database (which tracks
@@ -759,7 +924,21 @@ def clinvar_variants_overlapping(
     hi = int(end) + int(margin)
     term = f"{chrom}[chr] AND {lo}:{hi}[{tag}]"
     if significance:
-        term += f' AND "{significance}"[clinsig]'
+        # [clinsig] is not a ClinVar eSearch field -- Entrez silently degraded
+        # it to [All Fields] (confirmed live: chr17 BRCA1 window, 15508 hits
+        # unfiltered vs 13782 with '"Pathogenic"[clinsig]', i.e. a free-text
+        # match that also keeps "Likely pathogenic" and "Conflicting
+        # classifications of pathogenicity" records). Use the same verified
+        # [Filter]/[prop] clause the gene search uses. Values are validated by
+        # the caller against _CLINSIG_ACCEPTED.
+        components = (
+            significance
+            if isinstance(significance, list)
+            else _normalize_clinsig(significance)
+        )
+        clause = _clinsig_query_clause(components)
+        if clause:
+            term += f" AND {clause}"
 
     es = session.get(
         "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi",
@@ -843,6 +1022,25 @@ class ClinVarSearchByRegion(ClinVarRESTTool):
                 "status": "error",
                 "error": "Provide chrom/start/end, or region like 'chr7:155593770-155593780'.",
             }
+        # Same input validation as ClinVar_search_variants: an unrecognized
+        # class must not reach the query, where it would silently filter the
+        # region's variants down to nothing under a `status: success`.
+        clnsig_param = (
+            "clinical_significance"
+            if arguments.get("clinical_significance")
+            else "significance"
+        )
+        raw_clnsig = arguments.get("clinical_significance") or arguments.get(
+            "significance"
+        )
+        clnsig_components = []
+        if str(raw_clnsig or "").strip():
+            clnsig_components = _normalize_clinsig(raw_clnsig)
+            invalid_clnsig = [
+                c for c in clnsig_components if c not in _CLINSIG_ACCEPTED_NORMALIZED
+            ]
+            if invalid_clnsig:
+                return _invalid_clinsig_error(clnsig_param, raw_clnsig, invalid_clnsig)
         try:
             result = clinvar_variants_overlapping(
                 self.session,
@@ -851,8 +1049,7 @@ class ClinVarSearchByRegion(ClinVarRESTTool):
                 int(end),
                 assembly=arguments.get("assembly", "GRCh37"),
                 margin=int(arguments.get("margin", 2_000_000)),
-                significance=arguments.get("clinical_significance")
-                or arguments.get("significance"),
+                significance=clnsig_components or None,
                 max_results=int(arguments.get("max_results", 50)),
                 timeout=self.timeout,
             )

--- a/src/tooluniverse/compound_disease_tool.py
+++ b/src/tooluniverse/compound_disease_tool.py
@@ -5,10 +5,42 @@ returning identifiers, associated genes, phenotypes, and prevalence data
 in a single call.
 """
 
+import re
 from typing import Any, Dict, List
 
 from .base_tool import BaseTool
 from .tool_registry import register_tool
+
+# Disease nomenclature mixes Roman and Arabic subtype numbers freely --
+# "Mucopolysaccharidosis type I" (query), "Mucopolysaccharidosis Type I"
+# (NCIT) and "Mucopolysaccharidosis type 1" (Orphanet) are one disease.
+_ROMAN_TO_ARABIC = {
+    "i": "1",
+    "ii": "2",
+    "iii": "3",
+    "iv": "4",
+    "v": "5",
+    "vi": "6",
+    "vii": "7",
+    "viii": "8",
+    "ix": "9",
+    "x": "10",
+}
+
+
+def _normalize_disease_label(text: str) -> str:
+    """Fold a disease name to a comparable form: lowercase, punctuation-free,
+    with Roman subtype numerals rewritten as Arabic."""
+    tokens = re.split(r"[^0-9a-z]+", (text or "").lower())
+    return " ".join(_ROMAN_TO_ARABIC.get(t, t) for t in tokens if t)
+
+
+def _labels_match(query: str, label: str) -> bool:
+    """True when `label` names the same disease the caller asked for."""
+    normalized_query = _normalize_disease_label(query)
+    return (
+        bool(normalized_query) and _normalize_disease_label(label) == normalized_query
+    )
 
 
 def _truncate_msg(msg: str, limit: int = 240) -> str:
@@ -61,7 +93,7 @@ class CompoundDiseaseProfileTool(BaseTool):
         r = _try_tool(
             "Orphanet", "Orphanet_search_diseases", {"query": disease, "language": "en"}
         )
-        sections["orphanet"] = self._parse_orphanet(r)
+        sections["orphanet"] = self._parse_orphanet(r, disease)
 
         # 2. OMIM
         r = _try_tool("OMIM", "OMIM_search", {"query": disease, "limit": 5})
@@ -97,22 +129,38 @@ class CompoundDiseaseProfileTool(BaseTool):
             },
         }
 
-    def _parse_orphanet(self, result: Any) -> Dict[str, Any]:
+    @staticmethod
+    def _entry_label(entry: Dict[str, Any]) -> str:
+        return entry.get(
+            "Preferred term", entry.get("preferred_term", entry.get("name", ""))
+        )
+
+    def _parse_orphanet(self, result: Any, query: str) -> Dict[str, Any]:
         if not isinstance(result, dict) or result.get("status") == "error":
             return {}
         data = result.get("data", {})
         results_list = data.get("results", data) if isinstance(data, dict) else data
-        if isinstance(results_list, list) and results_list:
-            entry = results_list[0] if isinstance(results_list[0], dict) else {}
-            return {
-                "orpha_code": str(entry.get("ORPHAcode", entry.get("orpha_code", ""))),
-                "name": entry.get(
-                    "Preferred term", entry.get("preferred_term", entry.get("name", ""))
-                ),
-                "prevalence": entry.get("prevalence", ""),
-                "inheritance": entry.get("inheritance", ""),
-            }
-        return {}
+        if not isinstance(results_list, list) or not results_list:
+            return {}
+        entries = [e for e in results_list if isinstance(e, dict)]
+        if not entries:
+            return {}
+        # Orphanet's search is ranked by its own relevance, not by name
+        # equality: "mucopolysaccharidosis type I" puts MPS VI (ORPHA:583)
+        # first and the real MPS I (ORPHA:579) fourth. Taking results[0]
+        # therefore stamped a different disease's ORPHA code onto the
+        # profile. Prefer the hit whose name actually matches the query.
+        exact = next(
+            (e for e in entries if _labels_match(query, self._entry_label(e))), None
+        )
+        entry = exact or entries[0]
+        return {
+            "orpha_code": str(entry.get("ORPHAcode", entry.get("orpha_code", ""))),
+            "name": self._entry_label(entry),
+            "prevalence": entry.get("prevalence", ""),
+            "inheritance": entry.get("inheritance", ""),
+            "match": "exact" if exact is not None else "approximate",
+        }
 
     def _parse_omim(self, result: Any) -> Dict[str, Any]:
         if not isinstance(result, dict):
@@ -216,11 +264,21 @@ class CompoundDiseaseProfileTool(BaseTool):
         return {"terms": terms}
 
     def _build_profile(self, disease: str, sections: Dict[str, Any]) -> Dict[str, Any]:
-        """Build a unified disease profile from all sources."""
+        """Build a unified disease profile from all sources.
+
+        `identifiers` is the block downstream callers treat as "the IDs for
+        this disease", so only cross-references whose own label names the
+        queried disease belong in it. Every source is a ranked search, and
+        their top hits routinely disagree: for "mucopolysaccharidosis type I"
+        the unfiltered version emitted Orphanet 583 (MPS VI), MeSH D009085
+        (MPS IV) and ORDO 217085 (MPS II severe) side by side under one
+        disease name. Non-matching hits stay visible in `per_source` -- they
+        are just not promoted to identifiers.
+        """
         profile: Dict[str, Any] = {"disease": disease, "identifiers": {}}
 
         orphanet = sections.get("orphanet", {})
-        if orphanet.get("orpha_code"):
+        if orphanet.get("orpha_code") and orphanet.get("match") == "exact":
             profile["identifiers"]["orphanet"] = orphanet["orpha_code"]
         if orphanet.get("prevalence"):
             profile["prevalence"] = orphanet["prevalence"]
@@ -234,7 +292,7 @@ class CompoundDiseaseProfileTool(BaseTool):
                 profile["identifiers"]["omim"] = mim
 
         ot = sections.get("opentargets", {})
-        if ot.get("efo_id"):
+        if ot.get("efo_id") and _labels_match(disease, ot.get("name", "")):
             profile["identifiers"]["efo"] = ot["efo_id"]
         if ot.get("description"):
             profile["description"] = ot["description"]
@@ -243,7 +301,11 @@ class CompoundDiseaseProfileTool(BaseTool):
         if ols.get("terms"):
             for term in ols["terms"]:
                 ont = term.get("ontology", "").lower()
-                if ont and term.get("id"):
+                if (
+                    ont
+                    and term.get("id")
+                    and _labels_match(disease, term.get("label", ""))
+                ):
                     profile["identifiers"][ont] = term["id"]
 
         disgenet = sections.get("disgenet", {})

--- a/src/tooluniverse/ctg_tool.py
+++ b/src/tooluniverse/ctg_tool.py
@@ -24,7 +24,7 @@ def _phrase_quote_if_plain(value: str) -> str:
     return value
 
 
-def _restrict_to_area(value: str, area: str) -> str:
+def _restrict_to_area(value: str, areas: tuple) -> str:
     """Fix-R13B-1: CTG API v2's Essie search engine treats a bare
     query.intr/query.spons value as a match against the whole study
     record (brief summaries, arm descriptions, eligibility text, etc.)
@@ -40,10 +40,77 @@ def _restrict_to_area(value: str, area: str) -> str:
     phrase-quoting multi-word values, same as _phrase_quote_if_plain)
     fixes this -- but only for a plain value with no existing Essie
     syntax, since advanced users may already supply their own
-    AREA/boolean operators."""
+    AREA/boolean operators.
+
+    Fix-R23-1: restricting an intervention query to AREA[InterventionName]
+    *alone* went too far the other way. Registrants record brand names in
+    the separate InterventionOtherName (synonym) field, so a brand-name
+    query all but vanished while its generic returned a full set --
+    confirmed live: 'Eliquis' + atrial fibrillation matched 5 trials on
+    InterventionName vs. 43 once other-names are included, and 'Opdualag'
+    + melanoma went 2 -> 19. Searching both name fields recovers those
+    without reopening R13B-1's hole, since the noise it removed came from
+    description/arm-label text that neither name field contains (checked
+    against the unrestricted counts: vedolizumab 134 -> 142 vs. 215
+    unrestricted, apixaban 96 -> 108 vs. 189)."""
     if _ESSIE_OPERATOR_RE.search(value):
         return value
-    return f"AREA[{area}]{_phrase_quote_if_plain(value)}"
+    quoted = _phrase_quote_if_plain(value)
+    clauses = [f"AREA[{area}]{quoted}" for area in areas]
+    if len(clauses) == 1:
+        return clauses[0]
+    return "(" + " OR ".join(clauses) + ")"
+
+
+# Fix-R23-2: CTG API v2 rejects anything but its exact upper-snake enum
+# spellings, and it does so with a bare HTTP 400 whose remediation reads
+# "Retry the request / Check service status / Report issue if persistent" --
+# advice that is actively wrong when the caller simply typed
+# filter_status='recruiting' or filter_phase='Phase 3'. Both are the natural
+# spellings (and 'Phase 3' is how ClinicalTrials.gov renders it on screen), so
+# normalize them here and reject anything genuinely unknown at input with the
+# legal values named, rather than letting a user-input error come back dressed
+# as a service outage.
+_CTG_STATUS_VALUES = (
+    "ACTIVE_NOT_RECRUITING",
+    "APPROVED_FOR_MARKETING",
+    "AVAILABLE",
+    "COMPLETED",
+    "ENROLLING_BY_INVITATION",
+    "NO_LONGER_AVAILABLE",
+    "NOT_YET_RECRUITING",
+    "RECRUITING",
+    "SUSPENDED",
+    "TEMPORARILY_NOT_AVAILABLE",
+    "TERMINATED",
+    "UNKNOWN",
+    "WITHDRAWN",
+    "WITHHELD",
+)
+
+_CTG_PHASE_VALUES = (
+    "EARLY_PHASE1",
+    "NA",
+    "PHASE1",
+    "PHASE2",
+    "PHASE3",
+    "PHASE4",
+)
+
+
+def _canonicalize_enum(value: str, allowed: tuple):
+    """Map a loosely-spelled enum value onto its exact CTG spelling.
+
+    Comparison ignores case and every non-alphanumeric separator, so
+    'recruiting', 'Active, not recruiting' and 'Phase 3' all resolve.
+    Returns None when the value matches nothing, so the caller can raise a
+    validation error naming the legal set.
+    """
+
+    def _key(v):
+        return "".join(ch for ch in str(v).upper() if ch.isalnum())
+
+    return {_key(a): a for a in allowed}.get(_key(value))
 
 
 @register_tool("ClinicalTrialsTool")
@@ -185,8 +252,10 @@ class ClinicalTrialsTool(RESTfulTool):
     # Essie fields that get restricted via AREA[<name>] rather than a plain
     # value match (see _restrict_to_area). Keyed by the mapped API param name.
     _AREA_RESTRICTED_FIELDS = {
-        "query.intr": "InterventionName",
-        "query.spons": "LeadSponsorName",
+        # InterventionOtherName holds registrant-supplied synonyms, which is
+        # where brand names live (see Fix-R23-1 in _restrict_to_area).
+        "query.intr": ("InterventionName", "InterventionOtherName"),
+        "query.spons": ("LeadSponsorName",),
     }
 
     def _run_search(self, arguments):
@@ -224,7 +293,24 @@ class ClinicalTrialsTool(RESTfulTool):
                 continue
             if key == "filter_phase":
                 # CTG API v2 uses filter.advanced for phase, not filter.phase
-                phases = [p.strip() for p in value.split(",")]
+                phases = []
+                for raw in str(value).split(","):
+                    raw = raw.strip()
+                    if not raw:
+                        continue
+                    canonical = _canonicalize_enum(raw, _CTG_PHASE_VALUES)
+                    if canonical is None:
+                        return {
+                            "status": "error",
+                            "error": (
+                                f"Invalid filter_phase value '{raw}'. "
+                                f"Valid values are: {', '.join(_CTG_PHASE_VALUES)}. "
+                                "Comma-separate to combine (e.g. 'PHASE2,PHASE3')."
+                            ),
+                        }
+                    phases.append(canonical)
+                if not phases:
+                    continue
                 phase_clause = " OR ".join(f"AREA[Phase]{p}" for p in phases)
                 if len(phases) > 1:
                     phase_clause = f"({phase_clause})"
@@ -240,7 +326,30 @@ class ClinicalTrialsTool(RESTfulTool):
                 advanced_clauses.append(study_type_clause)
             elif key in _SEARCH_PARAM_MAP:
                 mapped_key = _SEARCH_PARAM_MAP[key]
-                if mapped_key == "query.cond" and isinstance(value, str):
+                if mapped_key == "filter.overallStatus":
+                    statuses = []
+                    raw_values = (
+                        value if isinstance(value, list) else str(value).split(",")
+                    )
+                    for raw in raw_values:
+                        raw = str(raw).strip()
+                        if not raw:
+                            continue
+                        canonical = _canonicalize_enum(raw, _CTG_STATUS_VALUES)
+                        if canonical is None:
+                            return {
+                                "status": "error",
+                                "error": (
+                                    f"Invalid status value '{raw}'. Valid values "
+                                    f"are: {', '.join(_CTG_STATUS_VALUES)}. "
+                                    "Comma-separate to combine."
+                                ),
+                            }
+                        statuses.append(canonical)
+                    if not statuses:
+                        continue
+                    value = ",".join(statuses)
+                elif mapped_key == "query.cond" and isinstance(value, str):
                     value = _phrase_quote_if_plain(value)
                 elif mapped_key in self._AREA_RESTRICTED_FIELDS and isinstance(
                     value, str
@@ -260,6 +369,20 @@ class ClinicalTrialsTool(RESTfulTool):
         studies = []
         for s in data.get("studies", []):
             proto = s.get("protocolSection", {})
+            # Fix-R23-3: the intervention list is capped at 5 for brevity, but
+            # it used to be sliced with no count and no flag -- so a study that
+            # genuinely matched the queried drug could come back listing five
+            # *other* interventions and read as a false positive (e.g.
+            # NCT03337698 is a real tiragolumab trial with 18 interventions,
+            # none of which survived the slice). Report the true count so a
+            # short list can be told apart from a truncated one.
+            all_interventions = [
+                iv.get("name")
+                for iv in proto.get("armsInterventionsModule", {}).get(
+                    "interventions", []
+                )
+                if iv.get("name")
+            ]
             studies.append(
                 {
                     "nct_id": proto.get("identificationModule", {}).get("nctId"),
@@ -275,13 +398,9 @@ class ClinicalTrialsTool(RESTfulTool):
                     "conditions": proto.get("conditionsModule", {}).get(
                         "conditions", []
                     ),
-                    "interventions": [
-                        iv.get("name")
-                        for iv in proto.get("armsInterventionsModule", {}).get(
-                            "interventions", []
-                        )
-                        if iv.get("name")
-                    ][:5],
+                    "interventions": all_interventions[:5],
+                    "intervention_count": len(all_interventions),
+                    "interventions_truncated": len(all_interventions) > 5,
                     "sponsor": (
                         proto.get("sponsorCollaboratorsModule", {}).get("leadSponsor")
                         or {}
@@ -588,6 +707,18 @@ class ClinicalTrialsSearchTool(ClinicalTrialsTool):
             "consider searching https://clinicaltrials.gov/ directly for "
             "NA-phase/observational studies."
         )
+        # Fix-R23-5: this note used to be attached only when the filter
+        # produced zero results, so a caller who got a healthy-looking list
+        # never learned that phase-1 and observational studies had been
+        # dropped from it -- exactly the studies a landscape scan must not
+        # miss. A non-empty result is just as filtered as an empty one, so
+        # disclose the filter whenever it was applied.
+        nonempty_phase_filter_note = (
+            "Results exclude phase-1-only, phase-NA, and observational studies "
+            "(this tool filters to phase 2/3/4 by default), so this is not the "
+            "complete set of matching trials on ClinicalTrials.gov. Use "
+            "ClinicalTrials_search_studies for an unfiltered search."
+        )
 
         # Fix-Round3-002: a well-formed query that legitimately matches zero
         # trials (empty `studies` list) is a success, not the error below --
@@ -597,8 +728,12 @@ class ClinicalTrialsSearchTool(ClinicalTrialsTool):
         # _simplify_output handles an empty list fine on its own.
         if response is not None and response and "studies" in response.keys():
             metadata = {"source": "ClinicalTrials.gov API v2"}
-            if phase_filter_applied and not response.get("studies"):
-                metadata["note"] = phase_filter_note
+            if phase_filter_applied:
+                metadata["note"] = (
+                    phase_filter_note
+                    if not response.get("studies")
+                    else nonempty_phase_filter_note
+                )
             return {
                 "status": "success",
                 "data": self._simplify_output(response),
@@ -846,6 +981,15 @@ class ClinicalTrialsDetailsTool(ClinicalTrialsTool):
         formatted_endpoint_url = self.endpoint_url
 
         responses = []
+        # Fix-R23-4: execute_RESTful_query returns a falsy value for every kind
+        # of failure -- HTTP error, timeout, undecodable JSON -- and each of
+        # those was dropped here without a trace. A transient upstream blip
+        # therefore surfaced as either a short result set (some IDs silently
+        # missing) or the "No relevant information found" message below, which
+        # reads as "this trial has no eligibility criteria" for a trial that
+        # demonstrably has them. Fetch failures and genuinely-absent data are
+        # different answers and must not share a response.
+        failed_ids = []
         for nct_id in nct_ids_list:
             formatted_endpoint_url = self._format_endpoint_url({"nctId": nct_id})
             response = execute_RESTful_query(
@@ -853,6 +997,8 @@ class ClinicalTrialsDetailsTool(ClinicalTrialsTool):
             )
             if response:
                 responses.append(response)
+            else:
+                failed_ids.append(nct_id)
 
         if query_type not in {"outcome", "safety"}:
             responses = [
@@ -880,12 +1026,36 @@ class ClinicalTrialsDetailsTool(ClinicalTrialsTool):
         # failure signal; a request that fetched real trials but simply
         # found no matching field data for them is a legitimate success.
         if not responses:
+            if failed_ids:
+                return {
+                    "status": "error",
+                    "error": (
+                        "Could not retrieve any of the requested studies from "
+                        f"ClinicalTrials.gov: {', '.join(failed_ids)}. This is a "
+                        "fetch failure (network error, timeout, or an "
+                        "unparseable API response), not a statement that these "
+                        "trials lack the requested data. Verify the NCT IDs and "
+                        "retry."
+                    ),
+                }
             return {
                 "status": "error",
                 "error": "No relevant information found for the given NCT IDs.",
             }
 
-        return {"status": "success", "data": responses}
+        result = {"status": "success", "data": responses}
+        if failed_ids:
+            result["metadata"] = {
+                "failed_nct_ids": failed_ids,
+                "note": (
+                    f"{len(failed_ids)} of {len(nct_ids_list)} requested studies "
+                    f"could not be retrieved ({', '.join(failed_ids)}) and are "
+                    "absent from `data`. These were fetch failures, not trials "
+                    "lacking the requested data -- retry them before concluding "
+                    "anything about them."
+                ),
+            }
+        return result
 
     def _simplify_output(self, study, query_type):
         """Manually extract generally most useful information"""

--- a/src/tooluniverse/data/alphafold_tools.json
+++ b/src/tooluniverse/data/alphafold_tools.json
@@ -18,6 +18,10 @@
           "type": "string",
           "description": "Alias for qualifier: UniProt accession (e.g., 'P69905')."
         },
+        "accession": {
+          "type": "string",
+          "description": "Alias for qualifier. UniProt accession (e.g., 'P04637') -- the same parameter name the UniProt_*_by_accession tools use."
+        },
         "sequence_checksum": {
           "type": "string",
           "description": "Optional CRC64 checksum of the UniProt sequence."
@@ -280,6 +284,10 @@
         "uniprot_accession": {
           "type": "string",
           "description": "Alias for qualifier. UniProt accession (e.g., 'P04637')."
+        },
+        "accession": {
+          "type": "string",
+          "description": "Alias for qualifier. UniProt accession (e.g., 'P04637') -- the same parameter name the UniProt_*_by_accession tools use."
         }
       },
       "required": []
@@ -517,6 +525,10 @@
         "uniprot_accession": {
           "type": "string",
           "description": "Alias for qualifier. UniProt accession (e.g., 'P69905')."
+        },
+        "accession": {
+          "type": "string",
+          "description": "Alias for qualifier. UniProt accession (e.g., 'P04637') -- the same parameter name the UniProt_*_by_accession tools use."
         }
       },
       "required": []

--- a/src/tooluniverse/data/aopwiki_tools.json
+++ b/src/tooluniverse/data/aopwiki_tools.json
@@ -2,10 +2,15 @@
   {
     "name": "AOPWiki_list_aops",
     "type": "AOPWikiListTool",
-    "description": "List Adverse Outcome Pathways (AOPs) from AOPWiki. Returns AOP IDs, titles, and short names. AOPs describe causal chains from molecular initiating events through key events to adverse outcomes, used in toxicology and risk assessment.",
+    "description": "List Adverse Outcome Pathways (AOPs) from AOPWiki. Returns AOP IDs, titles, and short names. AOPs describe causal chains from molecular initiating events through key events to adverse outcomes, used in toxicology and risk assessment. Pass `search` to keep only AOPs whose title or short name contains a keyword (e.g. 'thyroid', 'PPAR', 'steatosis') -- AOPWiki publishes ~600 AOPs, so an unfiltered list is rarely what you want. Use AOPWiki_get_aop on a returned ID for its key events, stressor chemicals, and causal relationships.",
     "parameter": {
       "type": "object",
-      "properties": {}
+      "properties": {
+        "search": {
+          "type": "string",
+          "description": "Case-insensitive keyword to filter AOPs by title or short name. Omit to return every AOP."
+        }
+      }
     },
     "return_schema": {
       "type": "array",
@@ -19,7 +24,8 @@
       }
     },
     "test_examples": [
-      {}
+      {},
+      {"search": "thyroid"}
     ],
     "label": ["AOPWiki", "Toxicology", "Adverse Outcome Pathway"],
     "metadata": {

--- a/src/tooluniverse/data/chebi_tools.json
+++ b/src/tooluniverse/data/chebi_tools.json
@@ -112,7 +112,7 @@
   },
   {
     "name": "ChEBI_search",
-    "description": "Search the ChEBI database for chemical entities by name, formula, or keyword. Uses Elasticsearch-powered full-text search across compound names, synonyms, definitions, and formulas. Returns matching compounds with IDs, names, formulas, and masses. Note: smiles and inchikey are not available from the search endpoint (use ChEBI_get_compound for structural data). Compound names are HTML-stripped. ChEBI contains 195,000+ chemical entities of biological interest.",
+    "description": "Search the ChEBI database for chemical entities by name, formula, or keyword. Uses Elasticsearch-powered full-text search across compound names, synonyms, definitions, and formulas. Returns matching compounds with IDs, names, formulas, and masses. Note: smiles and inchikey are not available from the search endpoint (use ChEBI_get_compound for structural data). Compound names are HTML-stripped. ChEBI contains 195,000+ chemical entities of biological interest. The underlying API paginates at 15 hits per page; this tool fetches as many pages as needed to satisfy 'limit' and reports the full size of the match set as 'total_matches'.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -125,7 +125,7 @@
             "integer",
             "null"
           ],
-          "description": "Maximum number of results to return. Default: 10. Max: 100."
+          "description": "Maximum number of compounds to return. Default: 10. Max: 100. Values above 15 are served by fetching additional API pages, so they cost extra requests."
         }
       },
       "required": [
@@ -155,7 +155,15 @@
               "type": "string"
             },
             "result_count": {
-              "type": "integer"
+              "type": "integer",
+              "description": "Number of compounds actually returned in 'compounds' (at most 'limit')."
+            },
+            "total_matches": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Total number of compounds in ChEBI matching the query, which may be far larger than result_count. Null when the API does not report a count. Compare against result_count to tell '10 returned of 116 matching' from 'only 10 exist'."
             },
             "compounds": {
               "type": "array",

--- a/src/tooluniverse/data/chembl_tools.json
+++ b/src/tooluniverse/data/chembl_tools.json
@@ -283,6 +283,10 @@
           "type": "string",
           "description": "Alias for molecule_chembl_id__exact. ChEMBL molecule ID."
         },
+        "chembl_id": {
+          "type": "string",
+          "description": "Alias for molecule_chembl_id__exact. Accepts the same name ChEMBL_get_molecule uses, so an ID can be carried straight from that call into this one."
+        },
         "limit": {
           "type": "integer",
           "default": 500,

--- a/src/tooluniverse/data/clinvar_tools.json
+++ b/src/tooluniverse/data/clinvar_tools.json
@@ -41,7 +41,7 @@
                 },
                 "clinical_significance": {
                     "type": "string",
-                    "description": "Filter by clinical significance (e.g., 'Pathogenic', 'Likely pathogenic', 'Benign', 'Uncertain significance', 'VUS'). Applied client-side after retrieval."
+                    "description": "Filter by clinical significance. Must be one of the classes ClinVar's index actually recognizes: 'Pathogenic', 'Likely pathogenic', 'Uncertain significance', 'VUS', 'Likely benign', 'Benign', 'Established risk allele', 'Likely risk allele', 'Uncertain risk allele', 'drug response', 'risk factor', 'not provided', 'other'. Case-insensitive; underscores/hyphens are treated as spaces. Combine two classes with '/' to search their union (e.g. 'Pathogenic/Likely pathogenic'). Any other value is rejected with an error rather than silently filtering the results to nothing."
                 },
                 "gene_symbol": {
                     "type": [
@@ -55,7 +55,7 @@
                         "string",
                         "null"
                     ],
-                    "description": "Alias for clinical_significance (e.g., \"pathogenic\", \"benign\", \"uncertain_significance\")."
+                    "description": "Alias for clinical_significance (e.g., \"pathogenic\", \"benign\", \"uncertain_significance\"). Same accepted value set and same validation as clinical_significance."
                 },
                 "query": {
                     "type": [

--- a/src/tooluniverse/data/disease_target_score_tools.json
+++ b/src/tooluniverse/data/disease_target_score_tools.json
@@ -11,7 +11,7 @@
         },
         "datasourceId": {
           "type": "string",
-          "description": "The datasource ID to extract scores from. Available options: 'clinical_precedence', 'eva', 'eva_somatic', 'cancer_gene_census', 'cancer_biomarkers', 'europepmc', 'expression_atlas', 'genomics_england', 'impc', 'reactome', 'uniprot_literature', 'uniprot_variants'"
+          "description": "The datasource ID to extract scores from. Available options: 'gwas_credible_sets' (genetic/GWAS association), 'gene_burden', 'clinical_precedence', 'eva', 'eva_somatic', 'cancer_gene_census', 'cancer_biomarkers', 'europepmc', 'expression_atlas', 'genomics_england', 'impc', 'reactome', 'uniprot_literature', 'uniprot_variants'. Two IDs were retired upstream and now match nothing rather than erroring: 'ot_genetics_portal' became 'gwas_credible_sets' and 'chembl' became 'clinical_precedence'; both retired names are remapped automatically and reported in datasource_rename_note."
         },
         "pageSize": {
           "type": "integer",

--- a/src/tooluniverse/data/gwas_tools.json
+++ b/src/tooluniverse/data/gwas_tools.json
@@ -1965,6 +1965,14 @@
         },
         "total_found": {
           "type": "integer"
+        },
+        "queried_gene_name": {
+          "type": "string",
+          "description": "Present only when the requested symbol matched nothing and an unhyphenated spelling was used instead; holds the symbol originally requested."
+        },
+        "gene_name_note": {
+          "type": "string",
+          "description": "Present only when the requested symbol matched nothing and an unhyphenated spelling was used instead; explains which spelling produced these results."
         }
       }
     },

--- a/src/tooluniverse/data/hpa_tools.json
+++ b/src/tooluniverse/data/hpa_tools.json
@@ -599,7 +599,7 @@
   {
     "type": "HPAGetRnaExpressionByTissueTool",
     "name": "HPA_get_rna_expression_in_specific_tissues",
-    "description": "Query RNA expression levels (nTPM) for a specific gene in one or more user-specified tissues with precise tissue matching. Note: HPA's rna_expression_in_specific_tissues endpoint returns 'No data' for many genes; test_examples removed pending a list of pre-populated ENSG ids.",
+    "description": "Query RNA expression levels (nTPM) for a specific gene in one or more user-specified tissues. Reads HPA's full per-tissue nTPM panel (the 'Tissue RNA - <tissue> [nTPM]' columns), so any of HPA's ~50 published tissues and brain regions can be queried, e.g. 'cerebral cortex', 'basal ganglia', 'midbrain', 'liver'. A tissue reported as 'Not found' means the tissue name is unrecognized by HPA, not that the gene lacks expression there.",
     "fields": {
       "endpoint": "https://www.proteinatlas.org/{ensembl_id}.json",
       "timeout": 30,
@@ -626,7 +626,7 @@
       ]
     },
     "input_description": "Input an Ensembl Gene ID and a list of tissue names. The tool will perform intelligent tissue name matching.",
-    "output_description": "Returns a dictionary mapping queried tissue names to their expression data, including matched tissue name, expression value in nTPM, and categorized expression level (Very high/High/Medium/Low/Very low). Also provides a sample of available tissues for reference.",
+    "output_description": "Returns a dictionary mapping queried tissue names to their expression data, including matched tissue name, expression value in nTPM, and categorized expression level (Very high/High/Medium/Low/Very low), and the HPA column the value came from. Also lists the tissues HPA classifies the gene as enriched in.",
     "test_examples": [
       {
         "ensembl_id": "ENSG00000254647",

--- a/src/tooluniverse/data/kegg_ext_tools.json
+++ b/src/tooluniverse/data/kegg_ext_tools.json
@@ -198,7 +198,7 @@
                         },
                         "dblinks": {
                             "type": "object",
-                            "description": "Cross-references to other databases (PubChem, ChEBI, DrugBank, etc.)"
+                            "description": "Cross-references to other databases (ChEBI, DrugBank, CAS, LIPIDMAPS, etc.). KEGG's PubChem cross-reference is a PubChem *substance* ID and is therefore returned as 'PubChem_SID' -- it is not a CID and must not be passed to CID-based tools. Resolve it first, e.g. PubChem PUG-REST /substance/sid/{sid}/cids."
                         }
                     }
                 },

--- a/src/tooluniverse/data/metabolights_tools.json
+++ b/src/tooluniverse/data/metabolights_tools.json
@@ -42,7 +42,7 @@
   {
     "type": "MetaboLightsRESTTool",
     "name": "metabolights_search_studies",
-    "description": "List MetaboLights study IDs. NOTE: The MetaboLights API does not support keyword filtering — the query parameter is accepted but has no effect; all public study IDs are returned regardless of query. To find studies on a specific topic, use metabolights_get_study on individual IDs. Returns all public MetaboLights study accessions (MTBLS###).",
+    "description": "Keyword-search MetaboLights studies and return the matching study accessions (MTBLS###). Searches organism, disease, metabolite and free-text study content. MetaboLights' own /ws/studies endpoint ignores keyword queries, so this tool searches through EBI Search, which indexes the same studies. Use metabolights_list_studies to browse all public studies without a keyword, and metabolights_get_study for the full record of a returned accession.",
     "parameter": {
       "type": "object",
       "properties": {

--- a/src/tooluniverse/data/ncbi_variation_tools.json
+++ b/src/tooluniverse/data/ncbi_variation_tools.json
@@ -139,7 +139,7 @@
   },
   {
     "name": "NCBIVariation_rsid_lookup",
-    "description": "Look up a dbSNP rsID and retrieve variant details including GRCh38 genomic coordinates, associated genes, clinical significance (ClinVar), citations, and MANE Select transcript IDs. Accepts rsID with or without 'rs' prefix (e.g., 'rs429358' or '429358'). Returns structured summary of the variant.",
+    "description": "Look up a dbSNP rsID and retrieve variant details including GRCh38 genomic coordinates, associated genes, clinical significance (ClinVar), citations, and MANE Select transcript IDs. Each entry in 'grch38_placements' reports 'position' as a 1-based GRCh38 coordinate (matching ClinVar, Ensembl VEP and MyVariant) and keeps dbSNP's 0-based interbase SPDI offset in 'spdi_position'. Accepts rsID with or without 'rs' prefix (e.g., 'rs429358' or '429358'). Returns structured summary of the variant.",
     "parameter": {
       "type": "object",
       "properties": {

--- a/src/tooluniverse/data/opentarget_tools.json
+++ b/src/tooluniverse/data/opentarget_tools.json
@@ -278,7 +278,7 @@
     },
     {
         "name": "OpenTargets_get_evidence_by_datasource",
-        "description": "Get target-disease evidence from Open Targets filtered by configurable data sources. Unlike OpenTargets_target_disease_evidence (intogen-only), this tool accepts any datasourceIds. Valid sources include: ot_genetics_portal, eva, eva_somatic, gene_burden, genomics_england, intogen, cancer_gene_census, clinical_precedence, crispr, europepmc, expression_atlas, gene2phenotype, orphanet, uniprot_literature, uniprot_variants, clingen, phewas_catalog, reactome, progeny, slapenrich, sysbio. Note: 'chembl' was renamed to 'clinical_precedence' upstream (confirmed live: 'chembl' now returns 0 rows even for well-documented drug-target-disease evidence). Returns evidence rows with scores, literature references, and source attribution.",
+        "description": "Get target-disease evidence from Open Targets filtered by configurable data sources. Unlike OpenTargets_target_disease_evidence (intogen-only), this tool accepts any datasourceIds. Valid sources include: gwas_credible_sets, eva, eva_somatic, gene_burden, genomics_england, intogen, cancer_gene_census, cancer_biomarkers, clinical_precedence, crispr, europepmc, expression_atlas, gene2phenotype, impc, orphanet, uniprot_literature, uniprot_variants, clingen, phewas_catalog, reactome, progeny, slapenrich, sysbio. Note: two source IDs were renamed upstream and the retired names now match nothing rather than erroring — 'ot_genetics_portal' became 'gwas_credible_sets' (confirmed live: IL23R/Crohn disease returns 0 rows for the old name and 43 for the new one) and 'chembl' became 'clinical_precedence'. This tool remaps both retired names automatically and reports the substitution in metadata.datasource_rename_note. Returns evidence rows with scores, literature references, and source attribution.",
         "label": [
             "Target",
             "Disease",
@@ -311,7 +311,7 @@
                     "items": {
                         "type": "string"
                     },
-                    "description": "List of datasource IDs to filter evidence. Examples: ['clinical_precedence', 'europepmc'], ['eva', 'clinvar'], ['intogen', 'cancer_gene_census']. Omit or pass empty array for all sources."
+                    "description": "List of datasource IDs to filter evidence. Examples: ['gwas_credible_sets', 'europepmc'], ['eva', 'clinical_precedence'], ['intogen', 'cancer_gene_census']. For genetic (GWAS) association evidence use 'gwas_credible_sets' — the retired 'ot_genetics_portal' name is remapped automatically. Omit or pass empty array for all sources."
                 },
                 "size": {
                     "type": "integer",

--- a/src/tooluniverse/data/opentarget_tools.json
+++ b/src/tooluniverse/data/opentarget_tools.json
@@ -5182,20 +5182,33 @@
     },
     {
         "name": "OpenTargets_get_target_expression_by_ensemblID",
-        "description": "Retrieve baseline expression summary statistics for a target across tissues and cell types (GTEx, Tabula Sapiens, and other bulk/single-cell sources) by Ensembl gene ID. Each row gives the data source, tissue (and cell type for single-cell data), value unit, and min/q1/median/q3/max distribution stats plus specificity/distribution scores. Well-studied targets can return hundreds to thousands of rows across sources; filter client-side by datasourceId if needed. Use to profile where a target is normally expressed.",
+        "description": "Retrieve baseline expression summary statistics for a target across tissues and cell types (GTEx, Tabula Sapiens, and other bulk/single-cell sources) by Ensembl gene ID. Each row gives the data source, tissue (and cell type for single-cell data), value unit, and min/q1/median/q3/max distribution stats plus specificity/distribution scores. Results are PAGINATED: a target typically has ~1400 rows across sources and only `size` of them are returned per call (default 250, max 3000 per the API). `baselineExpression.count` is the total, `baselineExpression.returned` is how many came back, and `baselineExpression.truncated` is true when rows remain unfetched; a truncation note is added to metadata. Rows from a given datasource are interleaved throughout the full result, so a partial page is NOT a complete view of any one source — set size=3000 to retrieve every row before filtering client-side by datasourceId. Use to profile where a target is normally expressed.",
         "parameter": {
             "type": "object",
             "properties": {
                 "ensemblId": {
                     "type": "string",
                     "description": "Ensembl gene ID of the target (e.g., 'ENSG00000146648' for EGFR)."
+                },
+                "size": {
+                    "type": "integer",
+                    "description": "Number of expression rows to return per page (default 250, max 3000). Targets carry ~1400 rows spread across all datasources, so use size=3000 to fetch the complete profile in one call; values above 3000 are clamped because the API rejects them.",
+                    "default": 250,
+                    "minimum": 1,
+                    "maximum": 3000
+                },
+                "index": {
+                    "type": "integer",
+                    "description": "0-based page index (default 0). Use with `size` to walk the remaining rows when `baselineExpression.truncated` is true.",
+                    "default": 0,
+                    "minimum": 0
                 }
             },
             "required": [
                 "ensemblId"
             ]
         },
-        "query_schema": "\n      query targetExpression($ensemblId: String!) {\n        target(ensemblId: $ensemblId) {\n          id\n          approvedSymbol\n          baselineExpression {\n            count\n            rows {\n              datasourceId\n              datatypeId\n              unit\n              min\n              q1\n              median\n              q3\n              max\n              specificity_score\n              distribution_score\n              tissueBiosample { biosampleId biosampleName }\n              celltypeBiosample { biosampleId biosampleName }\n            }\n          }\n        }\n      }\n    ",
+        "query_schema": "\n      query targetExpression($ensemblId: String!, $index: Int = 0, $size: Int = 250) {\n        target(ensemblId: $ensemblId) {\n          id\n          approvedSymbol\n          baselineExpression(page: {index: $index, size: $size}) {\n            count\n            rows {\n              datasourceId\n              datatypeId\n              unit\n              min\n              q1\n              median\n              q3\n              max\n              specificity_score\n              distribution_score\n              tissueBiosample { biosampleId biosampleName }\n              celltypeBiosample { biosampleId biosampleName }\n            }\n          }\n        }\n      }\n    ",
         "label": [
             "Target",
             "Expression",
@@ -5228,7 +5241,28 @@
                                     "type": "object",
                                     "properties": {
                                         "count": {
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Total expression rows available for this target across all pages."
+                                        },
+                                        "returned": {
+                                            "type": "integer",
+                                            "description": "Number of rows actually present in `rows` for this page."
+                                        },
+                                        "truncated": {
+                                            "type": "boolean",
+                                            "description": "True when `returned` plus the rows skipped by `index` is less than `count`, i.e. rows remain unfetched. Re-query with a larger `size` or a higher `index`."
+                                        },
+                                        "page": {
+                                            "type": "object",
+                                            "description": "The pagination actually applied to this request.",
+                                            "properties": {
+                                                "index": {
+                                                    "type": "integer"
+                                                },
+                                                "size": {
+                                                    "type": "integer"
+                                                }
+                                            }
                                         },
                                         "rows": {
                                             "type": "array",

--- a/src/tooluniverse/data/pubchem_tools.json
+++ b/src/tooluniverse/data/pubchem_tools.json
@@ -184,7 +184,7 @@
   },
   {
     "name": "PubChem_get_compound_properties_by_CID",
-    "description": "Get a set of specified molecular properties through CID (Compound ID), such as molecular weight, IUPAC name, Canonical SMILES.",
+    "description": "Get a set of specified molecular properties through CID (Compound ID), such as molecular weight, IUPAC name, and SMILES. PubChem's PUG-REST renamed its SMILES properties: ask for 'ConnectivitySMILES' (formerly 'CanonicalSMILES') and 'SMILES' (formerly 'IsomericSMILES'). Requesting a legacy name returns the value under the CURRENT key, so a caller that looks up the key it asked for will not find it.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -201,7 +201,7 @@
           "items": {
             "type": "string"
           },
-          "description": "Optional list of PubChem property names to retrieve (e.g. ['MolecularFormula','InChIKey','XLogP','IUPACName','MolecularWeight']). If omitted, returns a default set (MolecularWeight, IUPACName, SMILES). See PubChem PUG-REST property tables for valid names. Accepts a list or a comma-separated string."
+          "description": "Optional list of PubChem property names to retrieve (e.g. ['MolecularFormula','InChIKey','XLogP','IUPACName','MolecularWeight']). If omitted, returns a default set (MolecularWeight, IUPACName, ConnectivitySMILES). For SMILES use the current names 'ConnectivitySMILES' (was 'CanonicalSMILES') or 'SMILES' (was 'IsomericSMILES') — a legacy name still returns data, but under the current key, not the one requested. See PubChem PUG-REST property tables for valid names. Accepts a list or a comma-separated string."
         }
       },
       "required": [

--- a/src/tooluniverse/data/reactome_interactors_tools.json
+++ b/src/tooluniverse/data/reactome_interactors_tools.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "ReactomeInteractors_get_protein_interactors",
-    "description": "Get protein-protein interaction partners for a specific protein from Reactome's IntAct-derived interaction data. Returns interactor accessions, gene names, confidence scores, and evidence counts. Interactions are curated from experimental data with molecular interaction (MI) scores. Example: get interactors for P04637 (TP53) returns 248 interactors including MDM2 (score 0.995, 119 evidences), EP300 (score 0.976), BRCA1 (score 0.944); for Q04206 (NF-kB p65/RELA) returns 105 interactors.",
+    "description": "Get protein-protein interaction partners for a specific protein from Reactome's IntAct-derived interaction data. Returns interactor accessions, gene names, confidence scores, and evidence counts, plus the true total number of interactors ('total_interactors') and how many were returned on this page ('returned_interactors'); when 'truncated' is true, re-run with a larger page_size to get them all. Interactions are curated from experimental data with molecular interaction (MI) scores. Example: P04637 (TP53) has 249 interactors including MDM2 (score 0.995, 119 evidences), EP300 (score 0.976), BRCA1 (score 0.944); Q04206 (NF-kB p65/RELA) has 106; P42345 (MTOR) has 22.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -14,7 +14,7 @@
             "integer",
             "null"
           ],
-          "description": "Maximum number of interactors to return (default: 20, max: 100)."
+          "description": "Maximum number of interactors to return on this page (default: 20). Not capped - pass a value >= total_interactors (e.g. 300 for P04637) to retrieve every interactor in one call."
         }
       },
       "required": [
@@ -52,7 +52,23 @@
                 "integer",
                 "null"
               ],
-              "description": "Total number of known interactors"
+              "description": "True total number of known interactors for this protein (from Reactome's interactors summary endpoint), independent of page_size. Falls back to the number returned on this page when the summary endpoint is unavailable, in which case total_is_exact is false."
+            },
+            "total_is_exact": {
+              "type": "boolean",
+              "description": "True when total_interactors is the authoritative total; false when it is only the count returned on this page"
+            },
+            "returned_interactors": {
+              "type": "integer",
+              "description": "Number of interactors actually returned in this response"
+            },
+            "truncated": {
+              "type": "boolean",
+              "description": "True when returned_interactors is less than total_interactors, i.e. page_size cut off the result set"
+            },
+            "note": {
+              "type": "string",
+              "description": "Human-readable explanation present when results were truncated or the true total could not be determined"
             },
             "interactors": {
               "type": "array",

--- a/src/tooluniverse/data/xml_tools.json
+++ b/src/tooluniverse/data/xml_tools.json
@@ -2632,8 +2632,14 @@
         "synonyms": "db:synonyms/db:synonym",
         "cas_number": "db:cas-number",
         "unii": "db:unii",
-        "molecular_formula": "db:experimental-properties/db:property[db:kind='Molecular Formula']/db:value",
-        "molecular_weight": "db:experimental-properties/db:property[db:kind='Molecular Weight']/db:value",
+        "molecular_formula": [
+          "db:calculated-properties/db:property[db:kind='Molecular Formula']/db:value",
+          "db:experimental-properties/db:property[db:kind='Molecular Formula']/db:value"
+        ],
+        "molecular_weight": [
+          "db:calculated-properties/db:property[db:kind='Molecular Weight']/db:value",
+          "db:experimental-properties/db:property[db:kind='Molecular Weight']/db:value"
+        ],
         "melting_point": "db:experimental-properties/db:property[db:kind='Melting Point']/db:value",
         "water_solubility": "db:experimental-properties/db:property[db:kind='Water Solubility']/db:value",
         "isoelectric_point": "db:experimental-properties/db:property[db:kind='Isoelectric Point']/db:value",

--- a/src/tooluniverse/ebi_taxonomy_tool.py
+++ b/src/tooluniverse/ebi_taxonomy_tool.py
@@ -10,6 +10,7 @@ API: https://www.ebi.ac.uk/ena/taxonomy/rest
 No authentication required.
 """
 
+import re
 import requests
 from typing import Dict, Any
 from .base_tool import BaseTool
@@ -121,6 +122,28 @@ class EBITaxonomyTool(BaseTool):
         name = arguments.get("scientific_name", "")
         if not name:
             return {"status": "error", "error": "scientific_name parameter is required"}
+
+        # ENA indexes full binomials only, so the abbreviated genus form
+        # clinicians write ("K. pneumoniae") returns an ordinary empty
+        # success -- identical to a species that genuinely is not in the
+        # database. The genus letter cannot be expanded unambiguously
+        # ("K." is Klebsiella, Klebsormidium, Kluyveromyces, ...), so reject
+        # it rather than guess.
+        abbreviated = re.match(r"^([A-Z])\.\s*(\S.*)$", str(name).strip())
+        if abbreviated:
+            return {
+                "status": "error",
+                "error": (
+                    f"'{name}' abbreviates the genus to "
+                    f"'{abbreviated.group(1)}.'. ENA taxonomy indexes full "
+                    f"binomials only, so this matches nothing — re-send it "
+                    f"with the genus spelled out (e.g. 'Klebsiella pneumoniae' "
+                    f"rather than 'K. pneumoniae'). If you do not know which "
+                    f"genus '{abbreviated.group(1)}.' stands for, search on "
+                    f"'{abbreviated.group(2)}' with EBITaxonomy_search_by_name "
+                    f"or EBITaxonomy_suggest."
+                ),
+            }
 
         url = f"{EBI_TAXONOMY_BASE}/scientific-name/{name}"
         response = requests.get(

--- a/src/tooluniverse/efo_tool.py
+++ b/src/tooluniverse/efo_tool.py
@@ -29,7 +29,20 @@ class EFOTool(BaseTool):
         return self._search(disease, rows)
 
     def _search(self, disease, rows):
-        params = {"ontology": "efo", "q": disease, "rows": rows}
+        # Fix-20B-2: OLS4's default relevance ranking scores hits on the full
+        # indexed text (including free-text descriptions), not just the
+        # term's own name. For an abbreviation like "PCOS" this put a term
+        # whose *description* merely mentions "PCOS" in passing (EFO_0005187
+        # "C-peptide measurement") ahead of the actual term for the disease
+        # (MONDO_0008487 "polycystic ovary syndrome", which lists "PCOS" as
+        # an exact_synonym) -- confirmed live against the OLS4 API. Silently
+        # returning the wrong disease's EFO ID is worse than a fetch failure,
+        # since callers treat it as authoritative and chain further lookups
+        # on it. Always fetch enough candidates to see past a mis-ranked top
+        # hit, then prefer any candidate whose own label/exact_synonym is a
+        # case-insensitive exact match to the query over the raw OLS order.
+        fetch_rows = max(rows, 10)
+        params = {"ontology": "efo", "q": disease, "rows": fetch_rows}
         try:
             response = requests.get(self.base_url, params=params, timeout=20)
             response.raise_for_status()
@@ -44,6 +57,18 @@ class EFOTool(BaseTool):
         docs = data.get("docs", [])
         if not docs:
             return None
+
+        def _is_exact_match(doc):
+            target = disease.strip().lower()
+            label = (doc.get("label") or "").strip().lower()
+            if label == target:
+                return True
+            synonyms = doc.get("exact_synonyms") or []
+            return any(target == str(s).strip().lower() for s in synonyms)
+
+        exact = [d for d in docs if _is_exact_match(d)]
+        rest = [d for d in docs if d not in exact]
+        docs = (exact + rest)[:rows]
 
         if rows == 1:
             doc = docs[0]

--- a/src/tooluniverse/faers_analytics_tool.py
+++ b/src/tooluniverse/faers_analytics_tool.py
@@ -11,6 +11,23 @@ from .tool_registry import register_tool
 FDA_BASE_URL = "https://api.fda.gov/drug/event.json"
 
 
+def _drug_clause(drug_name: str) -> str:
+    """openFDA search clause matching a drug by generic OR brand name.
+
+    Matching only `generic_name` makes every brand name look like a drug with
+    zero reports, which for the disproportionality math is indistinguishable
+    from a genuinely unreported drug (confirmed live: "XELJANZ" yielded
+    a=0, b=0 and an "Insufficient data" error while its generic "tofacitinib"
+    returned a real ROR; the generic-or-brand form returns 183,405 reports for
+    the same brand name). Brand names are what prescribers and labels use, so
+    they must resolve to the same reports as the generic.
+    """
+    return (
+        f'(patient.drug.openfda.generic_name:"{drug_name}"'
+        f'+OR+patient.drug.openfda.brand_name:"{drug_name}")'
+    )
+
+
 @register_tool("FAERSAnalyticsTool")
 class FAERSAnalyticsTool(BaseTool):
     """
@@ -260,9 +277,9 @@ class FAERSAnalyticsTool(BaseTool):
 
             # Feature-121A-003: adverse_event is optional — filter by drug alone if omitted
             if adverse_event:
-                base_query = f'patient.drug.openfda.generic_name:"{drug_name}"+AND+patient.reaction.reactionmeddrapt:"{adverse_event}"'
+                base_query = f'{_drug_clause(drug_name)}+AND+patient.reaction.reactionmeddrapt:"{adverse_event}"'
             else:
-                base_query = f'patient.drug.openfda.generic_name:"{drug_name}"'
+                base_query = _drug_clause(drug_name)
 
             url = self._with_api_key(f"{FDA_BASE_URL}?search={base_query}&count={count_field}")
 
@@ -331,7 +348,7 @@ class FAERSAnalyticsTool(BaseTool):
                 return {"status": "error", "error": "Must provide drug_name"}
 
             # Build query for serious events
-            base_query = f'patient.drug.openfda.generic_name:"{drug_name}"'
+            base_query = _drug_clause(drug_name)
 
             # Add specific reaction filter if provided
             if adverse_event:
@@ -514,9 +531,9 @@ class FAERSAnalyticsTool(BaseTool):
 
             # Build base query
             if adverse_event:
-                search_query = f'patient.drug.openfda.generic_name:"{drug_name}"+AND+patient.reaction.reactionmeddrapt:"{adverse_event}"'
+                search_query = f'{_drug_clause(drug_name)}+AND+patient.reaction.reactionmeddrapt:"{adverse_event}"'
             else:
-                search_query = f'patient.drug.openfda.generic_name:"{drug_name}"'
+                search_query = _drug_clause(drug_name)
 
             # Get counts by receive date (year)
             url = self._with_api_key(f"{FDA_BASE_URL}?search={search_query}&count=receivedate")
@@ -588,7 +605,7 @@ class FAERSAnalyticsTool(BaseTool):
                 return {"status": "error", "error": "Must provide drug_name"}
 
             # Get preferred term (PT) level reactions
-            search_query = f'patient.drug.openfda.generic_name:"{drug_name}"'
+            search_query = _drug_clause(drug_name)
             url = self._with_api_key(
                 f"{FDA_BASE_URL}?search={search_query}&count=patient.reaction.reactionmeddrapt.exact"
             )
@@ -647,7 +664,7 @@ class FAERSAnalyticsTool(BaseTool):
         try:
             query_parts = []
             if drug_name:
-                query_parts.append(f'patient.drug.openfda.generic_name:"{drug_name}"')
+                query_parts.append(_drug_clause(drug_name))
             if adverse_event:
                 query_parts.append(
                     f'patient.reaction.reactionmeddrapt:"{adverse_event}"'

--- a/src/tooluniverse/genomics_gene_search_tool.py
+++ b/src/tooluniverse/genomics_gene_search_tool.py
@@ -38,36 +38,59 @@ class GWASGeneSearch(BaseTool):
         # diabetes associations were hidden, misleading a clinician into thinking
         # it is not a T2D locus. Also matches the sibling trait-search default.
         size = int(arguments.get("size") or arguments.get("limit") or 100)
-        url = f"{self.base_url}/v2/associations"
-        params = {"mapped_gene": gene_name, "size": size, "page": 0}
 
         try:
-            response = self.session.get(url, params=params, timeout=30)
-            response.raise_for_status()
-            data = response.json()
+            associations, total = self._fetch(gene_name, size)
+            resolved_name = gene_name
 
-            # Extract associations from _embedded structure
-            associations = []
-            if "_embedded" in data and "associations" in data["_embedded"]:
-                associations = data["_embedded"]["associations"]
+            # `mapped_gene` matches the catalog's symbol literally, so writing an
+            # interleukin the way clinicians do ("IL-23R") returns an ordinary
+            # empty result rather than the 112 associations filed under "IL23R".
+            # Genuinely hyphenated symbols are unaffected because they match on
+            # the first attempt (HLA-A returns 107), so only retry after a miss --
+            # and say which spelling produced the answer.
+            fallback_note = None
+            if not associations and "-" in gene_name:
+                candidate = gene_name.replace("-", "")
+                retry_associations, retry_total = self._fetch(candidate, size)
+                if retry_associations:
+                    associations, total = retry_associations, retry_total
+                    resolved_name = candidate
+                    fallback_note = (
+                        f"No GWAS Catalog associations are filed under "
+                        f"'{gene_name}'; these results are for '{candidate}', "
+                        f"the unhyphenated symbol the catalog uses."
+                    )
 
-            # The API does not order by significance, but the tool description
-            # promises the "strongest" associations -- sort the returned set by
-            # p-value (most significant first) so the top rows are the strongest.
-            associations = sorted(associations, key=self._pvalue_sort_key)
-
-            return {
-                "gene_name": gene_name,
+            result = {
+                "gene_name": resolved_name,
                 "association_count": len(associations),
                 "associations": associations,
-                "total_found": (
-                    data.get("page", {}).get("totalElements", 0)
-                    if "page" in data
-                    else 0
-                ),
+                "total_found": total,
             }
+            if fallback_note:
+                result["queried_gene_name"] = gene_name
+                result["gene_name_note"] = fallback_note
+            return result
 
         except requests.exceptions.RequestException as e:
             return {"status": "error", "error": f"Request failed: {str(e)}"}
         except Exception as e:
             return {"status": "error", "error": f"Unexpected error: {str(e)}"}
+
+    def _fetch(self, gene_name, size):
+        """Return (associations sorted by p-value, total matches) for a symbol."""
+        response = self.session.get(
+            f"{self.base_url}/v2/associations",
+            params={"mapped_gene": gene_name, "size": size, "page": 0},
+            timeout=30,
+        )
+        response.raise_for_status()
+        data = response.json()
+
+        associations = data.get("_embedded", {}).get("associations", [])
+        # The API does not order by significance, but the tool description
+        # promises the "strongest" associations -- sort the returned set by
+        # p-value (most significant first) so the top rows are the strongest.
+        associations = sorted(associations, key=self._pvalue_sort_key)
+        return associations, data.get("page", {}).get("totalElements", 0)

--- a/src/tooluniverse/graphql_tool.py
+++ b/src/tooluniverse/graphql_tool.py
@@ -166,6 +166,15 @@ class GraphQLTool(BaseTool):
         return result
 
 
+# Open Targets datasource IDs that were renamed upstream. The retired name is
+# not aliased server-side -- it simply matches nothing -- so queries using it
+# come back as a successful zero-row result.
+_OT_RENAMED_DATASOURCES = {
+    "ot_genetics_portal": "gwas_credible_sets",
+    "chembl": "clinical_precedence",
+}
+
+
 _OT_SEARCH_QUERY = """
 query otSearch($q: String!, $entity: [String!]!) {
   search(queryString: $q, entityNames: $entity, page: {index: 0, size: 1}) {
@@ -362,7 +371,34 @@ class OpentargetTool(GraphQLTool):
                     "Try passing efoId directly (e.g. MONDO_0005011 for Crohn disease).",
                 }
 
+        # Open Targets retires datasource IDs without keeping the old name as an
+        # alias, so a stale ID returns a perfectly successful "count: 0" that is
+        # indistinguishable from "this datasource has no evidence for this pair"
+        # (confirmed live: IL23R/Crohn disease returns 0 rows for
+        # 'ot_genetics_portal' and 43 for 'gwas_credible_sets'; TP53/cancer
+        # returns 0 and 51). Remap the retired IDs and say so, rather than
+        # letting the caller conclude the evidence does not exist.
+        renamed_datasources = []
+        _ds = arguments.get("datasourceIds")
+        if isinstance(_ds, list):
+            remapped = []
+            for _id in _ds:
+                _new = _OT_RENAMED_DATASOURCES.get(_id)
+                if _new:
+                    renamed_datasources.append(f"'{_id}' -> '{_new}'")
+                    remapped.append(_new)
+                else:
+                    remapped.append(_id)
+            arguments = dict(arguments, datasourceIds=remapped)
+
         result = super().run(arguments)
+
+        if renamed_datasources and result.get("status") == "success":
+            result.setdefault("metadata", {})["datasource_rename_note"] = (
+                "Retired Open Targets datasource ID(s) remapped: "
+                + "; ".join(renamed_datasources)
+                + ". Use the current name(s) directly to avoid this remapping."
+            )
 
         # Add note when IntOGen evidence count is 0 (Feature-122B-002).
         # Fix-R31D-3: this note is IntOGen-specific but was applied to every

--- a/src/tooluniverse/graphql_tool.py
+++ b/src/tooluniverse/graphql_tool.py
@@ -568,6 +568,18 @@ class OpentargetGeneticsTool(GraphQLTool):
         return super().run(arguments)
 
 
+# Open Targets retires datasource IDs without keeping the old name as a
+# server-side alias -- a stale ID simply matches nothing, so the query comes
+# back as a perfectly successful zero-row result that reads as "no evidence
+# exists". Confirmed live: progressive supranuclear palsy (MONDO_0019037)
+# returns 0 targets for 'ot_genetics_portal' and 23 (MOBP 0.69, MAPT 0.62,
+# STX6 0.57) for 'gwas_credible_sets'.
+_RETIRED_DATASOURCE_IDS = {
+    "ot_genetics_portal": "gwas_credible_sets",
+    "chembl": "clinical_precedence",
+}
+
+
 @register_tool("DiseaseTargetScoreTool")
 class DiseaseTargetScoreTool(GraphQLTool):
     """Tool to extract disease-target association scores from specific data sources"""
@@ -596,7 +608,13 @@ class DiseaseTargetScoreTool(GraphQLTool):
         if not datasource_id:
             return {"status": "error", "error": "datasourceId is required"}
 
+        renamed_from = None
+        if datasource_id in _RETIRED_DATASOURCE_IDS:
+            renamed_from = datasource_id
+            datasource_id = _RETIRED_DATASOURCE_IDS[datasource_id]
+
         results = []
+        seen_datasources = set()
         page_index = 0
         total_fetched = 0
         total_count = None
@@ -646,10 +664,11 @@ class DiseaseTargetScoreTool(GraphQLTool):
             for row in rows:
                 symbol = row["target"]["approvedSymbol"]
                 target_id = row["target"]["id"]
-                score_entry = next(
-                    (ds for ds in row["datasourceScores"] if ds["id"] == datasource_id),
-                    None,
-                )
+                score_entry = None
+                for ds in row["datasourceScores"]:
+                    seen_datasources.add(ds["id"])
+                    if ds["id"] == datasource_id:
+                        score_entry = ds
                 if score_entry:
                     results.append(
                         {
@@ -665,18 +684,51 @@ class DiseaseTargetScoreTool(GraphQLTool):
                 break
             page_index += 1
 
+        # The API returns targets in its own order, so a run cut short by the
+        # time budget used to yield an arbitrary subset in arbitrary order --
+        # "the top expression-atlas targets for this disease" was unobtainable.
+        # Sort by score so the strongest associations are always first.
+        results.sort(key=lambda r: r["score"], reverse=True)
+
         data = {
             "disease_info": disease_info,
             "datasource": datasource_id,
             "total_targets_with_scores": len(results),
             "target_scores": results,
         }
+        if renamed_from:
+            data["datasource_rename_note"] = (
+                f"Retired Open Targets datasource ID '{renamed_from}' remapped to "
+                f"'{datasource_id}'. Use the current name directly to avoid this "
+                "remapping."
+            )
+        if not results and seen_datasources:
+            # Distinguish "this datasource has no scores for this disease" from
+            # "that datasource ID does not exist any more" -- otherwise both look
+            # like an empty success. The available IDs cost nothing: they were
+            # already present in the rows just scanned.
+            data["available_datasources"] = sorted(seen_datasources)
+            data["note"] = (
+                f"No target has a '{datasource_id}' score for this disease among the "
+                f"{total_fetched} associated targets scanned. Datasource IDs actually "
+                "present for this disease are listed in available_datasources."
+            )
         if truncated:
             data["truncated"] = True
-            data["note"] = (
+            truncation_note = (
                 f"Stopped after {_DISEASE_TARGET_SCORE_TIME_BUDGET_S:.0f}s; "
                 f"scanned {total_fetched} of {total_count} associated targets. "
+                "Scores are sorted strongest-first within what was scanned. "
                 "Increase pageSize to scan more targets per request, or query a "
                 "more specific disease."
+            )
+            # Don't drop the "which datasources actually exist" guidance when a
+            # zero-result run also hit the time budget -- that combination is
+            # exactly when the caller most needs to know the ID was wrong.
+            existing_note = data.get("note")
+            data["note"] = (
+                f"{existing_note} {truncation_note}"
+                if existing_note
+                else truncation_note
             )
         return {"status": "success", "data": data}

--- a/src/tooluniverse/graphql_tool.py
+++ b/src/tooluniverse/graphql_tool.py
@@ -17,6 +17,12 @@ logger = logging.getLogger(__name__)
 # issues hundreds of sequential requests and can run for many minutes.
 _DISEASE_TARGET_SCORE_TIME_BUDGET_S = 25.0
 
+# OpenTargets rejects a baselineExpression page size above 3000 with a
+# "pagination error" (probed live against the v4 API: size=3000 succeeds,
+# size=5000 returns "the size must be between 0 and 3000"). Clamp rather than
+# let a caller's optimistic size turn into an opaque API failure.
+_OT_EXPRESSION_MAX_PAGE_SIZE = 3000
+
 
 def validate_query(query_str, schema_str):
     try:
@@ -391,6 +397,24 @@ class OpentargetTool(GraphQLTool):
                     remapped.append(_id)
             arguments = dict(arguments, datasourceIds=remapped)
 
+        # OpenTargets_get_target_expression_by_ensemblID paginates
+        # baselineExpression. Pin the effective page here (clamped to what the
+        # API accepts) so the post-processing below can report "N of COUNT"
+        # instead of leaving the caller to compare `count` against len(rows).
+        _is_expression_tool = (
+            self.tool_config.get("name")
+            == "OpenTargets_get_target_expression_by_ensemblID"
+        )
+        if _is_expression_tool:
+            _size = arguments.get("size")
+            if not isinstance(_size, int) or isinstance(_size, bool) or _size < 1:
+                _size = self.parameters.get("size", {}).get("default", 250)
+            arguments["size"] = min(int(_size), _OT_EXPRESSION_MAX_PAGE_SIZE)
+            _index = arguments.get("index")
+            if not isinstance(_index, int) or isinstance(_index, bool) or _index < 0:
+                _index = 0
+            arguments["index"] = int(_index)
+
         result = super().run(arguments)
 
         if renamed_datasources and result.get("status") == "success":
@@ -399,6 +423,38 @@ class OpentargetTool(GraphQLTool):
                 + "; ".join(renamed_datasources)
                 + ". Use the current name(s) directly to avoid this remapping."
             )
+
+        # Make baselineExpression truncation explicit. The API's default page
+        # size is 25 and the query previously passed no `page` argument at all,
+        # so a target with 1409 rows returned 25 of them with `count: 1409` as
+        # the only (easily missed) hint -- e.g. for NLRP7 (ENSG00000167634) the
+        # 25 delivered rows held exactly one GTEx tissue and omitted testis,
+        # its highest-expressing GTEx tissue. Report returned/truncated/page
+        # so a caller can tell "250 of 1409" from "1409 of 1409" directly.
+        if _is_expression_tool and result.get("status") == "success":
+            _target = result.get("data", {}).get("target") or {}
+            _expr = _target.get("baselineExpression")
+            if isinstance(_expr, dict):
+                _rows = _expr.get("rows")
+                _returned = len(_rows) if isinstance(_rows, list) else 0
+                _count = _expr.get("count")
+                _index = arguments.get("index", 0)
+                _size = arguments.get("size", 250)
+                _expr["returned"] = _returned
+                _expr["page"] = {"index": _index, "size": _size}
+                _fetched_through = _index * _size + _returned
+                _truncated = isinstance(_count, int) and _fetched_through < _count
+                _expr["truncated"] = _truncated
+                if _truncated:
+                    result.setdefault("metadata", {})["note"] = (
+                        f"PARTIAL RESULT: {_returned} of {_count} baseline "
+                        f"expression rows returned (page index={_index}, "
+                        f"size={_size}). Rows from any one datasource (e.g. "
+                        "gtex) are interleaved across the full result, so this "
+                        "page is not a complete view of any single source. "
+                        f"Re-query with size={_OT_EXPRESSION_MAX_PAGE_SIZE} to "
+                        "get every row, or advance `index` to page through."
+                    )
 
         # Add note when IntOGen evidence count is 0 (Feature-122B-002).
         # Fix-R31D-3: this note is IntOGen-specific but was applied to every
@@ -568,18 +624,6 @@ class OpentargetGeneticsTool(GraphQLTool):
         return super().run(arguments)
 
 
-# Open Targets retires datasource IDs without keeping the old name as a
-# server-side alias -- a stale ID simply matches nothing, so the query comes
-# back as a perfectly successful zero-row result that reads as "no evidence
-# exists". Confirmed live: progressive supranuclear palsy (MONDO_0019037)
-# returns 0 targets for 'ot_genetics_portal' and 23 (MOBP 0.69, MAPT 0.62,
-# STX6 0.57) for 'gwas_credible_sets'.
-_RETIRED_DATASOURCE_IDS = {
-    "ot_genetics_portal": "gwas_credible_sets",
-    "chembl": "clinical_precedence",
-}
-
-
 @register_tool("DiseaseTargetScoreTool")
 class DiseaseTargetScoreTool(GraphQLTool):
     """Tool to extract disease-target association scores from specific data sources"""
@@ -609,9 +653,9 @@ class DiseaseTargetScoreTool(GraphQLTool):
             return {"status": "error", "error": "datasourceId is required"}
 
         renamed_from = None
-        if datasource_id in _RETIRED_DATASOURCE_IDS:
+        if datasource_id in _OT_RENAMED_DATASOURCES:
             renamed_from = datasource_id
-            datasource_id = _RETIRED_DATASOURCE_IDS[datasource_id]
+            datasource_id = _OT_RENAMED_DATASOURCES[datasource_id]
 
         results = []
         seen_datasources = set()

--- a/src/tooluniverse/hpa_tool.py
+++ b/src/tooluniverse/hpa_tool.py
@@ -1224,19 +1224,35 @@ class HPAGetRnaExpressionByTissueTool(HPAJsonApiTool):
         if "error" in data:
             return data
 
-        # Get RNA tissue expression data
+        # "RNA tissue specific nTPM" is HPA's tissue-*enrichment* summary: it is
+        # populated only with the handful of tissues a gene is classified as
+        # enriched in, not the full ~50-tissue nTPM panel. Reading it alone made
+        # every non-enriched tissue look like missing data -- MAPT/'cerebral
+        # cortex' returned "No data" while HPA holds 147.9 nTPM for it. Query the
+        # per-tissue `t_RNA_<tissue>` columns instead (the same correction
+        # already applied to HPAGetRnaExpressionBySourceTool in Fix-R4A-2) and
+        # keep the enrichment summary only as a fallback.
         rna_data = data.get("RNA tissue specific nTPM", {})
         if not isinstance(rna_data, dict):
-            return {
-                "status": "error",
-                "error": "No RNA tissue expression data available for this gene",
-            }
-
-        expression_results = {}
+            rna_data = {}
         available_tissues = list(rna_data.keys())
 
+        panel = self._fetch_tissue_panel(ensembl_id, tissue_names)
+
+        expression_results = {}
         for tissue in tissue_names:
-            # Case-insensitive matching
+            value = panel.get(tissue)
+            if value is not None:
+                expression_results[tissue] = {
+                    "matched_tissue": tissue,
+                    "expression_value": value,
+                    "expression_level": self._categorize_expression(value),
+                    "source_field": f"Tissue RNA - {tissue} [nTPM]",
+                }
+                continue
+
+            # Fall back to the enrichment summary (case-insensitive substring
+            # match), which is all HPA's JSON record carries.
             found_tissue = None
             for available_tissue in available_tissues:
                 if (
@@ -1253,12 +1269,23 @@ class HPAGetRnaExpressionByTissueTool(HPAJsonApiTool):
                     "expression_level": self._categorize_expression(
                         rna_data[found_tissue]
                     ),
+                    "source_field": "RNA tissue specific nTPM (enrichment summary)",
                 }
             else:
+                # HPA silently drops unknown columns, so an absent column means
+                # the tissue name is not one HPA publishes -- report that as a
+                # naming problem rather than as "this gene is not expressed".
                 expression_results[tissue] = {
                     "matched_tissue": "Not found",
                     "expression_value": "N/A",
                     "expression_level": "No data",
+                    "note": (
+                        f"'{tissue}' did not match an HPA tissue column "
+                        f"(t_RNA_{self._tissue_column_suffix(tissue)}). This means the "
+                        "tissue name is unrecognized, not that the gene lacks "
+                        "expression. Use HPA_get_rna_expression_by_source to list "
+                        "valid source names for source_type='tissue' or 'brain'."
+                    ),
                 }
 
         return {
@@ -1270,13 +1297,54 @@ class HPAGetRnaExpressionByTissueTool(HPAJsonApiTool):
                 "expression_unit": "nTPM (normalized Transcripts Per Million)",
                 "queried_tissues": tissue_names,
                 "tissue_expression": expression_results,
-                "available_tissues_sample": (
-                    available_tissues[:10]
-                    if len(available_tissues) > 10
-                    else available_tissues
-                ),
-                "total_available_tissues": len(available_tissues),
+                "enriched_tissues": available_tissues,
             },
+        }
+
+    @staticmethod
+    def _tissue_column_suffix(tissue: str) -> str:
+        """Convert a human tissue name to HPA's column suffix form."""
+        return re.sub(r"[^a-z0-9]+", "_", str(tissue).strip().lower()).strip("_")
+
+    def _fetch_tissue_panel(
+        self, ensembl_id: str, tissue_names: List[str]
+    ) -> Dict[str, Any]:
+        """Fetch per-tissue nTPM values via HPA's search API `t_RNA_<tissue>` columns.
+
+        HPA drops columns it does not recognize instead of erroring, so a tissue
+        missing from the response is an unknown tissue name. Returns a mapping of
+        the caller's original tissue strings to their nTPM values.
+        """
+        suffixes = {t: self._tissue_column_suffix(t) for t in tissue_names}
+        columns = ",".join(["g", "eg"] + [f"t_RNA_{s}" for s in suffixes.values() if s])
+        params = {
+            "search": ensembl_id,
+            "format": "json",
+            "columns": columns,
+            "compress": "no",
+        }
+        try:
+            resp = requests.get(HPA_SEARCH_API, params=params, timeout=self.timeout)
+            if resp.status_code != 200:
+                return {}
+            rows = resp.json()
+        except (requests.RequestException, ValueError):
+            return {}
+        if not isinstance(rows, list) or not rows or not isinstance(rows[0], dict):
+            return {}
+
+        row = rows[0]
+        # HPA labels the returned columns "Tissue RNA - <tissue> [nTPM]".
+        by_suffix = {}
+        for key, value in row.items():
+            match = re.match(r"^Tissue RNA - (.+?) \[nTPM\]$", key)
+            if match:
+                by_suffix[self._tissue_column_suffix(match.group(1))] = value
+
+        return {
+            tissue: by_suffix[suffix]
+            for tissue, suffix in suffixes.items()
+            if by_suffix.get(suffix) not in (None, "")
         }
 
     def _categorize_expression(self, expr_value) -> str:

--- a/src/tooluniverse/kegg_ext_tool.py
+++ b/src/tooluniverse/kegg_ext_tool.py
@@ -32,6 +32,25 @@ _VARIANT_XREF_FIELDS = {
 }
 
 
+# KEGG deposits its compound/drug/disease records into PubChem as
+# *substances*, so a DBLINKS line "PubChem: 7805" carries a PubChem SID, not
+# a CID. Emitting it under the bare key "PubChem" invites callers to feed it
+# straight into a CID-based tool, which silently returns a different molecule
+# (SID 7805 = KEGG C05443 cholecalciferol, but CID 7805 = 1-bromo-4-
+# methylbenzene; SID 4808 = KEGG C01659 acrylamide, but CID 4808 is an
+# unrelated C36 compound). Verified live against PubChem PUG-REST:
+# /substance/sid/7805/cids -> 5280795 and /substance/sid/4808/cids -> 6579,
+# which are the real CIDs for those two compounds. Renaming the key makes the
+# namespace explicit at the point the value is produced.
+_DBLINK_KEY_RENAMES = {"PubChem": "PubChem_SID"}
+
+
+def _store_dblink(dblinks: Dict[str, str], raw_key: str, value: str) -> None:
+    """Record one KEGG DBLINKS entry under a namespace-explicit key."""
+    key = raw_key.strip()
+    dblinks[_DBLINK_KEY_RENAMES.get(key, key)] = value.strip()
+
+
 def _new_kegg_variation(mutation: str) -> Dict[str, Any]:
     """A fresh KEGG variant record with all cross-reference lists empty."""
     return {
@@ -418,7 +437,7 @@ class KEGGExtTool(BaseTool):
                 current_field = "DBLINKS"
                 parts = line[12:].strip().split(": ", 1)
                 if len(parts) == 2:
-                    result["dblinks"][parts[0].strip()] = parts[1].strip()
+                    _store_dblink(result["dblinks"], parts[0], parts[1])
             elif line.startswith("REMARK"):
                 result["remark"] = line[12:].strip()
                 current_field = None
@@ -439,7 +458,7 @@ class KEGGExtTool(BaseTool):
                 elif current_field == "DBLINKS":
                     parts = content.split(": ", 1)
                     if len(parts) == 2:
-                        result["dblinks"][parts[0].strip()] = parts[1].strip()
+                        _store_dblink(result["dblinks"], parts[0], parts[1])
             else:
                 # New field we don't specifically handle
                 current_field = None
@@ -716,7 +735,7 @@ class KEGGExtTool(BaseTool):
                 current_field = "DBLINKS"
                 parts = line[12:].strip().split(": ", 1)
                 if len(parts) == 2:
-                    result["dblinks"][parts[0].strip()] = parts[1].strip()
+                    _store_dblink(result["dblinks"], parts[0], parts[1])
             elif line.startswith("REFERENCE"):
                 current_field = "REFERENCE"
                 ref = line[12:].strip()
@@ -745,7 +764,7 @@ class KEGGExtTool(BaseTool):
                 elif current_field == "DBLINKS":
                     parts = content.split(": ", 1)
                     if len(parts) == 2:
-                        result["dblinks"][parts[0].strip()] = parts[1].strip()
+                        _store_dblink(result["dblinks"], parts[0], parts[1])
                 elif current_field == "REFERENCE":
                     result["references"].append(content)
             else:
@@ -914,7 +933,7 @@ class KEGGExtTool(BaseTool):
                 current_field = "DBLINKS"
                 parts = line[12:].strip().split(": ", 1)
                 if len(parts) == 2:
-                    result["dblinks"][parts[0].strip()] = parts[1].strip()
+                    _store_dblink(result["dblinks"], parts[0], parts[1])
             elif line.startswith("EFFICACY"):
                 current_field = "EFFICACY"
                 result["efficacy"] = line[12:].strip()
@@ -942,7 +961,7 @@ class KEGGExtTool(BaseTool):
                 elif current_field == "DBLINKS":
                     parts = content.split(": ", 1)
                     if len(parts) == 2:
-                        result["dblinks"][parts[0].strip()] = parts[1].strip()
+                        _store_dblink(result["dblinks"], parts[0], parts[1])
                 elif current_field == "EFFICACY":
                     result["efficacy"] = (result["efficacy"] or "") + " " + content
                 elif current_field == "PRODUCT":

--- a/src/tooluniverse/metabolights_tool.py
+++ b/src/tooluniverse/metabolights_tool.py
@@ -10,6 +10,10 @@ from typing import Any, Dict
 from .base_tool import BaseTool
 from .tool_registry import register_tool
 
+# MetaboLights' own /ws/studies endpoint ignores keyword queries; EBI Search
+# indexes the same studies and honours them.
+EBI_SEARCH_URL = "https://www.ebi.ac.uk/ebisearch/ws/rest/metabolights"
+
 
 @register_tool("MetaboLightsRESTTool")
 class MetaboLightsRESTTool(BaseTool):
@@ -55,9 +59,6 @@ class MetaboLightsRESTTool(BaseTool):
             if study_id:
                 return f"{self.base_url}/studies/{study_id}"
 
-        elif tool_name == "metabolights_search_studies":
-            return f"{self.base_url}/studies"
-
         elif tool_name == "metabolights_get_study_assays":
             study_id = args.get("study_id", "")
             if study_id:
@@ -80,15 +81,7 @@ class MetaboLightsRESTTool(BaseTool):
         params = {}
         tool_name = self.tool_config.get("name", "")
 
-        if tool_name == "metabolights_search_studies":
-            if "query" in args:
-                params["query"] = args["query"]
-            if "size" in args:
-                params["size"] = args["size"]
-            if "page" in args:
-                params["page"] = args["page"]
-
-        elif tool_name == "metabolights_list_studies":
+        if tool_name == "metabolights_list_studies":
             if "size" in args:
                 params["size"] = args["size"]
             if "page" in args:
@@ -214,9 +207,71 @@ class MetaboLightsRESTTool(BaseTool):
                 "error": f"Failed to extract files from study endpoint: {str(e)}",
             }
 
+    def _search_via_ebi_search(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        """Keyword-search MetaboLights studies through EBI Search.
+
+        MetaboLights' own /ws/studies endpoint accepts a `query` parameter and
+        silently ignores it, so every search returned the same first N study
+        accessions by ID with status "success" -- a wrong answer that looked
+        like a right one. EBI Search indexes the same MetaboLights studies and
+        does honour the query (confirmed live: "acylcarnitine" -> 113 hits).
+        """
+        query = str(arguments.get("query", "")).strip()
+        size = arguments.get("size", 20)
+        page = arguments.get("page", 0)
+        params = {
+            "query": query,
+            "format": "json",
+            "size": size,
+            "start": int(page) * int(size),
+        }
+        # EBI Search's first response for an uncached query regularly exceeds
+        # 30s while warm repeats return in ~1s, so retry once before failing.
+        try:
+            response = self.session.get(
+                EBI_SEARCH_URL, params=params, timeout=self.timeout
+            )
+        except requests.exceptions.Timeout:
+            response = self.session.get(
+                EBI_SEARCH_URL, params=params, timeout=self.timeout * 2
+            )
+        response.raise_for_status()
+        payload = response.json()
+        entries = payload.get("entries", []) or []
+        result = {
+            "status": "success",
+            "data": [e.get("id") for e in entries if e.get("id")],
+            "url": response.url,
+            "count": len(entries),
+            "total_hits": payload.get("hitCount", 0),
+        }
+        if not entries:
+            suggested = payload.get("suggestedQuery")
+            result["note"] = (
+                f"No MetaboLights study matched '{query}'."
+                + (f" Did you mean '{suggested}'?" if suggested else "")
+                + " Use metabolights_list_studies to browse all public studies."
+            )
+        return result
+
     def run(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Execute the MetaboLights API call"""
         tool_name = self.tool_config.get("name", "")
+
+        if tool_name == "metabolights_search_studies":
+            if not str(arguments.get("query", "")).strip():
+                return {
+                    "status": "error",
+                    "error": "query is required. To browse all public studies without "
+                    "a keyword, use metabolights_list_studies.",
+                }
+            try:
+                return self._search_via_ebi_search(arguments)
+            except (requests.RequestException, ValueError) as e:
+                return {
+                    "status": "error",
+                    "error": f"MetaboLights search via EBI Search failed: {str(e)}",
+                }
 
         if tool_name == "metabolights_get_reference_compound":
             if (
@@ -353,11 +408,8 @@ class MetaboLightsRESTTool(BaseTool):
                 extracted_data = data
                 count = len(data)
 
-            # Apply client-side pagination for list/search (API ignores size/page params)
-            if tool_name in (
-                "metabolights_list_studies",
-                "metabolights_search_studies",
-            ):
+            # Apply client-side pagination for the study list (API ignores size/page)
+            if tool_name == "metabolights_list_studies":
                 size = arguments.get("size", 20)
                 page = arguments.get("page", 0)
                 if isinstance(extracted_data, list):

--- a/src/tooluniverse/metabolomics_workbench_tool.py
+++ b/src/tooluniverse/metabolomics_workbench_tool.py
@@ -10,7 +10,7 @@ API Documentation: https://www.metabolomicsworkbench.org/tools/mw_rest.php
 """
 
 import requests
-from typing import Dict, Any
+from typing import Any, Dict, Optional
 from urllib.parse import quote
 from .base_tool import BaseTool
 from .tool_registry import register_tool
@@ -270,7 +270,49 @@ class MetabolomicsWorkbenchTool(BaseTool):
         output_item = arguments.get("output_item", "all")
         if not input_value:
             return {"status": "error", "error": "input_value parameter is required"}
-        return self._make_request(f"refmet/{input_item}/{input_value}/{output_item}")
+        result = self._make_request(f"refmet/{input_item}/{input_value}/{output_item}")
+
+        # `refmet/name/` is exact-match only, so standard clinical/HMDB names
+        # ("Octanoylcarnitine") return an empty success even though RefMet knows
+        # the compound under its own shorthand ("CAR 8:0"). RefMet's separate
+        # `refmet/match/` endpoint resolves synonyms -- use it to recover the
+        # canonical name, then re-run the original query with it.
+        if input_item == "name" and not result.get("data"):
+            canonical = self._resolve_refmet_name(input_value)
+            if canonical and canonical.lower() != str(input_value).lower():
+                retried = self._make_request(
+                    f"refmet/{input_item}/{canonical}/{output_item}"
+                )
+                if retried.get("data"):
+                    retried["name_resolution_note"] = (
+                        f"'{input_value}' is not a RefMet name; resolved to the "
+                        f"canonical RefMet name '{canonical}' via RefMet's synonym "
+                        "match endpoint."
+                    )
+                    return retried
+        return result
+
+    def _resolve_refmet_name(self, name: str) -> Optional[str]:
+        """Resolve a metabolite synonym to its canonical RefMet name.
+
+        Returns None when RefMet has no match -- the endpoint signals that with
+        a record whose every field is the literal string "-", not with an error.
+        """
+        try:
+            response = requests.get(
+                f"{MWBENCH_BASE_URL}/refmet/match/{quote(str(name), safe='')}/name/json",
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            payload = response.json()
+        except (requests.RequestException, ValueError):
+            return None
+        if isinstance(payload, list):
+            payload = payload[0] if payload else None
+        if not isinstance(payload, dict):
+            return None
+        refmet_name = str(payload.get("refmet_name", "")).strip()
+        return None if refmet_name in ("", "-") else refmet_name
 
     def _search_moverz(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Search by m/z value. Requires database as first URL path segment."""

--- a/src/tooluniverse/molecule_2d_tool.py
+++ b/src/tooluniverse/molecule_2d_tool.py
@@ -147,17 +147,19 @@ class Molecule2DTool(VisualizationTool):
         """Resolve molecule name to SMILES using PubChem."""
         try:
             # Use PubChem PUG REST API
+            # PubChem renamed "IsomericSMILES" to "SMILES"; accept either key
+            # so the resolver keeps working against both response shapes.
             url = (
                 f"https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/name/"
-                f"{name}/property/IsomericSMILES/JSON"
+                f"{name}/property/SMILES/JSON"
             )
             response = requests.get(url, timeout=10)
             if response.status_code == 200:
                 data = response.json()
                 if "PropertyTable" in data and "Properties" in data["PropertyTable"]:
                     props = data["PropertyTable"]["Properties"]
-                    if props and "IsomericSMILES" in props[0]:
-                        return props[0]["IsomericSMILES"]
+                    if props:
+                        return props[0].get("SMILES") or props[0].get("IsomericSMILES")
         except Exception:
             pass
         return None

--- a/src/tooluniverse/ncbi_variation_tool.py
+++ b/src/tooluniverse/ncbi_variation_tool.py
@@ -34,6 +34,50 @@ _ALFA_POP_FALLBACK = {
 }
 
 
+def _grch38_placement_from_spdi(spdi: Dict[str, Any]) -> Dict[str, Any]:
+    """Turn one dbSNP SPDI allele into a genome placement.
+
+    SPDI positions are 0-based interbase offsets, but this tool advertises
+    "GRCh38 genomic coordinates" and its output sits next to ClinVar, Ensembl
+    VEP and MyVariant results, all of which report 1-based positions. Passing
+    the SPDI offset through under the name `position` therefore reported every
+    variant one base 5' of where it is: rs121965019 (IDUA c.1205G>A) came back
+    as chr4:1002746 where the other three tools say 1002747, and the tool's
+    own documented example rs429358 as chr19:44908683 rather than 44908684.
+
+    `position` is now the 1-based coordinate; the untranslated SPDI offset is
+    kept alongside it so callers building SPDI strings do not lose it. For a
+    pure insertion there is no deleted base, so the 1-based anchor is the base
+    immediately 5' of the insertion point, which is the SPDI offset itself.
+    """
+    offset = spdi.get("position")
+    deleted = spdi.get("deleted_sequence")
+    position = offset
+    if isinstance(offset, int):
+        position = offset + 1 if deleted else offset
+    return {
+        "seq_id": spdi.get("seq_id"),
+        "position": position,
+        "coordinate_system": "1-based",
+        "spdi_position": offset,
+        "deleted_sequence": deleted,
+        "inserted_sequence": spdi.get("inserted_sequence"),
+    }
+
+
+def _dedupe_genes(genes):
+    """Collapse the per-placement gene rows dbSNP repeats for each allele."""
+    seen = set()
+    unique = []
+    for gene in genes:
+        key = (gene.get("gene_id"), gene.get("gene"))
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(gene)
+    return unique
+
+
 @register_tool("NCBIVariationTool")
 class NCBIVariationTool(BaseTool):
     """
@@ -226,16 +270,7 @@ class NCBIVariationTool(BaseTool):
                             spdi = allele.get("allele", {}).get("spdi", {})
                             if spdi:
                                 grch38_placements.append(
-                                    {
-                                        "seq_id": spdi.get("seq_id"),
-                                        "position": spdi.get("position"),
-                                        "deleted_sequence": spdi.get(
-                                            "deleted_sequence"
-                                        ),
-                                        "inserted_sequence": spdi.get(
-                                            "inserted_sequence"
-                                        ),
-                                    }
+                                    _grch38_placement_from_spdi(spdi)
                                 )
                         break
 
@@ -257,7 +292,7 @@ class NCBIVariationTool(BaseTool):
                                 }
                             )
                 if clinical:
-                    result["genes"] = clinical
+                    result["genes"] = _dedupe_genes(clinical)
 
                 # Extract clinical significance
                 for annot in allele_annots:

--- a/src/tooluniverse/openalex_tool.py
+++ b/src/tooluniverse/openalex_tool.py
@@ -3,7 +3,10 @@ import requests
 from typing import Any, Dict, Optional
 from .base_tool import BaseTool
 from .http_utils import request_with_retry
+from .logging_config import get_logger
 from .tool_registry import register_tool
+
+logger = get_logger("OpenAlexTool")
 
 
 def _with_api_key(params):
@@ -149,8 +152,8 @@ class OpenAlexTool(BaseTool):
                     # Skip papers with missing data rather than failing completely
                     continue
 
-            print(
-                f"[OpenAlex] Retrieved {len(papers)} papers for keywords: '{search_keywords}'"
+            logger.info(
+                "Retrieved %d papers for keywords: '%s'", len(papers), search_keywords
             )
             return papers
 
@@ -289,7 +292,7 @@ class OpenAlexTool(BaseTool):
             return self._extract_paper_info(work)
 
         except requests.exceptions.RequestException as e:
-            print(f"Error retrieving paper by DOI {doi}: {e}")
+            logger.warning("Error retrieving paper by DOI %s: %s", doi, e)
             return None
 
     def get_papers_by_author(self, author_name, max_results=10):
@@ -320,9 +323,7 @@ class OpenAlexTool(BaseTool):
                 paper_info = self._extract_paper_info(work)
                 papers.append(paper_info)
 
-            print(
-                f"[OpenAlex] Retrieved {len(papers)} papers by author: '{author_name}'"
-            )
+            logger.info("Retrieved %d papers by author: '%s'", len(papers), author_name)
             return papers
 
         except requests.exceptions.RequestException as e:

--- a/src/tooluniverse/openfda_tool.py
+++ b/src/tooluniverse/openfda_tool.py
@@ -430,6 +430,13 @@ def search_openfda(
     applied_return_field_mapping = {}  # primary_field -> fallback_field
     fallback_terms: list[str] = []
     used_generic_fallback = False
+    # Fix-20A-1: `used_generic_fallback` was tracked but never surfaced to the
+    # caller. Each fallback stage weakens the match in a different way, and
+    # the returned payload looked identical to an exact hit, so a caller had
+    # no way to tell "this is the drug you asked for" from "this is the
+    # closest thing we could find". Record which stage fired so we can attach
+    # an honest note.
+    fallback_note: str | None = None
 
     def _all_search_fields_from_orig() -> list[str]:
         out = []
@@ -575,6 +582,11 @@ def search_openfda(
                         requested_return_fields = [fb]
                         applied_return_field_mapping[primary] = fb
                         used_generic_fallback = True
+                        fallback_note = (
+                            f"Label section '{primary}' was not present for this "
+                            f"product; showing content from the related section "
+                            f"'{fb}' instead."
+                        )
                         break
                 if used_generic_fallback:
                     break
@@ -605,6 +617,12 @@ def search_openfda(
             if isinstance(tmp, dict) and "error" not in tmp:
                 response_data = tmp
                 used_generic_fallback = True
+                fallback_note = (
+                    f"No exact phrase match for '{qtext}'; results use a "
+                    f"broadened, term-based match in the same field(s) "
+                    f"({', '.join(sorted(orig_fields_flat))}) -- verify the "
+                    f"returned drug name is the one you intended."
+                )
 
         # Stage B: expand to label-text fields (robust when openfda is empty or name mismatched)
         if (
@@ -636,6 +654,22 @@ def search_openfda(
             if isinstance(tmp, dict) and "error" not in tmp:
                 response_data = tmp
                 used_generic_fallback = True
+                # Fix-20A-1: this stage matches '{qtext}' anywhere in full
+                # label-text fields, including ingredient lists -- so a query
+                # that is not a product name at all still returns rows. Live
+                # example: "magnesium stearate tablet" (an excipient plus a
+                # dosage form) returns unrelated products that merely list it,
+                # indistinguishable from a real hit. Flag that explicitly,
+                # since the field-based fallback above (Stage A) already
+                # covers ordinary name/spelling mismatches.
+                fallback_note = (
+                    f"No product/drug named '{qtext}' matched exactly; "
+                    f"results were broadened to full label text (e.g. "
+                    f"ingredients, indications, description) and may include "
+                    f"unrelated products that merely mention '{qtext}' -- "
+                    f"check the returned openfda.brand_name/generic_name "
+                    f"before treating this as data about '{qtext}' itself."
+                )
 
         # Stage C: data-driven closest-name candidates (name-based only, single token)
         if (
@@ -719,6 +753,13 @@ def search_openfda(
                         if isinstance(tmp, dict) and "error" not in tmp:
                             response_data = tmp
                             used_generic_fallback = True
+                            fallback_note = (
+                                f"No drug named '{term}' was found; showing "
+                                f"the closest-spelling candidate(s) "
+                                f"({', '.join(sorted(near))}) instead -- "
+                                f"verify the returned drug name matches what "
+                                f"you intended."
+                            )
                 except Exception:
                     pass
 
@@ -790,10 +831,16 @@ def search_openfda(
     # Extract results and return only the specified return fields
     results = response_data.get("results", [])
     if return_fields == "ALL":
-        return {"meta": meta_info, "results": results}
+        out = {"meta": meta_info, "results": results}
+        if fallback_note:
+            out["note"] = fallback_note
+        return out
     # If count parameter is used, return results directly (count API format)
     if params.get("count") or count:
-        return {"meta": meta_info, "results": results}
+        out = {"meta": meta_info, "results": results}
+        if fallback_note:
+            out["note"] = fallback_note
+        return out
     flat_keys = []
     # Use original search_fields for consistent output schema even when we fell
     # back to broad text search.
@@ -872,7 +919,10 @@ def search_openfda(
         if user_limit_final:
             extracted_results = extracted_results[:user_limit_final]
 
-    return {"meta": meta_info, "results": extracted_results}
+    out = {"meta": meta_info, "results": extracted_results}
+    if fallback_note:
+        out["note"] = fallback_note
+    return out
 
 
 @register_tool("FDATool")

--- a/src/tooluniverse/orphanet_tool.py
+++ b/src/tooluniverse/orphanet_tool.py
@@ -49,6 +49,52 @@ def _encode_orphadata_gene_name(name: str) -> str:
     return urllib.parse.quote(name.replace("/", "-"), safe="")
 
 
+def _same_char_class(a: str, b: str) -> bool:
+    """True when two characters continue the same token (digit-digit or
+    letter-letter)."""
+    return (a.isdigit() and b.isdigit()) or (a.isalpha() and b.isalpha())
+
+
+def _name_contains_disease(candidate_name: str, disease_name: str) -> bool:
+    """True when `candidate_name` names a subtype of `disease_name`.
+
+    A plain substring test is wrong here: Orphanet's preferred terms are
+    numbered, so "Mucopolysaccharidosis type 1" (ORPHA:579, MPS I) is a
+    substring of "Mucopolysaccharidosis type 10" (ORPHA:662216, MPS X) and the
+    gene lookup for MPS I answered with ARSK -- the MPS X gene -- instead of
+    IDUA. The same collision hits "Familial hyperaldosteronism type I" vs
+    "type II/III/IV", "Mucolipidosis type II" vs "type III", "Achondroplasia"
+    vs "Pseudoachondroplasia" and "Neuroblastoma" vs "Ganglioneuroblastoma".
+
+    So require the occurrence to sit on token boundaries: the characters
+    flanking it may not continue the same class (digit or letter) as the
+    adjacent character of the disease name. Real subtype names are unaffected,
+    because they extend the parent name across a class change -- a space, a
+    comma or a letter after a digit ("Mucopolysaccharidosis type 4A",
+    "Mucopolysaccharidosis type 2, severe form", "Autosomal dominant
+    Charcot-Marie-Tooth disease type 2N").
+    """
+    disease_lower = (disease_name or "").lower()
+    candidate_lower = (candidate_name or "").lower()
+    if not disease_lower:
+        return False
+    start = 0
+    while True:
+        index = candidate_lower.find(disease_lower, start)
+        if index < 0:
+            return False
+        end = index + len(disease_lower)
+        before_ok = index == 0 or not _same_char_class(
+            candidate_lower[index - 1], disease_lower[0]
+        )
+        after_ok = end >= len(candidate_lower) or not _same_char_class(
+            candidate_lower[end], disease_lower[-1]
+        )
+        if before_ok and after_ok:
+            return True
+        start = index + 1
+
+
 @register_tool("OrphanetTool")
 class OrphanetTool(BaseTool):
     """
@@ -383,12 +429,13 @@ class OrphanetTool(BaseTool):
             if response.status_code != 200:
                 return [], True
             all_entries = response.json().get("data", {}).get("results", [])
-            disease_lower = disease_name.lower()
             return (
                 [
                     entry
                     for entry in all_entries
-                    if disease_lower in entry.get("Preferred term", "").lower()
+                    if _name_contains_disease(
+                        entry.get("Preferred term", ""), disease_name
+                    )
                     and str(entry.get("ORPHAcode", "")) != str(exclude_code)
                 ],
                 False,

--- a/src/tooluniverse/proteins_api_tool.py
+++ b/src/tooluniverse/proteins_api_tool.py
@@ -492,12 +492,19 @@ class ProteinsAPIRESTTool(BaseTool):
                 used_gene = "gene" in params
 
                 def _retry_params(use_gene: bool, keep_human: bool) -> Dict[str, Any]:
-                    p = {"format": params.get("format", "json")}
-                    if "size" in params:
-                        p["size"] = params["size"]
+                    # Carry the original request forward and change only the
+                    # field being retried. Rebuilding from scratch dropped
+                    # every scoping parameter the caller had supplied
+                    # (organism=/taxid=), so a wheat query silently retried
+                    # against all of UniProt and answered with an insect.
+                    p = {
+                        k: v for k, v in params.items() if k not in ("gene", "protein")
+                    }
                     p["gene" if use_gene else "protein"] = query
-                    if keep_human and auto_human:
-                        p["taxid"] = "9606"
+                    if not keep_human and auto_human:
+                        # Only the human default this tool added itself may be
+                        # dropped; a caller-supplied taxid stays.
+                        p.pop("taxid", None)
                     return p
 
                 # Order: swap field but keep human; then drop the human filter
@@ -523,7 +530,7 @@ class ProteinsAPIRESTTool(BaseTool):
                     if isinstance(retry_data, list) and len(retry_data) > 0:
                         data = retry_data
                         response = retry_resp
-                        widened_organism = "taxid" not in cand
+                        widened_organism = auto_human and "taxid" not in cand
                         break
 
             # Cap features per entry to avoid 25MB+ responses for heavily-annotated proteins

--- a/src/tooluniverse/pubmed_tool.py
+++ b/src/tooluniverse/pubmed_tool.py
@@ -8,6 +8,67 @@ from .http_utils import request_with_retry
 from .tool_registry import register_tool
 
 
+def _clean_doi(value: Any) -> str:
+    """Normalize a raw DOI string: drop any display prefix and trailing dot."""
+    text = str(value or "").strip()
+    if text[:4].lower() == "doi:":
+        text = text[4:].strip()
+    return text.rstrip(".")
+
+
+def _doi_from_articleids(articleids: Any) -> str:
+    """Pull the DOI out of an esummary ``articleids`` list.
+
+    This is the structured, canonical location: NCBI stores a bare
+    ``{"idtype": "doi", "value": "10.x/y"}`` entry with no display prefix
+    and no other identifier mixed in.
+    """
+    for aid in articleids or []:
+        if isinstance(aid, dict) and aid.get("idtype") == "doi":
+            doi = _clean_doi(aid.get("value"))
+            if doi:
+                return doi
+    return ""
+
+
+def _doi_from_elocationid(elocationid: Any) -> str:
+    """Pull the DOI out of an esummary ``elocationid`` display string.
+
+    Handles ``"doi: 10.1234/abc"`` and the mixed preprint form
+    ``"pii: 2026.02.14.705936. doi: 10.64898/2026.02.14.705936"``.
+    """
+    text = str(elocationid or "")
+    lowered = text.lower()
+    if "doi:" not in lowered:
+        return ""
+    # Take the first token after "doi:" that contains '/' (valid DOI structure).
+    doi_part = text[lowered.index("doi:") + 4 :].strip()
+    for token in doi_part.split():
+        if "/" in token:
+            return token.rstrip(".")
+    return ""
+
+
+def _extract_doi(article_data: dict[str, Any]) -> str:
+    """Extract the DOI from a PubMed esummary record.
+
+    Fix-R25: the DOI used to be parsed *only* out of ``elocationid``, which
+    NCBI leaves empty for essentially every record published before ~2008 --
+    so ``doi``/``doi_url`` came back null for the whole older literature even
+    though the DOI was sitting in ``articleids`` in the very same response
+    (confirmed live for PMIDs 15720521, 17354009, 15500562, 14765742,
+    14627096, 5794093). ``articleids`` is preferred over ``elocationid``
+    because it is the structured field: it is populated for both old and new
+    records, its value needs no parsing, and it can never be confused with the
+    ``pii`` that NCBI packs into the same ``elocationid`` display string.
+    ``elocationid`` is kept as a fallback for records that carry one but no
+    ``doi`` articleid.
+    """
+    return _doi_from_articleids(
+        article_data.get("articleids")
+    ) or _doi_from_elocationid(article_data.get("elocationid"))
+
+
 @register_tool("PubMedRESTTool")
 class PubMedRESTTool(BaseRESTTool):
     """Generic REST tool for PubMed E-utilities (efetch, elink).
@@ -163,19 +224,7 @@ class PubMedRESTTool(BaseRESTTool):
             pub_date = article_data.get("pubdate", "")
             pub_year = pub_date.split()[0] if pub_date else ""
 
-            elocationid = article_data.get("elocationid", "")
-            # Extract DOI: handle formats like "doi: 10.1234/abc" and mixed
-            # "pii: 2026.02.14.705936. 10.64898/2026.02.14.705936" (preprints).
-            doi = ""
-            if "doi:" in elocationid:
-                # Find the "doi:" token and extract what follows it
-                doi_part = elocationid[elocationid.index("doi:") + 4 :].strip()
-                # Take the first token that contains '/' (valid DOI structure)
-                for token in doi_part.split():
-                    if "/" in token:
-                        doi = token.rstrip(".")
-                        break
-            doi = doi or None
+            doi = _extract_doi(article_data) or None
 
             journal = article_data.get(
                 "fulljournalname", article_data.get("source", "")
@@ -379,13 +428,30 @@ class PubMedRESTTool(BaseRESTTool):
             journal_el = art.find("Journal")
             journal = _text(journal_el, "Title") or _text(journal_el, "ISOAbbreviation")
 
-            doi = next(
-                (
-                    eid.text
-                    for eid in art.findall("ELocationID")
-                    if eid.get("EIdType") == "doi" and eid.text
-                ),
-                "",
+            # Fix-R25: same root cause as the esummary path -- older records
+            # (verified live for PMID 15720521) carry no <ELocationID> at all
+            # while still listing the DOI in <PubmedData><ArticleIdList>.
+            # Unlike esummary's free-text `elocationid`, the XML ELocationID is
+            # explicitly typed (EIdType="doi") and needs no parsing, so it stays
+            # the primary source here and ArticleIdList is added as a fallback.
+            doi = _clean_doi(
+                next(
+                    (
+                        eid.text
+                        for eid in art.findall("ELocationID")
+                        if eid.get("EIdType") == "doi" and eid.text
+                    ),
+                    "",
+                )
+            ) or _clean_doi(
+                next(
+                    (
+                        aid.text
+                        for aid in article_el.findall(".//ArticleIdList/ArticleId")
+                        if aid.get("IdType") == "doi" and aid.text
+                    ),
+                    "",
+                )
             )
 
             pd = art.find(".//PubDate")

--- a/src/tooluniverse/reactome_interactors_tool.py
+++ b/src/tooluniverse/reactome_interactors_tool.py
@@ -72,6 +72,30 @@ class ReactomeInteractorsTool(BaseTool):
         else:
             return {"status": "error", "error": f"Unknown endpoint: {self.endpoint}"}
 
+    def _fetch_total_interactor_count(self, accession: str):
+        """Return the true total interactor count, or None if unavailable.
+
+        Fix-R18B-2/Feature-23C-2: the ``count`` field of the interactors
+        ``/details`` response is the number of records on the page that was
+        requested, NOT the size of the full result set -- live-verified for
+        P04637, where page=1&pageSize=100 yields count=100 while
+        page=1&pageSize=300 yields count=249. The dedicated ``/summary``
+        endpoint is therefore the only cheap source of a real total
+        (live-verified: P04637 -> 249, P42345 -> 22). Returns None on any
+        failure so that a page count is never passed off as a total.
+        """
+        url = f"{REACTOME_BASE_URL}/interactors/static/molecule/{accession}/summary"
+        try:
+            response = requests.get(url, timeout=self.timeout)
+            response.raise_for_status()
+            entities = response.json().get("entities", [])
+        except (requests.exceptions.RequestException, ValueError, AttributeError):
+            return None
+        if not entities:
+            return None
+        count = entities[0].get("count")
+        return count if isinstance(count, int) else None
+
     def _get_interactors(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Get protein-protein interactors for a UniProt accession."""
         accession = arguments.get("accession", "")
@@ -84,22 +108,30 @@ class ReactomeInteractorsTool(BaseTool):
         page_size = arguments.get("page_size") or 20
 
         url = f"{REACTOME_BASE_URL}/interactors/static/molecule/{accession}/details"
-        # Fix-R18B-2: page=-1 tells Reactome's interactors API to ignore
-        # pagination and return every interactor regardless of pageSize --
-        # confirmed live (page=-1&pageSize=10 returned all 153 interactors
-        # for P31749; page=1&pageSize=10 correctly returned 10), directly
-        # contradicting this tool's own documented page_size contract.
-        params = {"page": 1, "pageSize": min(page_size, 100)}
+        # The requested page_size is passed through unclamped: Reactome honours
+        # any pageSize on this endpoint (live-verified: pageSize=300 for P04637
+        # returns all 249 interactors), so clamping here would silently truncate
+        # results the caller explicitly asked for.
+        params = {"page": 1, "pageSize": page_size}
 
         response = requests.get(url, params=params, timeout=self.timeout)
         response.raise_for_status()
         data = response.json()
 
+        total = self._fetch_total_interactor_count(accession)
+
         entities = data.get("entities", [])
         if not entities:
             return {
                 "status": "success",
-                "data": {"accession": accession, "interactors": [], "total": 0},
+                "data": {
+                    "accession": accession,
+                    "total_interactors": total if total is not None else 0,
+                    "total_is_exact": total is not None,
+                    "returned_interactors": 0,
+                    "truncated": bool(total),
+                    "interactors": [],
+                },
                 "metadata": {"source": "Reactome Interactors (IntAct)"},
             }
 
@@ -118,13 +150,33 @@ class ReactomeInteractorsTool(BaseTool):
         # Sort by score descending
         interactors.sort(key=lambda x: x.get("score") or 0, reverse=True)
 
+        returned = len(interactors)
+        truncated = total is not None and returned < total
+        result = {
+            "accession": entity.get("acc"),
+            "total_interactors": total if total is not None else returned,
+            "total_is_exact": total is not None,
+            "returned_interactors": returned,
+            "truncated": truncated,
+            "interactors": interactors,
+        }
+        if truncated:
+            result["note"] = (
+                f"Showing {returned} of {total} interactors "
+                f"(page_size={page_size}). Re-run with page_size={total} "
+                "to retrieve all of them."
+            )
+        elif total is None:
+            result["note"] = (
+                "The total interactor count is unavailable (Reactome summary "
+                "endpoint did not respond), so total_interactors reports the "
+                f"{returned} interactor(s) returned on this page and may be "
+                "incomplete."
+            )
+
         return {
             "status": "success",
-            "data": {
-                "accession": entity.get("acc"),
-                "total_interactors": entity.get("count"),
-                "interactors": interactors,
-            },
+            "data": result,
             "metadata": {
                 "source": "Reactome Interactors (IntAct)",
                 "resource": data.get("resource"),

--- a/src/tooluniverse/string_tool.py
+++ b/src/tooluniverse/string_tool.py
@@ -7,6 +7,13 @@ from .tool_registry import register_tool
 
 STRING_BASE_URL = "https://string-db.org/api"
 
+# Identifier-mapping endpoint. Only its responses carry the queryIndex ->
+# submitted-identifier correspondence used by _annotate_mapping_coverage.
+_STRING_IDS_ENDPOINT = "/json/get_string_ids"
+
+# Upper bound on the follow-up requests _classify_missing may issue.
+_MAX_MAPPING_PROBE_ROUNDS = 5
+
 # Categories whose STRING label differs from the value our schema advertises.
 # Every other enum value ('Process', 'Component', 'Function', 'KEGG',
 # 'WikiPathways', 'COMPARTMENTS', 'TISSUES', 'DISEASES') matches STRING exactly.
@@ -184,7 +191,154 @@ class STRINGRESTTool(BaseTool):
                 "data": rows,
                 "metadata": metadata,
             }
+
+        if self.endpoint_template == _STRING_IDS_ENDPOINT and isinstance(
+            api_response, list
+        ):
+            return self._annotate_mapping_coverage(api_response, arguments)
+
         return {"status": "success", "data": api_response}
+
+    @staticmethod
+    def _submitted_identifiers(arguments) -> List[str]:
+        """Recover the submitted identifier list in the order STRING indexed it.
+
+        `queryIndex` is a 0-based offset into the identifiers we posted, so the
+        list has to be rebuilt exactly as _build_params serialized it.
+        """
+        protein_ids = arguments.get("protein_ids")
+        if protein_ids is None:
+            protein_ids = arguments.get("identifiers", [])
+        if isinstance(protein_ids, list):
+            return [str(p) for p in protein_ids]
+        joined = str(protein_ids).replace("%0d", "\r").replace("\n", "\r")
+        return [part for part in joined.split("\r") if part.strip()]
+
+    def _annotate_mapping_coverage(self, records, arguments) -> Dict[str, Any]:
+        """Report which submitted identifiers STRING did not return.
+
+        STRING's /json/get_string_ids simply omits identifiers it does not
+        return -- no placeholder row, no warning -- so a batch of 500 gene
+        symbols could come back as 480 records with a plain "success" and the
+        caller would only notice by diffing the returned `queryIndex` values
+        against their own input. Silently shrinking the gene set skews every
+        downstream enrichment, and this tool's whole job is validating that
+        identifiers exist in STRING, so name the omissions explicitly.
+        """
+        submitted = self._submitted_identifiers(arguments)
+        # `limit` is matches-per-identifier here (up to 10), so several records
+        # can share one queryIndex -- correlate on distinct indices, not rows.
+        returned_indices = {
+            record["queryIndex"]
+            for record in records
+            if isinstance(record, dict) and isinstance(record.get("queryIndex"), int)
+        }
+
+        metadata: Dict[str, Any] = {
+            "submitted_count": len(submitted),
+            "mapped_count": len(returned_indices),
+        }
+
+        if not submitted or (records and not returned_indices):
+            # Nothing to correlate against (no queryIndex in the response);
+            # report the records as-is rather than inventing an omission list.
+            metadata["unmapped_count"] = 0
+            metadata["unmapped_identifiers"] = []
+            return {"status": "success", "data": records, "metadata": metadata}
+
+        missing = [
+            identifier
+            for index, identifier in enumerate(submitted)
+            if index not in returned_indices
+        ]
+
+        if not returned_indices:
+            metadata["unmapped_count"] = len(missing)
+            metadata["unmapped_identifiers"] = missing
+            error_msg = (
+                f"STRING could not map any of the {len(submitted)} submitted "
+                f"identifier(s): {', '.join(missing)}. Check the identifier "
+                "spelling and that `species` matches the organism."
+            )
+            metadata["unmapped_note"] = error_msg
+            return {
+                "status": "error",
+                "data": records,
+                "metadata": metadata,
+                "error": error_msg,
+            }
+
+        unmapped, duplicates = self._classify_missing(missing, arguments)
+        metadata["mapped_count"] = len(returned_indices) + len(duplicates)
+        metadata["unmapped_count"] = len(unmapped)
+        metadata["unmapped_identifiers"] = unmapped
+
+        if duplicates:
+            metadata["duplicate_identifiers"] = duplicates
+            metadata["duplicate_note"] = (
+                f"{len(duplicates)} submitted identifier(s) resolve to a STRING "
+                "protein that another submitted identifier already covers, and "
+                "STRING keeps only the last of each such group: "
+                f"{', '.join(duplicates)}. These are mapped, not missing."
+            )
+        if unmapped:
+            metadata["unmapped_note"] = (
+                f"{len(unmapped)} of {len(submitted)} submitted identifier(s) "
+                "could not be mapped by STRING and are absent from `data`: "
+                f"{', '.join(unmapped)}. Exclude them from downstream analyses "
+                "or supply an alternative identifier type."
+            )
+
+        return {"status": "success", "data": records, "metadata": metadata}
+
+    def _classify_missing(self, missing, arguments):
+        """Split absent identifiers into truly unmapped vs. collapsed duplicates.
+
+        An index absent from the response does not always mean STRING failed to
+        map it: STRING also de-duplicates by resolved protein, keeping only the
+        LAST identifier of every group that resolves to the same entry. Querying
+        ['TP53', 'P04637'] returns one record at queryIndex 1, so calling TP53
+        "not found in STRING" would be flatly wrong. Re-query the absent ones on
+        their own -- whatever STRING returns then was a collapsed duplicate,
+        whatever it still omits is genuinely unmapped. A round that resolves
+        nothing proves the remainder is unmappable, so this terminates quickly
+        (usually after one extra request, and none at all when nothing is
+        missing).
+        """
+        duplicates = []
+        remaining = list(missing)
+        # One round per alias-group member is needed in theory; cap the extra
+        # requests so a pathological input cannot fan out into a request storm.
+        for _ in range(min(len(missing), _MAX_MAPPING_PROBE_ROUNDS)):
+            if not remaining:
+                break
+            probe = self._make_request(
+                self._build_url(),
+                self._build_params({**arguments, "protein_ids": remaining}),
+            )
+            if not isinstance(probe, list):
+                # Probe failed (network/API error); stay conservative and treat
+                # the remainder as unmapped rather than claiming it mapped.
+                break
+            resolved = {
+                record["queryIndex"]
+                for record in probe
+                if isinstance(record, dict)
+                and isinstance(record.get("queryIndex"), int)
+            }
+            if not resolved:
+                break
+            duplicates.extend(
+                identifier
+                for index, identifier in enumerate(remaining)
+                if index in resolved
+            )
+            remaining = [
+                identifier
+                for index, identifier in enumerate(remaining)
+                if index not in resolved
+            ]
+        return remaining, duplicates
 
     @staticmethod
     def _label_partners(rows, arguments):

--- a/src/tooluniverse/tools/AOPWiki_list_aops.py
+++ b/src/tooluniverse/tools/AOPWiki_list_aops.py
@@ -9,6 +9,7 @@ from ._shared_client import get_shared_client
 
 
 def AOPWiki_list_aops(
+    search: Optional[str] = None,
     *,
     stream_callback: Optional[Callable[[str], None]] = None,
     use_cache: bool = False,
@@ -19,7 +20,8 @@ def AOPWiki_list_aops(
 
     Parameters
     ----------
-    No parameters
+    search : str, optional
+        Case-insensitive keyword to filter AOPs by title or short name. Omit t...
     stream_callback : Callable, optional
         Callback for streaming output
     use_cache : bool, default False
@@ -34,7 +36,7 @@ def AOPWiki_list_aops(
     # Handle mutable defaults to avoid B006 linting error
 
     # Strip None values so optional parameters don't trigger schema validation errors
-    _args = {k: v for k, v in {}.items() if v is not None}
+    _args = {k: v for k, v in {"search": search}.items() if v is not None}
     return get_shared_client().run_one_function(
         {
             "name": "AOPWiki_list_aops",

--- a/src/tooluniverse/tools/ChEBI_search.py
+++ b/src/tooluniverse/tools/ChEBI_search.py
@@ -24,7 +24,7 @@ def ChEBI_search(
     query : str
         Search query string - compound name, synonym, formula, or keyword. Examples: ...
     limit : int | Any
-        Maximum number of results to return. Default: 10. Max: 100.
+        Maximum number of compounds to return. Default: 10. Max: 100. Values above 15...
     stream_callback : Callable, optional
         Callback for streaming output
     use_cache : bool, default False

--- a/src/tooluniverse/tools/ChEMBL_get_molecule_targets.py
+++ b/src/tooluniverse/tools/ChEMBL_get_molecule_targets.py
@@ -11,6 +11,7 @@ from ._shared_client import get_shared_client
 def ChEMBL_get_molecule_targets(
     molecule_chembl_id__exact: Optional[str] = None,
     molecule_chembl_id: Optional[str] = None,
+    chembl_id: Optional[str] = None,
     limit: Optional[int] = 500,
     *,
     stream_callback: Optional[Callable[[str], None]] = None,
@@ -26,6 +27,8 @@ def ChEMBL_get_molecule_targets(
         ChEMBL molecule ID (e.g., 'CHEMBL25' for aspirin). To find a molecule ID, use...
     molecule_chembl_id : str
         Alias for molecule_chembl_id__exact. ChEMBL molecule ID.
+    chembl_id : str
+        Alias for molecule_chembl_id__exact. Accepts the same name...
     limit : int
         Maximum number of activity records to fetch for target deduplication (default...
     stream_callback : Callable, optional
@@ -47,6 +50,7 @@ def ChEMBL_get_molecule_targets(
         for k, v in {
             "molecule_chembl_id__exact": molecule_chembl_id__exact,
             "molecule_chembl_id": molecule_chembl_id,
+            "chembl_id": chembl_id,
             "limit": limit,
         }.items()
         if v is not None

--- a/src/tooluniverse/tools/OpenTargets_get_target_expression_by_ensemblID.py
+++ b/src/tooluniverse/tools/OpenTargets_get_target_expression_by_ensemblID.py
@@ -1,7 +1,7 @@
 """
 OpenTargets_get_target_expression_by_ensemblID
 
-Retrieve baseline RNA and protein expression for a target across ~119 tissues and cell types (Hum...
+Retrieve baseline expression summary statistics for a target across tissues and cell types (GTEx,...
 """
 
 from typing import Any, Optional, Callable
@@ -10,18 +10,24 @@ from ._shared_client import get_shared_client
 
 def OpenTargets_get_target_expression_by_ensemblID(
     ensemblId: str,
+    size: Optional[int] = 250,
+    index: Optional[int] = 0,
     *,
     stream_callback: Optional[Callable[[str], None]] = None,
     use_cache: bool = False,
     validate: bool = True,
 ) -> Any:
     """
-    Retrieve baseline RNA and protein expression for a target across ~119 tissues and cell types (Hum...
+    Retrieve baseline expression summary statistics for a target across tissues and cell types (GTEx,...
 
     Parameters
     ----------
     ensemblId : str
         Ensembl gene ID of the target (e.g., 'ENSG00000146648' for EGFR).
+    size : int
+        Number of expression rows to return per page (default 250, max 3000). Targets...
+    index : int
+        0-based page index (default 0). Use with `size` to walk the remaining rows wh...
     stream_callback : Callable, optional
         Callback for streaming output
     use_cache : bool, default False
@@ -36,7 +42,11 @@ def OpenTargets_get_target_expression_by_ensemblID(
     # Handle mutable defaults to avoid B006 linting error
 
     # Strip None values so optional parameters don't trigger schema validation errors
-    _args = {k: v for k, v in {"ensemblId": ensemblId}.items() if v is not None}
+    _args = {
+        k: v
+        for k, v in {"ensemblId": ensemblId, "size": size, "index": index}.items()
+        if v is not None
+    }
     return get_shared_client().run_one_function(
         {
             "name": "OpenTargets_get_target_expression_by_ensemblID",

--- a/src/tooluniverse/tools/ReactomeInteractors_get_protein_interactors.py
+++ b/src/tooluniverse/tools/ReactomeInteractors_get_protein_interactors.py
@@ -24,7 +24,7 @@ def ReactomeInteractors_get_protein_interactors(
     accession : str
         UniProt accession number for the query protein. Examples: 'P04637' (TP53), 'Q...
     page_size : int | Any
-        Maximum number of interactors to return (default: 20, max: 100).
+        Maximum number of interactors to return on this page (default: 20)...
     stream_callback : Callable, optional
         Callback for streaming output
     use_cache : bool, default False

--- a/src/tooluniverse/tools/alphafold_get_annotations.py
+++ b/src/tooluniverse/tools/alphafold_get_annotations.py
@@ -12,6 +12,7 @@ def alphafold_get_annotations(
     qualifier: Optional[str] = None,
     uniprot_id: Optional[str] = None,
     uniprot_accession: Optional[str] = None,
+    accession: Optional[str] = None,
     *,
     stream_callback: Optional[Callable[[str], None]] = None,
     use_cache: bool = False,
@@ -28,6 +29,8 @@ def alphafold_get_annotations(
         Alias for qualifier. UniProt accession (e.g., 'P69905').
     uniprot_accession : str
         Alias for qualifier. UniProt accession (e.g., 'P69905').
+    accession : str
+        Alias for qualifier. UniProt accession (e.g., 'P04637') -- the...
     stream_callback : Callable, optional
         Callback for streaming output
     use_cache : bool, default False
@@ -48,6 +51,7 @@ def alphafold_get_annotations(
             "qualifier": qualifier,
             "uniprot_id": uniprot_id,
             "uniprot_accession": uniprot_accession,
+            "accession": accession,
         }.items()
         if v is not None
     }

--- a/src/tooluniverse/tools/alphafold_get_prediction.py
+++ b/src/tooluniverse/tools/alphafold_get_prediction.py
@@ -12,6 +12,7 @@ def alphafold_get_prediction(
     qualifier: Optional[str] = None,
     uniprot_id: Optional[str] = None,
     uniprot_accession: Optional[str] = None,
+    accession: Optional[str] = None,
     sequence_checksum: Optional[str] = None,
     *,
     stream_callback: Optional[Callable[[str], None]] = None,
@@ -29,6 +30,8 @@ def alphafold_get_prediction(
         Alias for qualifier: UniProt accession (e.g., 'P69905').
     uniprot_accession : str
         Alias for qualifier: UniProt accession (e.g., 'P69905').
+    accession : str
+        Alias for qualifier. UniProt accession (e.g., 'P04637') -- the...
     sequence_checksum : str
         Optional CRC64 checksum of the UniProt sequence.
     stream_callback : Callable, optional
@@ -51,6 +54,7 @@ def alphafold_get_prediction(
             "qualifier": qualifier,
             "uniprot_id": uniprot_id,
             "uniprot_accession": uniprot_accession,
+            "accession": accession,
             "sequence_checksum": sequence_checksum,
         }.items()
         if v is not None

--- a/src/tooluniverse/tools/alphafold_get_summary.py
+++ b/src/tooluniverse/tools/alphafold_get_summary.py
@@ -12,6 +12,7 @@ def alphafold_get_summary(
     qualifier: Optional[str] = None,
     uniprot_id: Optional[str] = None,
     uniprot_accession: Optional[str] = None,
+    accession: Optional[str] = None,
     *,
     stream_callback: Optional[Callable[[str], None]] = None,
     use_cache: bool = False,
@@ -28,6 +29,8 @@ def alphafold_get_summary(
         Alias for qualifier. UniProt accession (e.g., 'P04637').
     uniprot_accession : str
         Alias for qualifier. UniProt accession (e.g., 'P04637').
+    accession : str
+        Alias for qualifier. UniProt accession (e.g., 'P04637') -- the...
     stream_callback : Callable, optional
         Callback for streaming output
     use_cache : bool, default False
@@ -48,6 +51,7 @@ def alphafold_get_summary(
             "qualifier": qualifier,
             "uniprot_id": uniprot_id,
             "uniprot_accession": uniprot_accession,
+            "accession": accession,
         }.items()
         if v is not None
     }

--- a/src/tooluniverse/uniprot_tool.py
+++ b/src/tooluniverse/uniprot_tool.py
@@ -1,8 +1,55 @@
+import re
 import time
 import requests
 from typing import Any, Dict, Optional
 from .base_tool import BaseTool, ToolError
 from .tool_registry import register_tool
+
+
+# Common-name / scientific-name shortcuts for the handful of model organisms
+# callers name in prose. Anything not listed here still works -- it is routed
+# to UniProt's organism_name field rather than being rejected.
+_ORGANISM_TAXIDS = {
+    "human": "9606",
+    "homo sapiens": "9606",
+    "mouse": "10090",
+    "mus musculus": "10090",
+    "rat": "10116",
+    "rattus norvegicus": "10116",
+    "yeast": "559292",
+    "saccharomyces cerevisiae": "559292",
+    "zebrafish": "7955",
+    "danio rerio": "7955",
+    "fruitfly": "7227",
+    "drosophila melanogaster": "7227",
+    "c. elegans": "6239",
+    "caenorhabditis elegans": "6239",
+    "arabidopsis": "3702",
+    "arabidopsis thaliana": "3702",
+    "pig": "9823",
+    "sus scrofa": "9823",
+    "cow": "9913",
+    "bos taurus": "9913",
+    "rabbit": "9986",
+    "oryctolagus cuniculus": "9986",
+}
+
+
+def _uniprot_organism_filter(organism: str) -> str:
+    """Build the UniProt query clause for an organism the caller named.
+
+    UniProt's `organism_id` field accepts numeric taxonomy IDs only; passing a
+    species name to it makes the whole search fail with HTTP 400 rather than
+    returning zero hits. Any organism that does not resolve to a taxid is
+    therefore expressed as `organism_name:"..."`, which accepts free text and
+    covers the long tail of species (pathogens, plants, non-model organisms)
+    that no shortcut table can enumerate.
+    """
+    name = str(organism).strip()
+    resolved = _ORGANISM_TAXIDS.get(name.lower(), name)
+    if resolved.isdigit():
+        return f"organism_id:{resolved}"
+    return f'organism_name:"{resolved}"'
 
 
 def _protein_name(protein_desc: Dict[str, Any]) -> str:
@@ -257,45 +304,24 @@ class UniProtRESTTool(BaseTool):
             limit_value = int(limit_value)
         limit = min(limit_value, 500)
 
-        # Normalize query: replace 'organism:' with 'organism_id:'
-        # for UniProt API compatibility
-        query = query.replace("organism:", "organism_id:")
+        # Normalize query: UniProt has no bare 'organism' field. Numeric values
+        # belong in organism_id, everything else in organism_name -- rewriting a
+        # species name into organism_id makes UniProt reject the whole request
+        # with HTTP 400 (confirmed live: 'organism_id:Klebsiella pneumoniae').
+        query = re.sub(
+            r"\borganism:(\"[^\"]+\"|\S+)",
+            lambda m: _uniprot_organism_filter(m.group(1).strip('"')),
+            query,
+        )
 
         # Build query string
         query_parts = [query]
         if organism:
-            # Support common organism names (both common names and scientific names)
-            organism_map = {
-                "human": "9606",
-                "homo sapiens": "9606",
-                "mouse": "10090",
-                "mus musculus": "10090",
-                "rat": "10116",
-                "rattus norvegicus": "10116",
-                "yeast": "559292",
-                "saccharomyces cerevisiae": "559292",
-                "zebrafish": "7955",
-                "danio rerio": "7955",
-                "fruitfly": "7227",
-                "drosophila melanogaster": "7227",
-                "c. elegans": "6239",
-                "caenorhabditis elegans": "6239",
-                "arabidopsis": "3702",
-                "arabidopsis thaliana": "3702",
-                "pig": "9823",
-                "sus scrofa": "9823",
-                "cow": "9913",
-                "bos taurus": "9913",
-                "rabbit": "9986",
-                "oryctolagus cuniculus": "9986",
-            }
-            taxon_id = organism_map.get(organism.lower(), organism)
-
-            # Check if query already includes organism_id filter
-            # to avoid duplication
-            if "organism_id:" not in query.lower():
-                query_parts.append(f"organism_id:{taxon_id}")
-            # If it does, skip adding the organism filter
+            # Skip when the caller already scoped the query themselves, so we
+            # don't AND two conflicting organism clauses together.
+            lowered = query.lower()
+            if "organism_id:" not in lowered and "organism_name:" not in lowered:
+                query_parts.append(_uniprot_organism_filter(organism))
 
         # Auto-convert length parameters to range syntax
         if min_length or max_length:

--- a/src/tooluniverse/xml_tool.py
+++ b/src/tooluniverse/xml_tool.py
@@ -29,7 +29,10 @@ class XMLDatasetTool(BaseTool):
         self.namespaces: Dict[str, str] = tool_config.get("settings").get(
             "namespaces", {}
         )
-        self.field_mappings: Dict[str, str] = tool_config.get("settings").get(
+        # Values may be a single XPath string, a LIST of XPath strings (tried
+        # in order, first non-empty wins -- see _extract_field_value), or a
+        # dict describing a nested structure (see _extract_record_data).
+        self.field_mappings: Dict[str, Any] = tool_config.get("settings").get(
             "field_mappings", {}
         )  # Dict of fields we're interested in extracting from each record
         self.filter_field: Optional[str] = tool_config.get("settings").get(
@@ -143,8 +146,27 @@ class XMLDatasetTool(BaseTool):
 
         return data
 
-    def _extract_field_value(self, element: ET.Element, xpath_expr: str) -> str:
-        """Extract field value using XPath expression."""
+    def _extract_field_value(self, element: ET.Element, xpath_expr: Any) -> str:
+        """Extract field value using XPath expression.
+
+        Fix Round 25: `xpath_expr` may also be a LIST of XPath strings, which
+        are tried in order and the first non-empty result returned. Some
+        source datasets file the same logical field under different parents
+        depending on the record -- DrugBank puts Molecular Formula/Weight
+        under <calculated-properties> for small molecules but under
+        <experimental-properties> for biotech/peptide entries, so a single
+        XPath silently yields "" for one whole class of records. Note that
+        ElementTree/lxml's findall() does not accept `|` XPath unions, so a
+        list of expressions (rather than one union expression) is the right
+        shape here.
+        """
+        if isinstance(xpath_expr, (list, tuple)):
+            for candidate in xpath_expr:
+                value = self._extract_field_value(element, candidate)
+                if value:
+                    return value
+            return ""
+
         try:
             # Handle attribute extraction with /@
             if "/@" in xpath_expr:

--- a/tests/integration/test_coding_api_integration.py
+++ b/tests/integration/test_coding_api_integration.py
@@ -20,6 +20,12 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 from tooluniverse import ToolUniverse  # noqa: E402
 from tooluniverse.generate_tools import main as generate_tools  # noqa: E402
 
+# Every generate_tools() call below must pass output_dir. Its default output
+# directory is the *committed* src/tooluniverse/tools/ tree, so calling it bare
+# — as these tests did, despite each site already allocating a temp dir and
+# commenting "Generate tools in temp directory" — rewrote 2,604 tracked wrapper
+# files as a side effect of running the integration suite.
+
 
 @pytest.mark.integration
 class TestCodingAPIIntegration(unittest.TestCase):
@@ -178,7 +184,7 @@ class TestSDKIntegration(unittest.TestCase):
         self.temp_dir = tempfile.mkdtemp()
         
         # Generate SDK for testing
-        generate_tools()
+        generate_tools(output_dir=Path(self.temp_dir))
         
         # Invalidate import caches to ensure newly generated modules are loaded
         # Remove all tooluniverse.tools modules from cache
@@ -287,7 +293,7 @@ class TestEndToEndIntegration(unittest.TestCase):
             pass
         
         # Step 2: Generate SDK
-        generate_tools()
+        generate_tools(output_dir=Path(self.temp_dir))
         
         # Step 3: Test SDK
         sys.path.insert(0, self.temp_dir)
@@ -327,7 +333,7 @@ class TestEndToEndIntegration(unittest.TestCase):
         
         # Test error handling in SDK mode
         # Generate tools in temp directory
-        generate_tools()
+        generate_tools(output_dir=Path(self.temp_dir))
         
         sys.path.insert(0, self.temp_dir)
         try:
@@ -379,7 +385,7 @@ class TestEndToEndIntegration(unittest.TestCase):
         
         # Test caching in SDK mode
         # Generate tools in temp directory
-        generate_tools()
+        generate_tools(output_dir=Path(self.temp_dir))
         
         sys.path.insert(0, self.temp_dir)
         try:

--- a/tests/unit/test_bgee_base_url_trailing_slash.py
+++ b/tests/unit/test_bgee_base_url_trailing_slash.py
@@ -1,0 +1,155 @@
+"""Bgee requests must target ``https://www.bgee.org/api/`` (with trailing slash).
+
+Regression: the tool built its URL from ``https://www.bgee.org/api`` (no
+trailing slash).  Requests to that path never reach the Bgee application -- the
+site's Cloudflare WAF answers them with an HTTP 403 challenge page
+(``cf-mitigated: challenge``), so every Bgee tool, including the documented
+``Bgee_get_gene_expression`` example (ENSG00000141510 / 9606), returned
+"Bgee API HTTP error: 403".  The same query with the trailing slash returns
+HTTP 200 and 145 expression calls.  Bisection showed this is independent of
+User-Agent (python-requests, curl and a browser UA all 403 without the slash
+and all 200 with it) and of the Accept header.
+
+Also covers the error path: Bgee reports an unknown gene ID as HTTP 404 with a
+JSON body carrying a ``message``, which must be surfaced instead of a bare
+status code.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+pytestmark = pytest.mark.unit
+
+
+def _make_tool(endpoint):
+    from tooluniverse.bgee_tool import BgeeTool
+
+    return BgeeTool(
+        {
+            "name": f"Bgee_{endpoint}",
+            "type": "BgeeTool",
+            "fields": {"endpoint": endpoint},
+        }
+    )
+
+
+class TestBgeeBaseUrl(unittest.TestCase):
+    def test_module_base_url_has_trailing_slash(self):
+        import tooluniverse.bgee_tool as mod
+
+        self.assertEqual(mod.BGEE_BASE_URL, "https://www.bgee.org/api/")
+        self.assertTrue(mod.BGEE_BASE_URL.endswith("/"))
+
+    def test_gene_expression_request_uses_trailing_slash(self):
+        tool = _make_tool("gene_expression")
+        with patch("tooluniverse.bgee_tool.requests.get") as get:
+            resp = MagicMock()
+            resp.raise_for_status.return_value = None
+            resp.json.return_value = {
+                "code": 200,
+                "status": "SUCCESS",
+                "data": {
+                    "requestedDataTypes": ["RNA-Seq"],
+                    "calls": [
+                        {
+                            "condition": {
+                                "anatEntity": {
+                                    "id": "UBERON:0003053",
+                                    "name": "ventricular zone",
+                                }
+                            },
+                            "expressionScore": {
+                                "expressionScore": "95.11",
+                                "expressionScoreConfidence": "high",
+                            },
+                            "expressionState": "expressed",
+                            "expressionQuality": "gold",
+                            "dataTypesWithData": ["RNA-Seq"],
+                        }
+                    ],
+                },
+            }
+            get.return_value = resp
+            result = tool.run({"gene_id": "ENSG00000141510", "species_id": "9606"})
+
+        url = get.call_args.args[0]
+        self.assertEqual(url, "https://www.bgee.org/api/")
+        self.assertTrue(
+            url.endswith("/"),
+            "Bgee URL must keep its trailing slash or Cloudflare returns 403",
+        )
+        self.assertEqual(
+            get.call_args.kwargs["params"],
+            {
+                "page": "gene",
+                "action": "expression",
+                "gene_id": "ENSG00000141510",
+                "species_id": "9606",
+                "display_type": "json",
+            },
+        )
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["data"][0]["tissue_name"], "ventricular zone")
+
+    def test_all_endpoints_use_trailing_slash(self):
+        cases = {
+            "gene_search": {"query": "TP53"},
+            "gene_expression": {"gene_id": "ENSG00000141510", "species_id": "9606"},
+            "species_list": {},
+        }
+        for endpoint, args in cases.items():
+            with self.subTest(endpoint=endpoint):
+                tool = _make_tool(endpoint)
+                with patch("tooluniverse.bgee_tool.requests.get") as get:
+                    resp = MagicMock()
+                    resp.raise_for_status.return_value = None
+                    resp.json.return_value = {"code": 200, "data": {}}
+                    get.return_value = resp
+                    tool.run(args)
+                self.assertEqual(get.call_args.args[0], "https://www.bgee.org/api/")
+
+
+class TestBgeeHttpErrorMessage(unittest.TestCase):
+    def test_unknown_gene_404_surfaces_api_message(self):
+        tool = _make_tool("gene_expression")
+        with patch("tooluniverse.bgee_tool.requests.get") as get:
+            resp = MagicMock()
+            resp.status_code = 404
+            resp.json.return_value = {
+                "code": 404,
+                "status": "ERROR",
+                "message": "Page not found.",
+                "data": {"exceptionType": "PageNotFoundException"},
+            }
+            resp.raise_for_status.side_effect = requests.exceptions.HTTPError(
+                response=resp
+            )
+            get.return_value = resp
+            result = tool.run({"gene_id": "ENSG99999999999", "species_id": "9606"})
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("404", result["error"])
+        self.assertIn("Page not found.", result["error"])
+        self.assertIn("Ensembl", result["error"])
+
+    def test_http_error_without_json_body_still_reports_status(self):
+        tool = _make_tool("species_list")
+        with patch("tooluniverse.bgee_tool.requests.get") as get:
+            resp = MagicMock()
+            resp.status_code = 500
+            resp.json.side_effect = ValueError("no json")
+            resp.raise_for_status.side_effect = requests.exceptions.HTTPError(
+                response=resp
+            )
+            get.return_value = resp
+            result = tool.run({})
+
+        self.assertEqual(result["status"], "error")
+        self.assertEqual(result["error"], "Bgee API HTTP error: 500")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_clinvar_invalid_clinsig_blamed_gene.py
+++ b/tests/unit/test_clinvar_invalid_clinsig_blamed_gene.py
@@ -1,0 +1,217 @@
+"""Unit test: an unrecognized clinical_significance is rejected at the input,
+and the zero-result hint stops blaming the gene for a filter's empty result.
+
+Regression: `{"gene": "TP53", "clinical_significance": "Banana"}` pasted the
+bogus class straight into the Entrez term, matched nothing, and returned
+`status: success` with total_count 0 plus a hint telling the caller to
+re-verify the gene symbol -- TP53, which matches thousands of records on its
+own. The only trace of the real culprit was buried in query_translation.
+
+Pins three things:
+  * an unrecognized value (via either parameter spelling) is an ERROR that
+    names the parameter and lists the accepted classes, and never reaches the
+    network;
+  * every accepted class still builds its verified [Filter]/[prop] clause;
+  * the genuine gene-symbol hint still fires unchanged for an unknown gene.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from tooluniverse.clinvar_tool import (
+    _CLINSIG_ACCEPTED,
+    ClinVarSearchByRegion,
+    ClinVarSearchVariants,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return ClinVarSearchVariants({"name": "ClinVar_search_variants"})
+
+
+def _run(arguments, count="0"):
+    """Run the tool with the network stubbed; returns (result, mock)."""
+    tool = _tool()
+    with patch.object(
+        ClinVarSearchVariants,
+        "_make_request",
+        return_value={
+            "status": "success",
+            "data": {"esearchresult": {"count": count, "idlist": []}},
+        },
+    ) as mock_request:
+        result = tool.run(arguments)
+    return result, mock_request
+
+
+# --- 1. invalid values are rejected up front -------------------------------
+
+
+@pytest.mark.parametrize("param", ["clinical_significance", "significance"])
+def test_invalid_value_is_an_error_naming_the_parameter(param):
+    result, mock_request = _run({"gene": "TP53", param: "Banana"})
+
+    assert result["status"] == "error"
+    assert result["parameter"] == param
+    # The offending parameter is named; the (valid) gene symbol is not blamed.
+    assert param in result["error"]
+    assert "banana" in result["error"].lower()
+    assert "HGNC" not in result["error"]
+    assert "verify the symbol" not in result["error"]
+    # The accepted classes are listed so the caller can self-correct.
+    for accepted in ("Pathogenic", "Likely benign", "risk factor"):
+        assert accepted in result["error"]
+    assert "Pathogenic" in result["valid_values"]
+    # ...and no query was ever sent.
+    mock_request.assert_not_called()
+
+
+def test_invalid_component_of_a_slash_value_is_rejected():
+    result, mock_request = _run(
+        {"gene": "TP53", "clinical_significance": "Pathogenic/Bananas"}
+    )
+    assert result["status"] == "error"
+    assert result["invalid_values"] == ["bananas"]
+    mock_request.assert_not_called()
+
+
+def test_invalid_value_never_reports_success_with_zero_results():
+    result, _ = _run({"gene": "TP53", "clinical_significance": "probably bad"})
+    assert result["status"] != "success"
+    assert "data" not in result
+
+
+# --- 2. every accepted class still builds its verified clause --------------
+
+
+@pytest.mark.parametrize("value", _CLINSIG_ACCEPTED)
+def test_accepted_values_still_query(value):
+    result, mock_request = _run({"gene": "BRCA2", "clinical_significance": value})
+    assert result["status"] == "success"
+    term = mock_request.call_args_list[0][0][1]["term"]
+    normalized = value.lower()
+    assert f'"clinsig {normalized}"[Filter]' in term
+    assert f"clinsig_{normalized.replace(' ', '_')}[prop]" in term
+
+
+@pytest.mark.parametrize(
+    "spelling", ["Pathogenic", "pathogenic", "PATHOGENIC", " Pathogenic "]
+)
+def test_case_and_whitespace_spellings_accepted(spelling):
+    result, _ = _run({"gene": "BRCA2", "clinical_significance": spelling})
+    assert result["status"] == "success"
+
+
+@pytest.mark.parametrize("spelling", ["risk_factor", "risk-factor", "Risk Factor"])
+def test_underscore_and_hyphen_spellings_map_to_the_indexed_token(spelling):
+    result, mock_request = _run({"gene": "HFE", "clinical_significance": spelling})
+    assert result["status"] == "success"
+    assert "clinsig_risk_factor[prop]" in mock_request.call_args_list[0][0][1]["term"]
+
+
+def test_alias_and_canonical_parameter_build_the_same_query():
+    _, canonical = _run({"gene": "NLRP7", "clinical_significance": "Pathogenic"})
+    _, alias = _run({"gene": "NLRP7", "significance": "Pathogenic"})
+    assert (
+        canonical.call_args_list[0][0][1]["term"]
+        == alias.call_args_list[0][0][1]["term"]
+    )
+
+
+# --- 3. the gene-symbol hint is preserved, but only when it's earned -------
+
+
+def test_unknown_gene_with_no_filter_still_gets_the_gene_symbol_hint():
+    result, _mock_request = _run({"gene": "NOTAGENE123"})
+
+    hint = result["data"]["zero_result_hint"]
+    assert "No ClinVar records matched gene 'NOTAGENE123'" in hint
+    assert "HGNC" in hint
+    assert "HGNC_search_genes" in hint
+    # No filters were supplied, so no evidence query is needed to say this.
+    assert "gene_only_match_count" not in result["data"]
+
+
+def test_unknown_gene_with_a_filter_still_blames_the_gene():
+    """The bare-gene probe also returns 0 -> the symbol really is the problem."""
+    result, _ = _run({"gene": "NOTAGENE123", "clinical_significance": "Pathogenic"})
+
+    hint = result["data"]["zero_result_hint"]
+    assert "No ClinVar records matched gene 'NOTAGENE123'" in hint
+    assert "HGNC" in hint
+    assert result["data"]["gene_only_match_count"] == 0
+
+
+def _dispatching_run(arguments, probe_response):
+    """Run with a stub that answers the bare-gene evidence probe (retmax=0)
+    with `probe_response` and everything else with an empty result set."""
+    empty = {
+        "status": "success",
+        "data": {"esearchresult": {"count": "0", "idlist": []}},
+    }
+
+    def responder(_endpoint, params=None, **_kwargs):
+        params = params or {}
+        if params.get("retmax") == 0:
+            return probe_response
+        return empty
+
+    tool = _tool()
+    with patch.object(
+        ClinVarSearchVariants, "_make_request", side_effect=responder
+    ) as mock_request:
+        result = tool.run(arguments)
+    return result, mock_request
+
+
+def test_valid_gene_with_a_filter_blames_the_filter_not_the_gene():
+    """The bare-gene probe returns hits -> the filter emptied the result."""
+    result, mock_request = _dispatching_run(
+        {"gene": "NLRP7", "clinical_significance": "Established risk allele"},
+        {
+            "status": "success",
+            "data": {"esearchresult": {"count": "434", "idlist": []}},
+        },
+    )
+
+    hint = result["data"]["zero_result_hint"]
+    assert result["data"]["gene_only_match_count"] == 434
+    assert "'NLRP7' is fine" in hint
+    assert "clinical_significance" in hint
+    # It must NOT tell the caller to go re-verify a symbol that matched 434.
+    assert "HGNC" not in hint
+    assert "outdated/misspelled" not in hint
+    # The probe is count-only and reuses the gene term.
+    probes = [
+        call[0][1]
+        for call in mock_request.call_args_list
+        if (call[0][1] or {}).get("retmax") == 0
+    ]
+    assert [p["term"] for p in probes] == ["NLRP7[gene]"]
+
+
+def test_hint_is_hedged_when_the_evidence_probe_fails():
+    result, _ = _dispatching_run(
+        {"gene": "NLRP7", "clinical_significance": "Pathogenic"},
+        {"status": "error", "error": "boom"},
+    )
+
+    hint = result["data"]["zero_result_hint"]
+    assert "could not be checked" in hint
+    assert "HGNC" not in hint
+
+
+# --- 4. the sibling region search shares the validation --------------------
+
+
+def test_region_search_rejects_an_invalid_significance():
+    tool = ClinVarSearchByRegion({"name": "ClinVar_search_by_region"})
+    result = tool.run(
+        {"region": "chr7:155593770-155593780", "clinical_significance": "Banana"}
+    )
+    assert result["status"] == "error"
+    assert result["parameter"] == "clinical_significance"
+    assert "banana" in result["error"].lower()

--- a/tests/unit/test_coding_api_generation_is_sandboxed.py
+++ b/tests/unit/test_coding_api_generation_is_sandboxed.py
@@ -1,0 +1,40 @@
+"""The integration suite must not regenerate the committed wrapper tree.
+
+tests/integration/test_coding_api_integration.py calls generate_tools() whose
+default output directory is src/tooluniverse/tools/ -- the tracked wrapper
+tree. Running the integration suite therefore rewrote 2,604 tracked files as a
+side effect, which is indistinguishable from a real change in `git status` and
+has already cost a fix round. Each call site allocates a temp dir; this guards
+that they actually use it.
+"""
+
+import ast
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+pytestmark = pytest.mark.unit
+
+TARGET = Path(__file__).parent.parent / "integration" / "test_coding_api_integration.py"
+
+
+def test_every_generate_tools_call_passes_an_output_dir():
+    tree = ast.parse(TARGET.read_text())
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "generate_tools"
+    ]
+
+    assert calls, "expected the integration test to exercise generate_tools"
+    for call in calls:
+        keywords = {kw.arg for kw in call.keywords}
+        assert "output_dir" in keywords, (
+            f"generate_tools() at line {call.lineno} would write into the "
+            "committed src/tooluniverse/tools/ tree"
+        )

--- a/tests/unit/test_ctg_phrase_quoting.py
+++ b/tests/unit/test_ctg_phrase_quoting.py
@@ -23,6 +23,16 @@ trial with no vedolizumab intervention, and sponsor="Takeda" surfaced
 trials sponsored by Neurocrine Biosciences and Shire (confirmed live).
 Values are now wrapped in Essie's AREA[InterventionName] /
 AREA[LeadSponsorName] operators (still phrase-quoted when multi-word).
+
+Fix-R23-1: restricting to AREA[InterventionName] alone overcorrected --
+brand names are registered in the separate InterventionOtherName synonym
+field, so 'Eliquis' + atrial fibrillation matched 5 trials against 43 once
+other-names are searched too, and 'Opdualag' + melanoma 2 against 19. An
+intervention value is now matched against both name fields; the noise
+Fix-R13B-1 removed lived in description/arm-label text, which neither name
+field contains, so precision is retained (vedolizumab 134 -> 142, against
+215 unrestricted). Sponsor still restricts to the single LeadSponsorName
+field.
 """
 
 import json
@@ -75,23 +85,39 @@ def test_already_quoted_value_is_not_double_quoted():
     assert _phrase_quote_if_plain('"cervical cancer"') == '"cervical cancer"'
 
 
+_INTR_AREAS = ("InterventionName", "InterventionOtherName")
+
+
 def test_area_restricted_value_is_not_double_wrapped():
     assert (
-        _restrict_to_area("AREA[InterventionName]nivolumab", "InterventionName")
+        _restrict_to_area("AREA[InterventionName]nivolumab", _INTR_AREAS)
         == "AREA[InterventionName]nivolumab"
     )
 
 
-def test_single_word_value_is_area_restricted_without_quotes():
-    assert _restrict_to_area("nivolumab", "InterventionName") == (
-        "AREA[InterventionName]nivolumab"
+def test_single_area_value_is_restricted_without_quotes():
+    assert _restrict_to_area("Pfizer", ("LeadSponsorName",)) == (
+        "AREA[LeadSponsorName]Pfizer"
+    )
+
+
+def test_single_word_value_searches_both_intervention_name_fields():
+    assert _restrict_to_area("nivolumab", _INTR_AREAS) == (
+        "(AREA[InterventionName]nivolumab OR AREA[InterventionOtherName]nivolumab)"
     )
 
 
 def test_multiword_value_is_area_restricted_and_phrase_quoted():
-    assert _restrict_to_area("immunotherapy radiotherapy", "InterventionName") == (
-        'AREA[InterventionName]"immunotherapy radiotherapy"'
+    assert _restrict_to_area("immunotherapy radiotherapy", _INTR_AREAS) == (
+        '(AREA[InterventionName]"immunotherapy radiotherapy" OR '
+        'AREA[InterventionOtherName]"immunotherapy radiotherapy")'
     )
+
+
+def test_brand_name_reaches_synonym_field():
+    """Brand names live in InterventionOtherName; searching only
+    InterventionName is what made 'Eliquis' return almost nothing."""
+    assert "InterventionOtherName" in _restrict_to_area("Eliquis", _INTR_AREAS)
 
 
 def test_condition_and_intervention_are_quoted_in_live_request():
@@ -107,7 +133,10 @@ def test_condition_and_intervention_are_quoted_in_live_request():
 
     params = mock_get.call_args.kwargs["params"]
     assert params["query.cond"] == '"cervical cancer"'
-    assert params["query.intr"] == 'AREA[InterventionName]"immunotherapy radiotherapy"'
+    assert params["query.intr"] == (
+        '(AREA[InterventionName]"immunotherapy radiotherapy" OR '
+        'AREA[InterventionOtherName]"immunotherapy radiotherapy")'
+    )
 
 
 def test_sponsor_alias_maps_to_query_spons():

--- a/tests/unit/test_disease_profile_identifier_match.py
+++ b/tests/unit/test_disease_profile_identifier_match.py
@@ -1,0 +1,108 @@
+"""gather_disease_profile must not mix several diseases into one identifier set.
+
+Every source behind the profile is a ranked search, and their top hits
+disagree. For "mucopolysaccharidosis type I" the profile used to emit Orphanet
+583 (MPS VI), MeSH D009085 (MPS IV) and ORDO 217085 (MPS II severe form)
+together under one disease name, because the first hit of each source was
+accepted without checking its label.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.compound_disease_tool import (
+    CompoundDiseaseProfileTool,
+    _labels_match,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return CompoundDiseaseProfileTool(
+        {"name": "gather_disease_profile", "type": "CompoundDiseaseProfileTool"}
+    )
+
+
+def test_roman_and_arabic_subtype_numbers_are_the_same_disease():
+    assert _labels_match("mucopolysaccharidosis type I", "Mucopolysaccharidosis type 1")
+    assert _labels_match("mucopolysaccharidosis type I", "Mucopolysaccharidosis Type I")
+
+
+def test_different_subtype_numbers_are_different_diseases():
+    assert not _labels_match(
+        "mucopolysaccharidosis type I", "Mucopolysaccharidosis type 6"
+    )
+    assert not _labels_match("mucopolysaccharidosis type I", "Mucopolysaccharidosis IV")
+
+
+def test_orphanet_hit_is_chosen_by_name_not_by_rank():
+    result = {
+        "status": "success",
+        "data": {
+            "results": [
+                {"ORPHAcode": 583, "Preferred term": "Mucopolysaccharidosis type 6"},
+                {"ORPHAcode": 579, "Preferred term": "Mucopolysaccharidosis type 1"},
+            ]
+        },
+    }
+
+    parsed = _tool()._parse_orphanet(result, "mucopolysaccharidosis type I")
+
+    assert parsed["orpha_code"] == "579"
+    assert parsed["match"] == "exact"
+
+
+def test_orphanet_without_a_name_match_is_flagged_and_not_promoted():
+    result = {
+        "status": "success",
+        "data": {
+            "results": [
+                {"ORPHAcode": 583, "Preferred term": "Mucopolysaccharidosis type 6"}
+            ]
+        },
+    }
+    tool = _tool()
+
+    parsed = tool._parse_orphanet(result, "mucopolysaccharidosis type I")
+    assert parsed["match"] == "approximate"
+
+    profile = tool._build_profile(
+        "mucopolysaccharidosis type I",
+        {"orphanet": parsed, "ols": {}, "opentargets": {}},
+    )
+    assert "orphanet" not in profile["identifiers"]
+
+
+def test_only_label_matching_ontology_terms_become_identifiers():
+    sections = {
+        "orphanet": {},
+        "opentargets": {},
+        "ols": {
+            "terms": [
+                {
+                    "id": "NCIT:C85053",
+                    "label": "Mucopolysaccharidosis Type I",
+                    "ontology": "ncit",
+                },
+                {
+                    "id": "mesh:D009085",
+                    "label": "Mucopolysaccharidosis IV",
+                    "ontology": "mesh",
+                },
+                {
+                    "id": "ORDO:217085",
+                    "label": "Mucopolysaccharidosis type 2, severe form",
+                    "ontology": "ordo",
+                },
+            ]
+        },
+    }
+
+    profile = _tool()._build_profile("mucopolysaccharidosis type I", sections)
+
+    assert profile["identifiers"] == {"ncit": "NCIT:C85053"}

--- a/tests/unit/test_disease_target_score_pagination.py
+++ b/tests/unit/test_disease_target_score_pagination.py
@@ -5,6 +5,7 @@ paginates client-side over all of them; without a wall-clock bound the
 loop issues hundreds of sequential requests and can run for minutes.
 These tests pin the time-budget guard without touching the live API.
 """
+
 from unittest.mock import patch
 
 import pytest
@@ -20,12 +21,12 @@ def make_tool():
             "type": "DiseaseTargetScoreTool",
             "query_schema": "query { disease { id } }",
             "parameter": {"type": "object", "properties": {}},
-            "datasource_id": "chembl",
+            "datasource_id": "clinical_precedence",
         }
     )
 
 
-def _page(index, page_size, total, datasource="chembl"):
+def _page(index, page_size, total, datasource="clinical_precedence"):
     """Build one associatedTargets page that always reports a huge total."""
     rows = [
         {
@@ -61,7 +62,11 @@ def test_pagination_stops_at_time_budget(monkeypatch):
 
     with patch.object(gqt, "execute_query", side_effect=fake_execute):
         result = make_tool().run(
-            {"efoId": "EFO_0000339", "datasourceId": "chembl", "pageSize": 5}
+            {
+                "efoId": "EFO_0000339",
+                "datasourceId": "clinical_precedence",
+                "pageSize": 5,
+            }
         )
 
     assert result["status"] == "success"
@@ -82,7 +87,11 @@ def test_pagination_completes_without_truncation(monkeypatch):
 
     with patch.object(gqt, "execute_query", side_effect=fake_execute):
         result = make_tool().run(
-            {"efoId": "EFO_0000339", "datasourceId": "chembl", "pageSize": 5}
+            {
+                "efoId": "EFO_0000339",
+                "datasourceId": "clinical_precedence",
+                "pageSize": 5,
+            }
         )
 
     assert result["status"] == "success"
@@ -107,7 +116,90 @@ def test_omitted_page_size_falls_back_to_100(monkeypatch):
         return _page(variables["index"], variables["size"], total=variables["size"])
 
     with patch.object(gqt, "execute_query", side_effect=fake_execute):
-        result = make_tool().run({"efoId": "EFO_0000339", "datasourceId": "chembl"})
+        result = make_tool().run(
+            {"efoId": "EFO_0000339", "datasourceId": "clinical_precedence"}
+        )
 
     assert result["status"] == "success"
     assert captured["size"] == 100
+
+
+@pytest.mark.unit
+def test_retired_datasource_id_is_remapped(monkeypatch):
+    """A retired datasource ID must not silently return zero scores.
+
+    Open Targets renamed 'ot_genetics_portal' to 'gwas_credible_sets' without
+    keeping the old name as an alias, so the stale ID matched nothing and the
+    tool returned a successful empty result that read as "no genetic evidence".
+    """
+    monkeypatch.setattr(gqt.time, "monotonic", lambda: 0.0)
+
+    def fake_execute(endpoint, query, variables):
+        return _page(
+            variables["index"],
+            variables["size"],
+            total=variables["size"],
+            datasource="gwas_credible_sets",
+        )
+
+    with patch.object(gqt, "execute_query", side_effect=fake_execute):
+        result = make_tool().run(
+            {
+                "efoId": "EFO_0000339",
+                "datasourceId": "ot_genetics_portal",
+                "pageSize": 5,
+            }
+        )
+
+    assert result["status"] == "success"
+    assert result["data"]["datasource"] == "gwas_credible_sets"
+    assert result["data"]["total_targets_with_scores"] == 5
+    assert "ot_genetics_portal" in result["data"]["datasource_rename_note"]
+
+
+@pytest.mark.unit
+def test_scores_are_sorted_strongest_first(monkeypatch):
+    """Truncated runs must still surface the strongest associations first."""
+    monkeypatch.setattr(gqt.time, "monotonic", lambda: 0.0)
+
+    def fake_execute(endpoint, query, variables):
+        page = _page(variables["index"], variables["size"], total=variables["size"])
+        rows = page["data"]["disease"]["associatedTargets"]["rows"]
+        for i, row in enumerate(rows):
+            row["datasourceScores"][0]["score"] = i / 10.0
+        return page
+
+    with patch.object(gqt, "execute_query", side_effect=fake_execute):
+        result = make_tool().run(
+            {
+                "efoId": "EFO_0000339",
+                "datasourceId": "clinical_precedence",
+                "pageSize": 5,
+            }
+        )
+
+    scores = [r["score"] for r in result["data"]["target_scores"]]
+    assert scores == sorted(scores, reverse=True)
+
+
+@pytest.mark.unit
+def test_unknown_datasource_reports_available_ids(monkeypatch):
+    """An empty result must say which datasource IDs the disease actually has."""
+    monkeypatch.setattr(gqt.time, "monotonic", lambda: 0.0)
+
+    def fake_execute(endpoint, query, variables):
+        return _page(
+            variables["index"],
+            variables["size"],
+            total=variables["size"],
+            datasource="europepmc",
+        )
+
+    with patch.object(gqt, "execute_query", side_effect=fake_execute):
+        result = make_tool().run(
+            {"efoId": "EFO_0000339", "datasourceId": "not_a_source", "pageSize": 5}
+        )
+
+    assert result["status"] == "success"
+    assert result["data"]["total_targets_with_scores"] == 0
+    assert result["data"]["available_datasources"] == ["europepmc"]

--- a/tests/unit/test_kegg_dblinks_pubchem_namespace.py
+++ b/tests/unit/test_kegg_dblinks_pubchem_namespace.py
@@ -1,0 +1,34 @@
+"""KEGG DBLINKS PubChem values are substance IDs, and must say so.
+
+KEGG deposits its records into PubChem as substances, so C05443's
+"PubChem: 7805" is SID 7805 (cholecalciferol, CID 5280795). Emitting it under
+the bare key "PubChem" invited callers to pass it to a CID-based tool, which
+answers with CID 7805 -- 1-bromo-4-methylbenzene -- as a plain success.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.kegg_ext_tool import _store_dblink
+
+pytestmark = pytest.mark.unit
+
+
+def test_pubchem_is_labelled_as_a_substance_id():
+    dblinks = {}
+    _store_dblink(dblinks, "PubChem", " 7805 ")
+
+    assert dblinks == {"PubChem_SID": "7805"}
+    assert "PubChem" not in dblinks
+
+
+def test_other_cross_references_keep_their_own_namespace():
+    dblinks = {}
+    _store_dblink(dblinks, "ChEBI", "28940")
+    _store_dblink(dblinks, "CAS", "67-97-0")
+
+    assert dblinks == {"ChEBI": "28940", "CAS": "67-97-0"}

--- a/tests/unit/test_ncbi_variation_placement_coordinates.py
+++ b/tests/unit/test_ncbi_variation_placement_coordinates.py
@@ -1,0 +1,68 @@
+"""NCBIVariation_rsid_lookup reports 1-based GRCh38 positions.
+
+dbSNP SPDI offsets are 0-based interbase. Passing them through under the name
+`position` put every variant one base 5' of its real location while the tool
+advertised "GRCh38 genomic coordinates": rs121965019 (IDUA c.1205G>A) came back
+as chr4:1002746 where ClinVar, Ensembl VEP and MyVariant all say 1002747.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.ncbi_variation_tool import (
+    _dedupe_genes,
+    _grch38_placement_from_spdi,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_substitution_position_is_one_based():
+    placement = _grch38_placement_from_spdi(
+        {
+            "seq_id": "NC_000004.12",
+            "position": 1002746,
+            "deleted_sequence": "G",
+            "inserted_sequence": "A",
+        }
+    )
+
+    assert placement["position"] == 1002747
+    assert placement["coordinate_system"] == "1-based"
+    assert placement["spdi_position"] == 1002746
+
+
+def test_insertion_anchors_on_the_preceding_base():
+    placement = _grch38_placement_from_spdi(
+        {
+            "seq_id": "NC_000019.10",
+            "position": 44908683,
+            "deleted_sequence": "",
+            "inserted_sequence": "T",
+        }
+    )
+
+    assert placement["position"] == 44908683
+    assert placement["spdi_position"] == 44908683
+
+
+def test_missing_position_is_passed_through_unchanged():
+    placement = _grch38_placement_from_spdi(
+        {"seq_id": "NC_000019.10", "position": None, "deleted_sequence": "T"}
+    )
+
+    assert placement["position"] is None
+
+
+def test_genes_repeated_per_allele_are_collapsed():
+    genes = [
+        {"gene": "IDUA", "name": "alpha-L-iduronidase", "gene_id": 3425},
+        {"gene": "IDUA", "name": "alpha-L-iduronidase", "gene_id": 3425},
+        {"gene": "APOE", "name": "apolipoprotein E", "gene_id": 348},
+    ]
+
+    assert [g["gene"] for g in _dedupe_genes(genes)] == ["IDUA", "APOE"]

--- a/tests/unit/test_opentargets_expression_pagination.py
+++ b/tests/unit/test_opentargets_expression_pagination.py
@@ -1,0 +1,161 @@
+"""OpenTargets_get_target_expression_by_ensemblID must paginate, and must say so.
+
+Regression: the tool's GraphQL query called ``baselineExpression { ... }`` with
+no ``page`` argument, so the OpenTargets default page size of 25 applied
+silently. For NLRP7 (ENSG00000167634) the response advertised
+``count: 1409`` and delivered 25 rows -- the remaining 1384 were unreachable
+because the tool exposed no pagination parameter at all. Those 25 rows held
+exactly one GTEx tissue and omitted testis (median 7.53), the gene's
+highest-expressing GTEx tissue, so the truncated answer was well-formed,
+confident and biologically wrong.
+
+The fix wires ``page: {index: $index, size: $size}`` into the query (default
+size 250, API maximum 3000) and annotates the response with
+``returned`` / ``truncated`` / ``page`` so a caller can tell "250 of 1409"
+from "1409 of 1409" without counting array elements.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import tooluniverse
+from tooluniverse.graphql_tool import OpentargetTool
+
+pytestmark = pytest.mark.unit
+
+TOOL_NAME = "OpenTargets_get_target_expression_by_ensemblID"
+_CONFIG = Path(tooluniverse.__file__).parent / "data" / "opentarget_tools.json"
+
+
+def _tool_config():
+    for entry in json.loads(_CONFIG.read_text()):
+        if isinstance(entry, dict) and entry.get("name") == TOOL_NAME:
+            return entry
+    raise AssertionError(f"{TOOL_NAME} not found in {_CONFIG}")
+
+
+def _mock_post(payload):
+    resp = MagicMock()
+    resp.ok = True
+    resp.status_code = 200
+    resp.json.return_value = payload
+    return resp
+
+
+def _expression_payload(count, n_rows):
+    return {
+        "data": {
+            "target": {
+                "id": "ENSG00000167634",
+                "approvedSymbol": "NLRP7",
+                "baselineExpression": {
+                    "count": count,
+                    "rows": [
+                        {
+                            "datasourceId": "gtex",
+                            "median": 1.0,
+                            "tissueBiosample": {"biosampleName": f"tissue{i}"},
+                        }
+                        for i in range(n_rows)
+                    ],
+                },
+            }
+        }
+    }
+
+
+def test_query_paginates_baseline_expression():
+    """The shipped GraphQL string must pass a page argument, not rely on the
+    API's silent default of 25."""
+    query = _tool_config()["query_schema"]
+    assert "baselineExpression(page:" in query.replace(" (", "(")
+    assert "$index" in query and "$size" in query
+    # A bare `baselineExpression {` (no page argument) is the defect.
+    assert "baselineExpression {" not in query
+
+
+def test_size_and_index_parameters_are_exposed():
+    props = _tool_config()["parameter"]["properties"]
+    assert props["size"]["type"] == "integer"
+    # Default must be materially better than the API's silent 25.
+    assert props["size"]["default"] == 250
+    # 3000 is the API's hard ceiling (probed live: 5000 -> pagination error).
+    assert props["size"]["maximum"] == 3000
+    assert props["index"]["type"] == "integer"
+    assert props["index"]["default"] == 0
+
+
+def test_return_schema_advertises_partialness_fields():
+    target_props = _tool_config()["return_schema"]["oneOf"][0]["properties"]["target"][
+        "properties"
+    ]
+    expr_props = target_props["baselineExpression"]["properties"]
+    assert expr_props["returned"]["type"] == "integer"
+    assert expr_props["truncated"]["type"] == "boolean"
+    assert "page" in expr_props
+
+
+def test_description_documents_pagination():
+    description = _tool_config()["description"]
+    assert "truncated" in description
+    assert "3000" in description
+
+
+def test_partial_response_is_flagged():
+    tool = OpentargetTool(_tool_config())
+    with patch("tooluniverse.graphql_tool.requests.post") as post:
+        post.return_value = _mock_post(_expression_payload(1409, 250))
+        result = tool.run({"ensemblId": "ENSG00000167634"})
+
+    # The default page size must reach the API, not the API's own default of 25.
+    sent = post.call_args.kwargs["json"]["variables"]
+    assert sent["size"] == 250
+    assert sent["index"] == 0
+
+    expr = result["data"]["target"]["baselineExpression"]
+    assert expr["count"] == 1409
+    assert expr["returned"] == 250
+    assert expr["truncated"] is True
+    assert expr["page"] == {"index": 0, "size": 250}
+    note = result["metadata"]["note"]
+    assert "250 of 1409" in note
+
+
+def test_complete_response_is_not_flagged_as_truncated():
+    """A target whose rows all fit in one page must not claim truncation."""
+    tool = OpentargetTool(_tool_config())
+    with patch("tooluniverse.graphql_tool.requests.post") as post:
+        post.return_value = _mock_post(_expression_payload(42, 42))
+        result = tool.run({"ensemblId": "ENSG00000167634"})
+
+    expr = result["data"]["target"]["baselineExpression"]
+    assert expr["returned"] == 42
+    assert expr["truncated"] is False
+    assert "note" not in result.get("metadata", {})
+
+
+def test_later_page_accounts_for_skipped_rows():
+    """returned=700 at index=1 means 1400 rows seen, so 1409 is still partial,
+    while index=1 of a 500-row page covering the tail is complete."""
+    tool = OpentargetTool(_tool_config())
+    with patch("tooluniverse.graphql_tool.requests.post") as post:
+        post.return_value = _mock_post(_expression_payload(1409, 700))
+        partial = tool.run({"ensemblId": "ENSG00000167634", "size": 700, "index": 1})
+    assert partial["data"]["target"]["baselineExpression"]["truncated"] is True
+
+    with patch("tooluniverse.graphql_tool.requests.post") as post:
+        post.return_value = _mock_post(_expression_payload(900, 400))
+        done = tool.run({"ensemblId": "ENSG00000167634", "size": 500, "index": 1})
+    assert done["data"]["target"]["baselineExpression"]["truncated"] is False
+
+
+def test_oversized_page_is_clamped_to_api_maximum():
+    """The API rejects size > 3000 outright; clamp instead of forwarding it."""
+    tool = OpentargetTool(_tool_config())
+    with patch("tooluniverse.graphql_tool.requests.post") as post:
+        post.return_value = _mock_post(_expression_payload(1409, 1409))
+        tool.run({"ensemblId": "ENSG00000167634", "size": 99999})
+    assert post.call_args.kwargs["json"]["variables"]["size"] == 3000

--- a/tests/unit/test_orphanet_subtype_name_boundary.py
+++ b/tests/unit/test_orphanet_subtype_name_boundary.py
@@ -1,0 +1,98 @@
+"""Orphanet_get_genes must not resolve a parent code to a numerically
+adjacent disease.
+
+Orphanet curates gene associations on subtype codes, so Orphanet_get_genes
+falls back to searching the Orphadata orphacode list for entries whose
+preferred term contains the parent's name. That test was a bare substring
+check, and Orphanet's terms are numbered: "Mucopolysaccharidosis type 1"
+(ORPHA:579, MPS I) is a substring of "Mucopolysaccharidosis type 10"
+(ORPHA:662216, MPS X). MPS I therefore reported ARSK -- the MPS X gene, on a
+different chromosome -- instead of IDUA, as a plain success.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.orphanet_tool import OrphanetTool, _name_contains_disease
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize(
+    "candidate",
+    [
+        "Mucopolysaccharidosis type 10",
+        "Mucopolysaccharidosis type 11",
+        "Familial hyperaldosteronism type II",
+        "Pseudoachondroplasia",
+        "Ganglioneuroblastoma",
+    ],
+)
+def test_rejects_names_that_only_extend_the_same_token(candidate):
+    parent = {
+        "Mucopolysaccharidosis type 10": "Mucopolysaccharidosis type 1",
+        "Mucopolysaccharidosis type 11": "Mucopolysaccharidosis type 1",
+        "Familial hyperaldosteronism type II": "Familial hyperaldosteronism type I",
+        "Pseudoachondroplasia": "Achondroplasia",
+        "Ganglioneuroblastoma": "Neuroblastoma",
+    }[candidate]
+    assert not _name_contains_disease(candidate, parent)
+
+
+@pytest.mark.parametrize(
+    "candidate,parent",
+    [
+        ("Mucopolysaccharidosis type 4A", "Mucopolysaccharidosis type 4"),
+        ("Mucopolysaccharidosis type 2, severe form", "Mucopolysaccharidosis type 2"),
+        ("Marfan syndrome type 1", "Marfan syndrome"),
+        ("Neonatal Marfan syndrome", "Marfan syndrome"),
+        (
+            "Autosomal dominant Charcot-Marie-Tooth disease type 2N",
+            "Charcot-Marie-Tooth disease",
+        ),
+        ("Classical Ehlers-Danlos syndrome", "Ehlers-Danlos syndrome"),
+    ],
+)
+def test_accepts_real_subtype_names(candidate, parent):
+    assert _name_contains_disease(candidate, parent)
+
+
+def _json_response(payload, status_code=200):
+    response = MagicMock()
+    response.status_code = status_code
+    response.json.return_value = payload
+    response.raise_for_status = MagicMock()
+    return response
+
+
+@patch("tooluniverse.orphanet_tool.requests.get")
+def test_mps_one_does_not_borrow_the_mps_ten_gene(mock_get):
+    tool = OrphanetTool({"name": "Orphanet_get_genes", "fields": {}})
+    name_resp = _json_response(
+        {"ORPHAcode": 579, "Preferred term": "Mucopolysaccharidosis type 1"}
+    )
+    direct_resp = _json_response({}, status_code=404)
+    list_resp = _json_response(
+        {
+            "data": {
+                "results": [
+                    {
+                        "ORPHAcode": 662216,
+                        "Preferred term": "Mucopolysaccharidosis type 10",
+                    }
+                ]
+            }
+        }
+    )
+    mock_get.side_effect = [name_resp, direct_resp, list_resp]
+
+    result = tool._get_genes({"orpha_code": "579"})
+
+    assert result["status"] == "success"
+    assert result["data"]["genes"] == []
+    assert "subtype_sources" not in result["data"]

--- a/tests/unit/test_proteins_api_organism_widening.py
+++ b/tests/unit/test_proteins_api_organism_widening.py
@@ -79,6 +79,28 @@ class TestOrganismWidening(unittest.TestCase):
         params = tool._build_params({"query": "blaKPC", "taxid": "573"})
         self.assertEqual(params.get("taxid"), "573")
 
+    def test_caller_supplied_organism_survives_the_field_swap_retry(self):
+        """A gene->protein retry must not drop the caller's organism filter.
+
+        Rebuilding the retry parameters from scratch dropped organism=/taxid=,
+        so a wheat query ("FT1" in Triticum aestivum) retried against all of
+        UniProt and answered with an assassin-bug protein under a note
+        claiming no organism had been supplied.
+        """
+        tool = _make_tool()
+        tool.session.get = MagicMock(
+            side_effect=[_resp(200, []), _resp(200, [{"accession": "X"}])]
+        )
+
+        result = tool.run({"query": "FT1", "organism": "Triticum aestivum", "size": 2})
+
+        self.assertEqual(result["status"], "success")
+        self.assertNotIn("note", result)
+        retry_params = tool.session.get.call_args_list[1].kwargs["params"]
+        self.assertEqual(retry_params.get("organism"), "Triticum aestivum")
+        self.assertEqual(retry_params.get("protein"), "FT1")
+        self.assertNotIn("gene", retry_params)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_pubmed_doi_articleids_fallback.py
+++ b/tests/unit/test_pubmed_doi_articleids_fallback.py
@@ -1,0 +1,237 @@
+"""Regression guard for Fix-R25: PubMed_search_articles returned
+doi=None/doi_url=None for essentially every article published before ~2008.
+
+The DOI was parsed *only* out of the esummary ``elocationid`` display string,
+which NCBI leaves empty for older records -- even though the very same
+response carries the DOI in the structured ``articleids`` list, two keys away
+(confirmed live for PMIDs 15720521, 17354009, 15500562, 14765742, 14627096).
+``articleids`` is now the primary source, with the ``elocationid`` parse kept
+as a fallback. The same defect existed on the efetch XML path, where older
+records carry no <ELocationID> but do list the DOI in <ArticleIdList>.
+
+All assertions below run against synthetic payloads -- no network.
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+import tooluniverse
+from tooluniverse.pubmed_tool import PubMedRESTTool
+
+pytestmark = pytest.mark.unit
+
+DATA_DIR = Path(tooluniverse.__file__).parent / "data"
+
+
+def _tool():
+    return PubMedRESTTool(
+        {
+            "name": "PubMed_search_articles",
+            "type": "PubMedRESTTool",
+            "fields": {
+                "db": "pubmed",
+                "retmode": "json",
+                "endpoint": "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi",
+            },
+            "parameter": {"type": "object", "properties": {}, "required": []},
+        }
+    )
+
+
+def _summarize(record, pmid="15720521"):
+    """Run one synthetic esummary record through _fetch_summaries."""
+    tool = _tool()
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {"result": {"uids": [pmid], pmid: record}}
+
+    with (
+        patch.object(tool, "_enforce_rate_limit"),
+        patch("tooluniverse.pubmed_tool.request_with_retry", return_value=resp),
+    ):
+        result = tool._fetch_summaries([pmid])
+
+    assert result["status"] == "success"
+    return result["data"][0]
+
+
+def _record(**overrides):
+    base = {
+        "uid": "15720521",
+        "pubdate": "2005 Feb",
+        "title": "Development of a PCR-based diagnostic test",
+        "authors": [{"name": "Geyer J"}],
+        "fulljournalname": "J Vet Pharmacol Ther",
+        "pubtype": ["Journal Article"],
+        "elocationid": "",
+        "articleids": [],
+    }
+    base.update(overrides)
+    return base
+
+
+def test_old_record_doi_comes_from_articleids():
+    """Empty elocationid + articleids doi entry -> DOI is populated."""
+    article = _summarize(
+        _record(
+            elocationid="",
+            articleids=[
+                {"idtype": "pubmed", "value": "15720521"},
+                {"idtype": "doi", "value": "10.1111/j.1365-2885.2004.00625.x"},
+                {"idtype": "pii", "value": "JVP625"},
+            ],
+        )
+    )
+
+    assert article["doi"] == "10.1111/j.1365-2885.2004.00625.x"
+    assert article["doi_url"] == "https://doi.org/10.1111/j.1365-2885.2004.00625.x"
+
+
+def test_articleids_doi_is_not_double_prefixed():
+    """The fallback must not leave/insert a 'doi:' prefix in the value."""
+    article = _summarize(
+        _record(articleids=[{"idtype": "doi", "value": "10.2460/javma.2003.223.1453"}])
+    )
+
+    assert article["doi"] == "10.2460/javma.2003.223.1453"
+    assert not article["doi"].lower().startswith("doi:")
+    assert article["doi_url"].count("https://doi.org/") == 1
+
+
+def test_modern_record_with_populated_elocationid_is_unchanged():
+    """A record where both sources agree still yields the clean DOI."""
+    article = _summarize(
+        _record(
+            elocationid="doi: 10.1002/jat.70166",
+            articleids=[
+                {"idtype": "pubmed", "value": "41837342"},
+                {"idtype": "pmc", "value": "PMC13136416"},
+                {"idtype": "doi", "value": "10.1002/jat.70166"},
+            ],
+        )
+    )
+
+    assert article["doi"] == "10.1002/jat.70166"
+    assert article["doi_url"] == "https://doi.org/10.1002/jat.70166"
+
+
+def test_elocationid_still_used_when_articleids_lacks_doi():
+    """Pre-existing behaviour: parse elocationid when there is no doi id."""
+    article = _summarize(
+        _record(
+            elocationid="pii: 2026.02.14.705936. doi: 10.64898/2026.02.14.705936",
+            articleids=[{"idtype": "pmc", "value": "PMC13136416"}],
+        )
+    )
+
+    assert article["doi"] == "10.64898/2026.02.14.705936"
+    assert "pii" not in article["doi"]
+    assert article["doi_url"] == "https://doi.org/10.64898/2026.02.14.705936"
+
+
+def test_record_with_no_doi_anywhere_returns_none():
+    """A genuinely DOI-less record (e.g. PMID 13678080) stays None, not ''."""
+    article = _summarize(
+        _record(elocationid="", articleids=[{"idtype": "pubmed", "value": "13678080"}])
+    )
+
+    assert article["doi"] is None
+    assert article["doi_url"] is None
+
+
+def test_malformed_articleids_do_not_crash():
+    """Blank/missing doi values fall through safely instead of yielding ''."""
+    article = _summarize(
+        _record(
+            elocationid="",
+            articleids=[
+                {"idtype": "doi"},
+                {"idtype": "doi", "value": ""},
+                {"idtype": "doi", "value": None},
+            ],
+        )
+    )
+
+    assert article["doi"] is None
+    assert article["doi_url"] is None
+
+
+def test_efetch_xml_doi_falls_back_to_articleidlist():
+    """Older efetch XML has no <ELocationID> but does list a doi ArticleId."""
+    xml = """<?xml version="1.0"?>
+<PubmedArticleSet><PubmedArticle>
+  <MedlineCitation>
+    <PMID>15720521</PMID>
+    <Article>
+      <Journal><Title>J Vet Pharmacol Ther</Title></Journal>
+      <ArticleTitle>PCR-based diagnostic test</ArticleTitle>
+    </Article>
+  </MedlineCitation>
+  <PubmedData><ArticleIdList>
+    <ArticleId IdType="pubmed">15720521</ArticleId>
+    <ArticleId IdType="doi">10.1111/j.1365-2885.2004.00625.x</ArticleId>
+  </ArticleIdList></PubmedData>
+</PubmedArticle></PubmedArticleSet>"""
+
+    resp = MagicMock()
+    resp.text = xml
+    resp.url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi"
+    parsed = _tool()._parse_efetch_xml(resp)
+
+    assert parsed["status"] == "success"
+    assert parsed["data"]["doi"] == "10.1111/j.1365-2885.2004.00625.x"
+    assert (
+        parsed["data"]["doi_url"] == "https://doi.org/10.1111/j.1365-2885.2004.00625.x"
+    )
+
+
+def test_efetch_xml_elocationid_still_wins_and_no_doi_stays_none():
+    """ELocationID remains primary; a record with neither source stays None."""
+    with_eloc = """<?xml version="1.0"?>
+<PubmedArticleSet><PubmedArticle>
+  <MedlineCitation><PMID>41837342</PMID><Article>
+    <Journal><Title>J Appl Toxicol</Title></Journal>
+    <ArticleTitle>Modern article</ArticleTitle>
+    <ELocationID EIdType="doi">10.1002/jat.70166</ELocationID>
+  </Article></MedlineCitation>
+</PubmedArticle></PubmedArticleSet>"""
+
+    resp = MagicMock()
+    resp.text = with_eloc
+    resp.url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi"
+    assert _tool()._parse_efetch_xml(resp)["data"]["doi"] == "10.1002/jat.70166"
+
+    without_any = """<?xml version="1.0"?>
+<PubmedArticleSet><PubmedArticle>
+  <MedlineCitation><PMID>13678080</PMID><Article>
+    <Journal><Title>Old Journal</Title></Journal>
+    <ArticleTitle>No DOI anywhere</ArticleTitle>
+  </Article></MedlineCitation>
+  <PubmedData><ArticleIdList>
+    <ArticleId IdType="pubmed">13678080</ArticleId>
+  </ArticleIdList></PubmedData>
+</PubmedArticle></PubmedArticleSet>"""
+
+    resp2 = MagicMock()
+    resp2.text = without_any
+    resp2.url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi"
+    data = _tool()._parse_efetch_xml(resp2)["data"]
+    assert data["doi"] is None
+    assert data["doi_url"] is None
+
+
+def test_search_tool_config_still_declares_doi_fields():
+    """The tool contract advertising doi/doi_url is resolved via the package
+    directory, not a cwd-relative path."""
+    config_path = DATA_DIR / "pubmed_tools.json"
+    assert config_path.is_file(), f"missing {config_path}"
+
+    configs = json.loads(config_path.read_text())
+    search = next(c for c in configs if c["name"] == "PubMed_search_articles")
+    assert search["type"] == "PubMedRESTTool"

--- a/tests/unit/test_reactome_interactors_pagination.py
+++ b/tests/unit/test_reactome_interactors_pagination.py
@@ -3,6 +3,15 @@ page=-1 (a Reactome-specific "ignore pagination, return everything"
 signal), so the tool's own documented page_size parameter had zero effect
 -- confirmed live that page=-1&pageSize=10 returned all 153 interactors for
 P31749, while page=1&pageSize=10 correctly returned 10.
+
+Feature-23C-2: page_size was additionally clamped to 100, and
+total_interactors was read from the /details response's `count` field --
+which reports how many records that page returned, not the size of the
+full result set. So a page_size=300 request came back with
+total_interactors=100 and no indication anything had been dropped
+(live-verified for P04637: pageSize=100 -> count=100, pageSize=300 ->
+count=249). The clamp is gone and the true total now comes from the
+dedicated /summary endpoint, so these tests assert against two calls.
 """
 
 import sys
@@ -10,6 +19,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
 
@@ -24,23 +34,111 @@ def _tool():
     )
 
 
-def test_page_size_is_honored_via_correct_page_param():
-    tool = _tool()
+def _fake_reactome(total, returned, acc="P31749"):
+    """Mock Reactome's two endpoints: /summary gives the true total,
+    /details gives one page. Records the params each one was called with."""
     captured = {}
 
     def fake_get(url, params=None, **kwargs):
-        captured["params"] = params
         resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        if url.endswith("/summary"):
+            captured["summary_params"] = params
+            resp.json.return_value = {
+                "resource": "static",
+                "entities": [{"acc": acc, "count": total}],
+            }
+        else:
+            captured["details_params"] = params
+            resp.json.return_value = {
+                "resource": "IntAct",
+                "entities": [
+                    {
+                        "acc": acc,
+                        # `count` here is the page's own size, which is exactly
+                        # why it must not be reported as a total.
+                        "count": returned,
+                        "interactors": [
+                            {
+                                "acc": f"P{i}",
+                                "alias": None,
+                                "score": 0.5,
+                                "evidences": [],
+                            }
+                            for i in range(returned)
+                        ],
+                    }
+                ],
+            }
+        return resp
+
+    return fake_get, captured
+
+
+def test_page_size_is_honored_via_correct_page_param():
+    tool = _tool()
+    fake_get, captured = _fake_reactome(total=10, returned=10)
+
+    with patch(
+        "tooluniverse.reactome_interactors_tool.requests.get", side_effect=fake_get
+    ):
+        result = tool._get_interactors({"accession": "P31749", "page_size": 10})
+
+    assert captured["details_params"]["page"] == 1
+    assert captured["details_params"]["pageSize"] == 10
+    assert len(result["data"]["interactors"]) == 10
+
+
+def test_page_size_above_100_is_not_clamped():
+    tool = _tool()
+    fake_get, captured = _fake_reactome(total=249, returned=249, acc="P04637")
+
+    with patch(
+        "tooluniverse.reactome_interactors_tool.requests.get", side_effect=fake_get
+    ):
+        result = tool._get_interactors({"accession": "P04637", "page_size": 300})
+
+    assert captured["details_params"]["pageSize"] == 300
+    assert result["data"]["total_interactors"] == 249
+    assert result["data"]["returned_interactors"] == 249
+    assert result["data"]["truncated"] is False
+
+
+def test_truncated_page_reports_true_total_and_flags_truncation():
+    tool = _tool()
+    fake_get, _ = _fake_reactome(total=249, returned=20, acc="P04637")
+
+    with patch(
+        "tooluniverse.reactome_interactors_tool.requests.get", side_effect=fake_get
+    ):
+        result = tool._get_interactors({"accession": "P04637"})
+
+    data = result["data"]
+    # The /details page reported count=20; the total must come from /summary.
+    assert data["total_interactors"] == 249
+    assert data["returned_interactors"] == 20
+    assert data["truncated"] is True
+    assert data["total_is_exact"] is True
+    assert "249" in data["note"]
+
+
+def test_unavailable_summary_does_not_pass_page_count_off_as_total():
+    tool = _tool()
+
+    def fake_get(url, params=None, **kwargs):
+        resp = MagicMock()
+        if url.endswith("/summary"):
+            raise requests.exceptions.ConnectionError("summary down")
         resp.raise_for_status = MagicMock()
         resp.json.return_value = {
             "resource": "IntAct",
             "entities": [
                 {
                     "acc": "P31749",
-                    "count": 10,
+                    "count": 20,
                     "interactors": [
                         {"acc": f"P{i}", "alias": None, "score": 0.5, "evidences": []}
-                        for i in range(10)
+                        for i in range(20)
                     ],
                 }
             ],
@@ -50,8 +148,9 @@ def test_page_size_is_honored_via_correct_page_param():
     with patch(
         "tooluniverse.reactome_interactors_tool.requests.get", side_effect=fake_get
     ):
-        result = tool._get_interactors({"accession": "P31749", "page_size": 10})
+        result = tool._get_interactors({"accession": "P31749"})
 
-    assert captured["params"]["page"] == 1
-    assert captured["params"]["pageSize"] == 10
-    assert len(result["data"]["interactors"]) == 10
+    data = result["data"]
+    assert data["total_is_exact"] is False
+    assert data["returned_interactors"] == 20
+    assert "incomplete" in data["note"]

--- a/tests/unit/test_xml_tool_multi_xpath_field.py
+++ b/tests/unit/test_xml_tool_multi_xpath_field.py
@@ -1,0 +1,196 @@
+"""Regression guard for Fix Round 25: a flat `field_mappings` value may be a
+LIST of XPath expressions, tried in order with the first non-empty result winning.
+
+drugbank_get_drug_chemistry_by_drug_name_or_drugbank_id mapped
+molecular_formula/molecular_weight only to
+<experimental-properties>, but DrugBank files those two properties under
+<calculated-properties> for small molecules -- so the two fields the tool's own
+description promises came back "" for EVERY small molecule (confirmed live:
+{"drug_name": "Ivermectin"} returned molecular_formula="" while melting_point
+and water_solubility were populated). Biotech/peptide records genuinely do carry
+them under <experimental-properties>, so the fix must consult both sections.
+ElementTree/lxml findall() does not support `|` XPath unions, hence a list.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+NS = {"db": "http://www.drugbank.ca"}
+
+# Two records mirroring the real dataset's two shapes: a small molecule with
+# the properties under <calculated-properties>, and a biotech entry with them
+# under <experimental-properties>.
+SAMPLE_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<drugbank xmlns="http://www.drugbank.ca">
+  <drug type="small molecule">
+    <drugbank-id primary="true">DB00602</drugbank-id>
+    <name>Ivermectin</name>
+    <experimental-properties>
+      <property><kind>Melting Point</kind><value>155 &#176;C</value></property>
+    </experimental-properties>
+    <calculated-properties>
+      <property><kind>Molecular Formula</kind><value>C95H146O28</value></property>
+      <property><kind>Molecular Weight</kind><value>1736.185</value></property>
+    </calculated-properties>
+  </drug>
+  <drug type="biotech">
+    <drugbank-id primary="true">DB00001</drugbank-id>
+    <name>Lepirudin</name>
+    <experimental-properties>
+      <property><kind>Molecular Formula</kind><value>C287H440N80O111S6</value></property>
+      <property><kind>Molecular Weight</kind><value>6979.0</value></property>
+    </experimental-properties>
+  </drug>
+</drugbank>
+"""
+
+CALCULATED = "db:calculated-properties/db:property[db:kind='{}']/db:value"
+EXPERIMENTAL = "db:experimental-properties/db:property[db:kind='{}']/db:value"
+
+
+def _make_tool(tmp_path, formula_mapping, weight_mapping):
+    from tooluniverse.xml_tool import XMLDatasetTool
+
+    xml_path = tmp_path / "drugbank_sample.xml"
+    xml_path.write_text(SAMPLE_XML, encoding="utf-8")
+
+    return XMLDatasetTool(
+        {
+            "name": "drugbank_get_drug_chemistry_by_drug_name_or_drugbank_id",
+            "parameter": {
+                "type": "object",
+                "properties": {"query": {"type": "string"}},
+                "required": ["query"],
+            },
+            "settings": {
+                "local_dataset_path": str(xml_path),
+                "namespaces": NS,
+                "record_xpath": "db:drug",
+                "search_fields": ["drug_name", "drugbank_id"],
+                "field_mappings": {
+                    "drug_name": "db:name",
+                    "drugbank_id": "db:drugbank-id[@primary='true']",
+                    "molecular_formula": formula_mapping,
+                    "molecular_weight": weight_mapping,
+                    "melting_point": EXPERIMENTAL.format("Melting Point"),
+                },
+            },
+        }
+    )
+
+
+def _lookup(tool, query):
+    result = tool.run({"query": query})
+    assert result["status"] == "success", result
+    records = result["data"]["results"]
+    assert len(records) == 1, records
+    return records[0]
+
+
+@pytest.fixture
+def tool(tmp_path):
+    """A tool configured the way the shipped config now is: list-valued."""
+    return _make_tool(
+        tmp_path,
+        [
+            CALCULATED.format("Molecular Formula"),
+            EXPERIMENTAL.format("Molecular Formula"),
+        ],
+        [
+            CALCULATED.format("Molecular Weight"),
+            EXPERIMENTAL.format("Molecular Weight"),
+        ],
+    )
+
+
+def test_small_molecule_falls_to_calculated_properties(tool):
+    """The bug: this record has NO experimental Molecular Formula at all."""
+    record = _lookup(tool, "Ivermectin")
+    assert record["molecular_formula"] == "C95H146O28"
+    assert record["molecular_weight"] == "1736.185"
+    # The fields that already worked must be untouched.
+    assert record["melting_point"] == "155 °C"
+
+
+def test_biotech_still_resolves_via_experimental_fallback(tool):
+    """Second XPath in the list wins when the first yields nothing."""
+    record = _lookup(tool, "Lepirudin")
+    assert record["molecular_formula"] == "C287H440N80O111S6"
+    assert record["molecular_weight"] == "6979.0"
+
+
+def test_plain_string_mapping_behaviour_is_unchanged(tmp_path):
+    """A str value must behave exactly as before -- including yielding ''."""
+    tool = _make_tool(
+        tmp_path,
+        EXPERIMENTAL.format("Molecular Formula"),
+        EXPERIMENTAL.format("Molecular Weight"),
+    )
+    assert _lookup(tool, "Ivermectin")["molecular_formula"] == ""
+    assert _lookup(tool, "Lepirudin")["molecular_formula"] == "C287H440N80O111S6"
+
+
+def test_list_mapping_yields_empty_string_when_no_xpath_matches(tmp_path):
+    tool = _make_tool(
+        tmp_path,
+        [CALCULATED.format("Nonexistent"), EXPERIMENTAL.format("Nonexistent")],
+        [CALCULATED.format("Nonexistent")],
+    )
+    record = _lookup(tool, "Ivermectin")
+    assert record["molecular_formula"] == ""
+    assert record["molecular_weight"] == ""
+
+
+def test_list_valued_mapping_still_lands_in_default_search_fields(tmp_path):
+    """search_fields defaults to list(field_mappings.keys()); a list value
+    must not break that, nor the config echo in get_dataset_info()."""
+    from tooluniverse.xml_tool import XMLDatasetTool
+
+    xml_path = tmp_path / "drugbank_sample.xml"
+    xml_path.write_text(SAMPLE_XML, encoding="utf-8")
+    tool = XMLDatasetTool(
+        {
+            "name": "t",
+            "settings": {
+                "local_dataset_path": str(xml_path),
+                "namespaces": NS,
+                "record_xpath": "db:drug",
+                "field_mappings": {
+                    "molecular_formula": [
+                        CALCULATED.format("Molecular Formula"),
+                        EXPERIMENTAL.format("Molecular Formula"),
+                    ]
+                },
+            },
+        }
+    )
+    assert tool.search_fields == ["_text", "molecular_formula"]
+    info = tool.get_dataset_info()
+    assert isinstance(info["field_mappings"]["molecular_formula"], list)
+    # get_dataset_info() feeds JSON responses; a list value must serialize.
+    json.dumps(info["field_mappings"])
+
+
+def test_shipped_config_lists_calculated_before_experimental():
+    # Resolve via the installed package rather than the process cwd, so the
+    # test does not depend on pytest being invoked from the repository root.
+    import tooluniverse
+
+    config_path = Path(tooluniverse.__file__).parent / "data" / "xml_tools.json"
+    with open(config_path) as f:
+        tools = json.load(f)
+    settings = next(
+        t
+        for t in tools
+        if t["name"] == "drugbank_get_drug_chemistry_by_drug_name_or_drugbank_id"
+    )["settings"]
+    for field, kind in (
+        ("molecular_formula", "Molecular Formula"),
+        ("molecular_weight", "Molecular Weight"),
+    ):
+        mapping = settings["field_mappings"][field]
+        assert mapping == [CALCULATED.format(kind), EXPERIMENTAL.format(kind)], field


### PR DESCRIPTION
Consolidates test-harness rounds 20-25 — six PRs, 12 commits, onto current `main`. Opened because the originals no longer merge cleanly with each other, not merely to tidy the queue.

Supersedes #493 (r20), #494 (r21), #495 (r22), #496 (r23), #497 (r24), #498 (r25). Every commit is preserved with its original message; nothing was squashed.

## Why now

Rounds 21, 22 and 25 all modify `OpentargetTool.run` in `graphql_tool.py`, and rounds 21+22 vs 25 **conflict textually** — cherry-picking round 25 onto 21+22 fails in that method. Merging the originals in any order would have required hand-resolving that conflict at merge time.

The backlog was also throttling the harness itself. Round 25 discarded 12 of 16 persona findings, but only 4 were true false positives: **5 were duplicates of work already queued in #493-#497, and 3 were real, CLI-verified defects declined purely because fixing them would collide with an open PR** (HPA substring over-match binding `"ear"` to `heart muscle`; UniProt species-vs-strain taxid returning 0 for bacteria; a KEGG organism-code collision). Those are unblocked once this lands.

## Conflict resolution

**`graphql_tool.py` — kept both features.** The round-21/22 change remaps retired Open Targets datasource IDs; the round-25 change pins and reports `baselineExpression` pagination. They are independent, and both mutate `arguments` before a single `super().run(arguments)`, so the resolution sequences both mutations ahead of that one call and both post-processing blocks after it. Neither behaviour was dropped.

**Collapsed a duplicated constant.** Rounds 21 and 22 each introduced their own module-level dict with identical contents — `_OT_RENAMED_DATASOURCES` (for `OpentargetTool`, list-valued `datasourceIds`) and `_RETIRED_DATASOURCE_IDS` (for `DiseaseTargetScoreTool`, scalar `datasourceId`). They were not a duplicated *fix* — two different classes genuinely needed the remap, and neither branch could reference the other's since both cut from `main`. Here there is one source of truth: `_RETIRED_DATASOURCE_IDS` is removed and its consumer points at `_OT_RENAMED_DATASOURCES`.

No other conflicts; rounds 20, 23 and 24 cherry-picked clean.

## What is in it

| Round | Theme | Representative fix |
| --- | --- | --- |
| 20 | Confidently wrong ontology hit | `PCOS` resolved to *C-peptide measurement* instead of polycystic ovary syndrome |
| 21 | Lookup returns empty when the data exists | UniProt put a species *name* into a numeric-only `organism_id:` field, HTTP 400 for every non-model organism |
| 22 | Same, via a wrong source field | HPA read the tissue-*enrichment* summary, so MAPT in cerebral cortex reported "No data" against a published 147.9 nTPM |
| 23 | Looks complete, silently is not | Reactome reported the *page size* as `total_interactors` (100 vs the real 249) |
| 24 | Right shape, wrong entity | Orphanet returned **ARSK** for Mucopolysaccharidosis type **1**, matched from "type 10" by bare substring |
| 25 | Truncation and misattributed errors | OpenTargets returned 25 of 1,409 expression rows as if complete, omitting the target's highest-expressing tissue |

Round 24 also fixed a repo-hygiene defect worth calling out: `tests/integration/test_coding_api_integration.py` called `generate_tools()` with no `output_dir` at four sites — each having already allocated a temp dir, two directly under the comment `# Generate tools in temp directory`. Its default output is the tracked `src/tooluniverse/tools/` tree, so **running the integration suite rewrote 2,604 tracked files as a side effect**. That noise caused the same incident to be misdiagnosed twice. Now fixed and guarded by an AST test.

## Verification

- Every round was independently CI-green as its own PR before consolidation, and each round's headline claims were re-verified live against the real APIs (before *and* after), not taken from the authoring agent's report.
- Full `tests/unit` green on this consolidated branch.
- Targeted re-run of the merged OpenTargets paths — `test_opentargets_expression_pagination.py` + `test_disease_target_score_pagination.py` — 14 passed, confirming the hand-resolved method still satisfies both rounds' tests.
- `git status --short src/tooluniverse/tools/` is clean: the bulk wrapper generator was never run.

## Not included

IntAct Complex Portal's `complex-ws` endpoint is retired, and the entire Complex Portal service currently returns 503 — including its own web UI. A replacement endpoint cannot be live-verified while the service is down, so that migration is deliberately left for a later round rather than shipped unverified.
