### PR TITLE
Fix Round 26: answers that look complete or name the wrong record

### DIFF
--- a/src/tooluniverse/base_tool.py
+++ b/src/tooluniverse/base_tool.py
@@ -16,6 +16,28 @@ import hashlib
 import inspect
 
 
+def resolve_configured_operation(tool_config: Any) -> Optional[str]:
+    """Return the ``operation`` a tool's own config implies, if any.
+
+    Many multi-operation tool classes are registered once per operation and
+    still read ``arguments["operation"]``, so ToolUniverse fills that key in
+    from the tool's own config (``fields.operation``, else the schema default)
+    before the tool runs -- see
+    ``ToolUniverse._apply_operation_default``. Both the injection and the
+    validation-side recognition of the injected key resolve the value through
+    this single function, so the two cannot drift apart.
+    """
+    if not isinstance(tool_config, dict):
+        return None
+    operation = (tool_config.get("fields") or {}).get("operation")
+    if not operation:
+        schema = tool_config.get("parameter") or {}
+        prop = (schema.get("properties") or {}).get("operation")
+        if isinstance(prop, dict):
+            operation = prop.get("default")
+    return operation if isinstance(operation, str) and operation else None
+
+
 class BaseTool:
     STATIC_CACHE_VERSION = "1"
 
@@ -297,6 +319,28 @@ class BaseTool:
 
             jsonschema.validate(filtered_arguments, schema)
 
+            # Feature-26A-8: ToolUniverse fills `operation` into `arguments`
+            # from the tool's own config before validation, for the tool
+            # classes that read it from there. The caller never sent it, so
+            # the unrecognized-parameter reporting below must not see it:
+            # `Pharos_get_target_expression {"target": "EGFR"}` was answered
+            # with "Unrecognized parameter(s): 'target', 'operation'", naming a
+            # parameter the caller did not pass and could not remove. Drop the
+            # key only when its value is exactly what the config would have
+            # supplied -- a caller-supplied `operation` that says anything else
+            # is a genuine mistake and stays in the report. Dropping it from
+            # `checked_arguments` (not just from the message) also keeps the
+            # total-mismatch guard honest in both directions: the injected key
+            # must not pad the "recognized" side for the 348 configs that do
+            # declare `operation`, nor pad the "unknown" side for the 235 that
+            # do not. jsonschema itself still sees the full argument set.
+            checked_arguments = filtered_arguments
+            auto_operation = resolve_configured_operation(self.tool_config)
+            if auto_operation and filtered_arguments.get("operation") == auto_operation:
+                checked_arguments = {
+                    k: v for k, v in filtered_arguments.items() if k != "operation"
+                }
+
             # Feature-14A-01 / Feature-14B-01: jsonschema only rejects an
             # unknown key when it causes a *required* property to end up
             # missing. A tool whose schema has no required properties (a
@@ -325,10 +369,10 @@ class BaseTool:
             # risk of being a genuine mistake, and flagging it risks
             # rejecting legitimate pass-through/forward-compatible callers.
             properties = schema.get("properties", {})
-            if properties and filtered_arguments:
-                unknown = self._unknown_keys(filtered_arguments, properties)
+            if properties and checked_arguments:
+                unknown = self._unknown_keys(checked_arguments, properties)
                 if unknown:
-                    unset_props = [p for p in properties if p not in filtered_arguments]
+                    unset_props = [p for p in properties if p not in checked_arguments]
                     # Match each *unknown supplied key* (typically 1-2) against
                     # the unset schema properties (can be 30+ for a
                     # filter-heavy endpoint), rather than the reverse -- same
@@ -351,7 +395,7 @@ class BaseTool:
                                 "valid_parameters": sorted(properties),
                             },
                         )
-                    if len(unknown) == len(filtered_arguments):
+                    if len(unknown) == len(checked_arguments):
                         return ToolValidationError(
                             f"Unrecognized parameter(s): "
                             f"{', '.join(repr(k) for k in unknown)}. "

--- a/src/tooluniverse/civic_tool.py
+++ b/src/tooluniverse/civic_tool.py
@@ -8,6 +8,7 @@ API Documentation: https://civicdb.org/api
 GraphQL Endpoint: https://civicdb.org/api/graphql
 """
 
+import re
 import requests
 from typing import Dict, Any, Optional
 from .base_tool import BaseTool
@@ -55,6 +56,74 @@ CIVIC_EVIDENCE_SIGNIFICANCES = {
     "LIKELY_ONCOGENIC",
 }
 CIVIC_EVIDENCE_DIRECTIONS = {"SUPPORTS", "DOES_NOT_SUPPORT", "NA"}
+
+# Feature-26A-03 / Feature-26A-04: gene-symbol-prefixed variant spellings.
+# Clinical writing joins the gene symbol and the variant designation into one
+# token ("EGFRvIII", "BRAFV600E", "KRASG12C"), but CIViC stores the variant under
+# the bare designation ("VIII", "V600E") and names its molecular profile
+# "<GENE> <designation>". Every CIViC name filter (variants(name:),
+# evidenceItems(molecularProfileName:)) is a case-insensitive *substring* match,
+# so the joined spelling can never reach the curated record — it silently matches
+# only same-spelled duplicate stubs, or nothing at all. We detect that spelling
+# and query the gene-stripped form as well, then merge.
+_GENE_SYMBOL_RE = re.compile(r"^[A-Z][A-Z0-9]*$")
+# A trailing designation is recognized either by a lowercase initial ("vIII",
+# "del", "fs") or by protein-change notation ("V600E", "G12C", "R175fs").
+# Both require a character after the digits, so a plain gene symbol carrying
+# digits ("ERBB2", "TP53") never splits.
+_VARIANT_DESIGNATION_RES = (
+    re.compile(r"^[a-z][A-Za-z0-9]*$"),
+    re.compile(r"^[A-Z]\d+[A-Za-z*]\w*$"),
+)
+_GENE_PREFIX_MIN_LEN = 2
+
+
+def _split_gene_prefixed_name(name: Any, gene: Optional[str] = None) -> Optional[tuple]:
+    """Split a "<GENE><designation>" spelling into (gene_symbol, designation).
+
+    When ``gene`` is supplied the caller has already named the gene, so a
+    case-insensitive prefix match is authoritative. Otherwise the longest leading
+    run that looks like a gene symbol and leaves a recognizable variant
+    designation behind is used. Returns None when ``name`` is not a
+    gene-symbol-prefixed spelling (including already-separated forms such as
+    "EGFR VIII", which CIViC matches natively).
+    """
+    if not isinstance(name, str):
+        return None
+    name = name.strip()
+    if not name:
+        return None
+    if isinstance(gene, str) and gene.strip():
+        gene = gene.strip()
+        if len(name) > len(gene) and name.upper().startswith(gene.upper()):
+            designation = name[len(gene) :].lstrip(" \t:_.-")
+            if designation:
+                return gene.upper(), designation
+        return None
+    for cut in range(len(name) - 1, _GENE_PREFIX_MIN_LEN - 1, -1):
+        prefix, designation = name[:cut], name[cut:]
+        if _GENE_SYMBOL_RE.match(prefix) and any(
+            pattern.match(designation) for pattern in _VARIANT_DESIGNATION_RES
+        ):
+            return prefix, designation
+    return None
+
+
+def _name_matches_any(name: Any, terms: list) -> bool:
+    """True when any of ``terms`` occurs in ``name`` (case-insensitive)."""
+    lowered = (name or "").lower() if isinstance(name, str) else ""
+    return any(term.lower() in lowered for term in terms)
+
+
+def _union_nodes_by_id(preferred: list, extra: list) -> list:
+    """Concatenate two node lists, dropping repeats of an already-seen id."""
+    merged = list(preferred)
+    seen = {node.get("id") for node in preferred}
+    for node in extra:
+        if node.get("id") not in seen:
+            seen.add(node.get("id"))
+            merged.append(node)
+    return merged
 
 
 @register_tool("CIViCTool")
@@ -451,16 +520,33 @@ class CIViCTool(BaseTool):
                     gene_data = result["data"].get("gene", {})
                     nodes = gene_data.get("variants", {}).get("nodes", [])
                     q_lower = query_term.lower()
+                    # Feature-26A-03: when the caller writes the gene symbol as a
+                    # prefix of the variant name (EGFRvIII), the joined spelling
+                    # cannot substring-match the record CIViC stores under the bare
+                    # designation (VIII) — it reaches only same-spelled duplicate
+                    # stubs. Match on both spellings and merge.
+                    _primary_split = _split_gene_prefixed_name(query_term, gene_name)
+                    _primary_terms = [query_term]
+                    if _primary_split:
+                        _primary_terms.append(_primary_split[1])
                     filtered = [
-                        v for v in nodes if q_lower in v.get("name", "").lower()
+                        v
+                        for v in nodes
+                        if _name_matches_any(v.get("name"), _primary_terms)
                     ]
                     # Feature-54A-005: AND logic when both query and variant_name provided
+                    _secondary_split = None
                     if _secondary_term:
-                        sec_lower = _secondary_term.lower()
+                        _secondary_split = _split_gene_prefixed_name(
+                            _secondary_term, gene_name
+                        )
+                        _secondary_terms = [_secondary_term]
+                        if _secondary_split:
+                            _secondary_terms.append(_secondary_split[1])
                         filtered = [
                             v
                             for v in filtered
-                            if sec_lower in v.get("name", "").lower()
+                            if _name_matches_any(v.get("name"), _secondary_terms)
                         ]
                         result["filter_note"] = (
                             f"Both query='{raw_query}' and variant_name='{raw_variant_name}' "
@@ -470,6 +556,27 @@ class CIViCTool(BaseTool):
                     if user_limit:
                         filtered = filtered[:user_limit]
                     gene_data.get("variants", {})["nodes"] = filtered
+                    # Feature-26A-03: disclose the gene-prefix expansion — a caller
+                    # must never be unable to tell that two spellings were unioned.
+                    _prefix_notes = []
+                    for _raw_form, _split in (
+                        (query_term, _primary_split),
+                        (_secondary_term, _secondary_split),
+                    ):
+                        if _split:
+                            _prefix_notes.append(
+                                f"'{_raw_form}' carries the gene symbol as a prefix, but CIViC "
+                                f"stores {_split[0]} variants under the bare designation, so both "
+                                f"'{_raw_form}' and '{_split[1]}' were matched within {_split[0]} "
+                                f"and the results merged (de-duplicated by variant id)."
+                            )
+                    if _prefix_notes:
+                        result["normalization_note"] = (
+                            "Gene-prefixed input expanded: "
+                            + " ".join(_prefix_notes)
+                            + " These records differ in curation depth — check each one's"
+                            " molecularProfileScore with civic_get_variant before relying on it."
+                        )
                     # Feature-48B-02: recompute duplicate names among filtered results only.
                     # The metadata.note from _get_variants_for_gene_id cites duplicates from ALL
                     # gene variants; after filtering, only filtered duplicates are relevant.
@@ -669,6 +776,62 @@ class CIViCTool(BaseTool):
             if tool_name == "civic_search_evidence_items":
                 mol_profile = arguments.get("molecular_profile")
                 disease = arguments.get("disease") or arguments.get("disease_name")
+
+                # Feature-26A-04: a gene-symbol-prefixed profile name ("EGFRvIII",
+                # "BRAFV600E") cannot substring-match CIViC's "<GENE> <designation>"
+                # profile ("EGFR VIII", "BRAF V600E"), so it silently returns a small
+                # plausible subset (or nothing) while most of the evidence is dropped.
+                # Query the separated form as well and merge, but only when the input
+                # actually carries a gene prefix — no extra round-trip otherwise.
+                _mp_prefix_split = _split_gene_prefixed_name(mol_profile)
+                if _mp_prefix_split:
+                    _mp_alt = f"{_mp_prefix_split[0]} {_mp_prefix_split[1]}"
+                    _mp_alt_nodes: list = []
+                    try:
+                        _alt_args = dict(arguments)
+                        _alt_args["molecular_profile"] = _mp_alt
+                        _alt_resp = requests.post(
+                            CIVIC_GRAPHQL_URL,
+                            json=self._build_graphql_query(_alt_args),
+                            timeout=self.timeout,
+                            headers={
+                                "Content-Type": "application/json",
+                                "Accept": "application/json",
+                            },
+                        )
+                        _mp_alt_nodes = (
+                            _alt_resp.json()
+                            .get("data", {})
+                            .get("evidenceItems", {})
+                            .get("nodes", [])
+                        )
+                    except Exception:
+                        _mp_alt_nodes = []
+                    _mp_orig_nodes = (
+                        result.get("data", {}).get("evidenceItems", {}).get("nodes", [])
+                    )
+                    # The separated form is the exact CIViC profile, so it leads the
+                    # merged list; nothing found under the original spelling is dropped.
+                    _mp_merged = _union_nodes_by_id(_mp_alt_nodes, _mp_orig_nodes)
+                    if len(_mp_merged) > len(_mp_orig_nodes):
+                        result.setdefault("data", {}).setdefault("evidenceItems", {})[
+                            "nodes"
+                        ] = _mp_merged
+                        _mp_union_note = (
+                            f"Gene-prefixed input expanded: molecular_profile "
+                            f"'{mol_profile}' carries the gene symbol as a prefix, but CIViC "
+                            f"names this profile '<gene> <designation>'. Both '{mol_profile}' "
+                            f"({len(_mp_orig_nodes)} item(s)) and '{_mp_alt}' "
+                            f"({len(_mp_alt_nodes)} item(s)) were queried and the results merged "
+                            f"({len(_mp_merged)} item(s), de-duplicated by evidence id, "
+                            f"'{_mp_alt}' matches first). The merged list may exceed `limit`, "
+                            f"which applies per queried spelling."
+                        )
+                        result["normalization_note"] = (
+                            result["normalization_note"] + " " + _mp_union_note
+                            if result.get("normalization_note")
+                            else _mp_union_note
+                        )
 
                 # Feature-63B-002: CIViC GraphQL uses substring/contains matching for
                 # molecularProfileName — compound profiles like "BRAF V600E OR KIAA1549::BRAF
@@ -898,6 +1061,52 @@ class CIViCTool(BaseTool):
                 _variant_nodes = (
                     result.get("data", {}).get("variants", {}).get("nodes", [])
                 )
+                # Feature-26A-03: same expansion on the no-gene path — variants(name:)
+                # is a substring filter, so a gene-prefixed spelling reaches only
+                # same-spelled stubs. Re-query the bare designation and keep the hits
+                # that belong to the prefixed gene.
+                _vn_split = _split_gene_prefixed_name(arguments.get("query"))
+                if _vn_split:
+                    _vn_gene, _vn_designation = _vn_split
+                    _vn_alt_nodes: list = []
+                    try:
+                        _vn_alt_args = dict(arguments)
+                        _vn_alt_args["query"] = _vn_designation
+                        _vn_alt_resp = requests.post(
+                            CIVIC_GRAPHQL_URL,
+                            json=self._build_graphql_query(_vn_alt_args),
+                            timeout=self.timeout,
+                            headers={
+                                "Content-Type": "application/json",
+                                "Accept": "application/json",
+                            },
+                        )
+                        _vn_alt_nodes = [
+                            node
+                            for node in _vn_alt_resp.json()
+                            .get("data", {})
+                            .get("variants", {})
+                            .get("nodes", [])
+                            if (node.get("feature") or {}).get("name", "").upper()
+                            == _vn_gene
+                        ]
+                    except Exception:
+                        _vn_alt_nodes = []
+                    _vn_merged = _union_nodes_by_id(_vn_alt_nodes, _variant_nodes)
+                    if len(_vn_merged) > len(_variant_nodes):
+                        result.setdefault("data", {}).setdefault("variants", {})[
+                            "nodes"
+                        ] = _vn_merged
+                        _variant_nodes = _vn_merged
+                        result["normalization_note"] = (
+                            f"Gene-prefixed input expanded: '{arguments.get('query')}' carries "
+                            f"the gene symbol as a prefix, but CIViC stores {_vn_gene} variants "
+                            f"under the bare designation, so '{_vn_designation}' was queried as "
+                            f"well and the {_vn_gene} matches merged in (de-duplicated by variant "
+                            f"id). These records differ in "
+                            f"curation depth — check each one's molecularProfileScore with "
+                            f"civic_get_variant before relying on it."
+                        )
                 if len(_variant_nodes) == 0:
                     import re as _re_vn
 

--- a/src/tooluniverse/cpic_search_pairs_tool.py
+++ b/src/tooluniverse/cpic_search_pairs_tool.py
@@ -359,6 +359,34 @@ class CPICSearchPairsTool(BaseRESTTool):
     def _build_url(self, args: Dict[str, Any]) -> str:
         return super()._build_url(self._resolve_aliases(args))
 
+    def _process_response(
+        self, response: requests.Response, url: str
+    ) -> Dict[str, Any]:
+        """Report the URL that was actually requested, filters included.
+
+        Feature-26C-4: the base class reports the endpoint *template* as the
+        response's `url`, while the PostgREST filter clauses this tool builds
+        (``genesymbol=eq.HLA-B``, ``cpiclevel=eq.A``, ``limit=...``) travel
+        separately in the request's query params. Confirmed live that the two
+        answers `{"gene": "HLA-B"}` (13 rows) and `{}` (635 rows) advertised a
+        byte-identical url --
+        `.../pair?select=genesymbol,drugid,cpiclevel,guidelineid,usedforrecommendation,clinpgxlevel,pgxtesting,drug(name)`
+        -- which returns all 635 rows when pasted, so a caller spot-checking
+        provenance concludes the gene filter was ignored (it was not; only the
+        reported url was wrong). `response.url` is the URL requests actually
+        sent, assembled from the very params object used for the request, so
+        the advertised and requested URLs cannot drift apart again. This is the
+        same shape CPICGetAllelesTool in this module already reports.
+        """
+        result = super()._process_response(response, url)
+        if (
+            isinstance(result, dict)
+            and "url" in result
+            and isinstance(response.url, str)
+        ):
+            result["url"] = response.url
+        return result
+
 
 @register_tool("CPICGetAllelesTool")
 class CPICGetAllelesTool(BaseTool):

--- a/src/tooluniverse/data/civic_tools.json
+++ b/src/tooluniverse/data/civic_tools.json
@@ -292,7 +292,7 @@
         },
         "variant_name": {
           "type": "string",
-          "description": "Specific variant name to filter within a gene (e.g., 'L858R', 'V600E', 'T790M'). Use together with gene_name — CIViC stores variants without the gene prefix (use 'L858R' not 'EGFR L858R')."
+          "description": "Specific variant name to filter within a gene (e.g., 'L858R', 'V600E', 'T790M'). Use together with gene_name — CIViC stores variants without the gene prefix (use 'L858R' not 'EGFR L858R'). Gene-prefixed clinical spellings ('EGFRvIII', 'BRAFV600E') are still handled: the gene-stripped designation is queried as well and both result sets are merged, reported in normalization_note."
         }
       },
       "required": []
@@ -435,7 +435,7 @@
         },
         "molecular_profile": {
           "type": "string",
-          "description": "Filter by molecular profile name (e.g., 'BRAF V600E', 'EGFR T790M', 'KRAS G12C'). Uses substring matching — 'FLT3 ITD' will also match 'FLT3 ITD AND FLT3 D835Y'. For gene fusions, CIViC uses double-colon notation: 'GENE::PARTNER Fusion' (e.g., 'FGFR2::BICC1 Fusion', 'ALK::EML4 Fusion'). Use civic_search_molecular_profiles to discover exact profile names."
+          "description": "Filter by molecular profile name (e.g., 'BRAF V600E', 'EGFR T790M', 'KRAS G12C'). Uses substring matching — 'FLT3 ITD' will also match 'FLT3 ITD AND FLT3 D835Y'. For gene fusions, CIViC uses double-colon notation: 'GENE::PARTNER Fusion' (e.g., 'FGFR2::BICC1 Fusion', 'ALK::EML4 Fusion'). Use civic_search_molecular_profiles to discover exact profile names. Gene-prefixed clinical spellings ('EGFRvIII', 'BRAFV600E') are also handled: CIViC names the profile '<gene> <designation>' ('EGFR VIII'), so that separated form is queried too and both result sets are merged, reported in normalization_note."
         },
         "evidence_type": {
           "type": [

--- a/src/tooluniverse/data/fda_drug_adverse_event_tools.json
+++ b/src/tooluniverse/data/fda_drug_adverse_event_tools.json
@@ -2,7 +2,7 @@
   {
     "type": "FDADrugAdverseEventTool",
     "name": "FAERS_count_reactions_by_drug_event",
-    "description": "Count the number of adverse reactions reported for a given drug. Only medicinalproduct is required; all other filters (patientsex, patientagegroup, occurcountry, serious, seriousnessdeath, reactionmeddraverse) are optional. When reactionmeddraverse is not specified, returns all adverse reactions (AE) with their counts grouped by MedDRA Preferred Term. When reactionmeddraverse is specified, filters results to only include that specific MedDRA Lowest Level Term. Use filters sparingly to avoid overly restrictive searches that return no results. Data source: FDA Adverse Event Reporting System (FAERS).",
+    "description": "Count the number of adverse reactions reported for a given drug. Only medicinalproduct is required; all other filters (patientsex, patientagegroup, occurcountry, serious, seriousnessdeath, reactionmeddraverse) are optional. When reactionmeddraverse is not specified, returns adverse reactions (AE) with their counts grouped by MedDRA Preferred Term, ranked by descending report count and capped at 'limit' terms -- not the complete list. When reactionmeddraverse is specified, filters results to only include that specific MedDRA Lowest Level Term. Use filters sparingly to avoid overly restrictive searches that return no results. Data source: FDA Adverse Event Reporting System (FAERS). Returns an object with 'results' (term/count rows ranked by descending report count), 'result_count', the applied 'limit' (default 100, maximum 1000) and a 'truncated' flag; when 'truncated' is true a 'truncation_note' explains that more terms exist and how to request them. openFDA does not report how many distinct terms exist in total, so a term missing from a truncated list is not evidence it was never reported.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -52,7 +52,7 @@
         },
         "reactionmeddraverse": {
           "type": "string",
-          "description": "Optional: Filter by MedDRA reaction term (Lowest Level Term). When omitted, returns all adverse reactions with their counts. When specified, filters results to only include that specific reaction term."
+          "description": "Optional: Filter by MedDRA reaction term (Lowest Level Term). When omitted, returns the top-ranked adverse reactions with their counts, capped at 'limit'. When specified, filters results to only include that specific reaction term."
         },
         "manufacturer_name": {
           "type": "string",
@@ -61,6 +61,13 @@
         "receivedate": {
           "type": "string",
           "description": "Filter by the date FDA received the report. Accepts a single date 'YYYYMMDD' or an openFDA range '[20141001 TO 20141231]' (e.g. 2014 Q4)."
+        },
+        "limit": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1000,
+          "default": 100,
+          "description": "Optional: maximum number of ranked terms to return (default 100, which is openFDA's own page size for count aggregations; maximum 1000, openFDA's documented ceiling). Terms are ranked by descending report count, so a small limit hides the long tail -- a term absent from the response is NOT evidence that it was never reported. The response sets 'truncated' and adds a 'truncation_note' whenever more terms exist beyond the limit. Values above 999 require an openFDA API key in the FDA_API_KEY environment variable."
         }
       },
       "required": [
@@ -115,191 +122,86 @@
       }
     ],
     "return_schema": {
-      "anyOf": [
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "results": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "term": {
+                    "type": "string"
+                  },
+                  "count": {
+                    "type": "integer"
+                  }
+                }
+              },
+              "description": "Term/count rows ordered by descending report count. Empty when no reports match."
+            },
+            "result_count": {
+              "type": "integer",
+              "description": "Number of rows in 'results'."
+            },
+            "limit": {
+              "type": "integer",
+              "description": "Maximum number of terms requested from openFDA."
+            },
+            "truncated": {
+              "type": "boolean",
+              "description": "True when openFDA has more terms than the applied limit, i.e. 'results' is an incomplete ranking."
+            },
+            "truncation_note": {
+              "type": "string",
+              "description": "Present only when 'truncated' is true; states the applied limit and how to retrieve more terms."
+            }
+          },
+          "required": [
+            "results",
+            "result_count",
+            "limit",
+            "truncated"
+          ]
+        },
         {
           "type": "array",
           "items": {
-            "type": "object"
-          }
-        },
-        {
-          "type": "object"
-        }
-      ],
-      "properties": {
-        "error": {
-          "type": "string"
-        },
-        "error_details": {
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string"
-            },
-            "message": {
-              "type": "string"
-            },
-            "retriable": {
-              "type": "boolean"
-            },
-            "next_steps": {
-              "type": "array",
-              "items": {
+            "type": "object",
+            "properties": {
+              "error": {
                 "type": "string"
               }
-            },
-            "details": {
-              "type": "object",
-              "properties": {
-                "validation_error": {
-                  "type": "string"
-                },
-                "path": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "type": {
-                      "type": "string"
-                    },
-                    "properties": {
-                      "type": "object",
-                      "properties": {
-                        "medicinalproduct": {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string"
-                            },
-                            "description": {
-                              "type": "string"
-                            }
-                          }
-                        },
-                        "patientsex": {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string"
-                            },
-                            "enum": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "description": {
-                              "type": "string"
-                            }
-                          }
-                        },
-                        "patientagegroup": {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string"
-                            },
-                            "enum": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "description": {
-                              "type": "string"
-                            }
-                          }
-                        },
-                        "occurcountry": {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string"
-                            },
-                            "pattern": {
-                              "type": "string"
-                            },
-                            "description": {
-                              "type": "string"
-                            }
-                          }
-                        },
-                        "serious": {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string"
-                            },
-                            "enum": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "description": {
-                              "type": "string"
-                            }
-                          }
-                        },
-                        "seriousnessdeath": {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string"
-                            },
-                            "enum": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "description": {
-                              "type": "string"
-                            }
-                          }
-                        },
-                        "reactionmeddraverse": {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string"
-                            },
-                            "description": {
-                              "type": "string"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "required": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                },
-                "parameter": {
-                  "type": "string"
-                },
-                "expected": {
-                  "type": "string"
-                }
-              }
             }
-          }
+          },
+          "description": "Error entries returned when the openFDA request fails."
+        },
+        {
+          "type": "object",
+          "properties": {
+            "status": {
+              "type": "string",
+              "enum": [
+                "error"
+              ]
+            },
+            "error": {
+              "type": "string",
+              "description": "Error message when parameters are invalid or the request fails."
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
-      }
+      ]
     }
   },
   {
     "type": "FDADrugAdverseEventTool",
     "name": "FAERS_count_drugs_by_drug_event",
-    "description": "Count the number of different drugs involved in FDA adverse event reports. All filters (patientsex, patientagegroup, occurcountry, serious) are optional. Use filters sparingly to avoid overly restrictive searches. Data source: FDA Adverse Event Reporting System (FAERS).",
+    "description": "Count the number of different drugs involved in FDA adverse event reports. All filters (patientsex, patientagegroup, occurcountry, serious) are optional. Use filters sparingly to avoid overly restrictive searches. Data source: FDA Adverse Event Reporting System (FAERS). Returns an object with 'results' (term/count rows ranked by descending report count), 'result_count', the applied 'limit' (default 100, maximum 1000) and a 'truncated' flag; when 'truncated' is true a 'truncation_note' explains that more terms exist and how to request them. openFDA does not report how many distinct terms exist in total, so a term missing from a truncated list is not evidence it was never reported.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -343,6 +245,13 @@
         "receivedate": {
           "type": "string",
           "description": "Filter by the date FDA received the report. Accepts a single date 'YYYYMMDD' or an openFDA range '[20141001 TO 20141231]' (e.g. 2014 Q4)."
+        },
+        "limit": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1000,
+          "default": 100,
+          "description": "Optional: maximum number of ranked terms to return (default 100, which is openFDA's own page size for count aggregations; maximum 1000, openFDA's documented ceiling). Terms are ranked by descending report count, so a small limit hides the long tail -- a term absent from the response is NOT evidence that it was never reported. The response sets 'truncated' and adds a 'truncation_note' whenever more terms exist beyond the limit. Values above 999 require an openFDA API key in the FDA_API_KEY environment variable."
         }
       },
       "required": []
@@ -381,149 +290,86 @@
       }
     ],
     "return_schema": {
-      "anyOf": [
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "results": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "term": {
+                    "type": "string"
+                  },
+                  "count": {
+                    "type": "integer"
+                  }
+                }
+              },
+              "description": "Term/count rows ordered by descending report count. Empty when no reports match."
+            },
+            "result_count": {
+              "type": "integer",
+              "description": "Number of rows in 'results'."
+            },
+            "limit": {
+              "type": "integer",
+              "description": "Maximum number of terms requested from openFDA."
+            },
+            "truncated": {
+              "type": "boolean",
+              "description": "True when openFDA has more terms than the applied limit, i.e. 'results' is an incomplete ranking."
+            },
+            "truncation_note": {
+              "type": "string",
+              "description": "Present only when 'truncated' is true; states the applied limit and how to retrieve more terms."
+            }
+          },
+          "required": [
+            "results",
+            "result_count",
+            "limit",
+            "truncated"
+          ]
+        },
         {
           "type": "array",
           "items": {
-            "type": "object"
-          }
-        },
-        {
-          "type": "object"
-        }
-      ],
-      "properties": {
-        "error": {
-          "type": "string"
-        },
-        "error_details": {
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string"
-            },
-            "message": {
-              "type": "string"
-            },
-            "retriable": {
-              "type": "boolean"
-            },
-            "next_steps": {
-              "type": "array",
-              "items": {
+            "type": "object",
+            "properties": {
+              "error": {
                 "type": "string"
               }
-            },
-            "details": {
-              "type": "object",
-              "properties": {
-                "validation_error": {
-                  "type": "string"
-                },
-                "path": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "type": {
-                      "type": "string"
-                    },
-                    "properties": {
-                      "type": "object",
-                      "properties": {
-                        "patientsex": {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string"
-                            },
-                            "enum": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "description": {
-                              "type": "string"
-                            }
-                          }
-                        },
-                        "patientagegroup": {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string"
-                            },
-                            "enum": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "description": {
-                              "type": "string"
-                            }
-                          }
-                        },
-                        "occurcountry": {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string"
-                            },
-                            "pattern": {
-                              "type": "string"
-                            },
-                            "description": {
-                              "type": "string"
-                            }
-                          }
-                        },
-                        "serious": {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string"
-                            },
-                            "enum": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "description": {
-                              "type": "string"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "required": {
-                      "type": "array"
-                    }
-                  }
-                },
-                "parameter": {
-                  "type": "string"
-                },
-                "expected": {
-                  "type": "string"
-                }
-              }
             }
-          }
+          },
+          "description": "Error entries returned when the openFDA request fails."
+        },
+        {
+          "type": "object",
+          "properties": {
+            "status": {
+              "type": "string",
+              "enum": [
+                "error"
+              ]
+            },
+            "error": {
+              "type": "string",
+              "description": "Error message when parameters are invalid or the request fails."
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
-      }
+      ]
     }
   },
   {
     "type": "FDADrugAdverseEventTool",
     "name": "FAERS_count_country_by_drug_event",
-    "description": "Count the number of adverse event reports per country of occurrence. Only medicinalproduct is required; all other filters (patientsex, patientagegroup, serious) are optional. Use filters sparingly to avoid overly restrictive searches. Data source: FDA Adverse Event Reporting System (FAERS).",
+    "description": "Count the number of adverse event reports per country of occurrence. Only medicinalproduct is required; all other filters (patientsex, patientagegroup, serious) are optional. Use filters sparingly to avoid overly restrictive searches. Data source: FDA Adverse Event Reporting System (FAERS). Returns an object with 'results' (term/count rows ranked by descending report count), 'result_count', the applied 'limit' (default 100, maximum 1000) and a 'truncated' flag; when 'truncated' is true a 'truncation_note' explains that more terms exist and how to request them. openFDA does not report how many distinct terms exist in total, so a term missing from a truncated list is not evidence it was never reported.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -566,6 +412,13 @@
         "receivedate": {
           "type": "string",
           "description": "Filter by the date FDA received the report. Accepts a single date 'YYYYMMDD' or an openFDA range '[20141001 TO 20141231]' (e.g. 2014 Q4)."
+        },
+        "limit": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1000,
+          "default": 100,
+          "description": "Optional: maximum number of ranked terms to return (default 100, which is openFDA's own page size for count aggregations; maximum 1000, openFDA's documented ceiling). Terms are ranked by descending report count, so a small limit hides the long tail -- a term absent from the response is NOT evidence that it was never reported. The response sets 'truncated' and adds a 'truncation_note' whenever more terms exist beyond the limit. Values above 999 require an openFDA API key in the FDA_API_KEY environment variable."
         }
       },
       "required": [
@@ -607,24 +460,86 @@
       }
     ],
     "return_schema": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "term": {
-            "type": "string"
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "results": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "term": {
+                    "type": "string"
+                  },
+                  "count": {
+                    "type": "integer"
+                  }
+                }
+              },
+              "description": "Term/count rows ordered by descending report count. Empty when no reports match."
+            },
+            "result_count": {
+              "type": "integer",
+              "description": "Number of rows in 'results'."
+            },
+            "limit": {
+              "type": "integer",
+              "description": "Maximum number of terms requested from openFDA."
+            },
+            "truncated": {
+              "type": "boolean",
+              "description": "True when openFDA has more terms than the applied limit, i.e. 'results' is an incomplete ranking."
+            },
+            "truncation_note": {
+              "type": "string",
+              "description": "Present only when 'truncated' is true; states the applied limit and how to retrieve more terms."
+            }
           },
-          "count": {
-            "type": "integer"
-          }
+          "required": [
+            "results",
+            "result_count",
+            "limit",
+            "truncated"
+          ]
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "error": {
+                "type": "string"
+              }
+            }
+          },
+          "description": "Error entries returned when the openFDA request fails."
+        },
+        {
+          "type": "object",
+          "properties": {
+            "status": {
+              "type": "string",
+              "enum": [
+                "error"
+              ]
+            },
+            "error": {
+              "type": "string",
+              "description": "Error message when parameters are invalid or the request fails."
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
-      }
+      ]
     }
   },
   {
     "type": "FDADrugAdverseEventTool",
     "name": "FAERS_count_reportercountry_by_drug_event",
-    "description": "Count the number of FDA adverse event reports grouped by the country of the primary reporter. Only medicinalproduct is required; all other filters (patientsex, patientagegroup, serious) are optional. Use filters sparingly to avoid overly restrictive searches. Data source: FDA Adverse Event Reporting System (FAERS).",
+    "description": "Count the number of FDA adverse event reports grouped by the country of the primary reporter. Only medicinalproduct is required; all other filters (patientsex, patientagegroup, serious) are optional. Use filters sparingly to avoid overly restrictive searches. Data source: FDA Adverse Event Reporting System (FAERS). Returns an object with 'results' (term/count rows ranked by descending report count), 'result_count', the applied 'limit' (default 100, maximum 1000) and a 'truncated' flag; when 'truncated' is true a 'truncation_note' explains that more terms exist and how to request them. openFDA does not report how many distinct terms exist in total, so a term missing from a truncated list is not evidence it was never reported.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -667,6 +582,13 @@
         "receivedate": {
           "type": "string",
           "description": "Filter by the date FDA received the report. Accepts a single date 'YYYYMMDD' or an openFDA range '[20141001 TO 20141231]' (e.g. 2014 Q4)."
+        },
+        "limit": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1000,
+          "default": 100,
+          "description": "Optional: maximum number of ranked terms to return (default 100, which is openFDA's own page size for count aggregations; maximum 1000, openFDA's documented ceiling). Terms are ranked by descending report count, so a small limit hides the long tail -- a term absent from the response is NOT evidence that it was never reported. The response sets 'truncated' and adds a 'truncation_note' whenever more terms exist beyond the limit. Values above 999 require an openFDA API key in the FDA_API_KEY environment variable."
         }
       },
       "required": [
@@ -708,24 +630,86 @@
       }
     ],
     "return_schema": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "term": {
-            "type": "string"
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "results": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "term": {
+                    "type": "string"
+                  },
+                  "count": {
+                    "type": "integer"
+                  }
+                }
+              },
+              "description": "Term/count rows ordered by descending report count. Empty when no reports match."
+            },
+            "result_count": {
+              "type": "integer",
+              "description": "Number of rows in 'results'."
+            },
+            "limit": {
+              "type": "integer",
+              "description": "Maximum number of terms requested from openFDA."
+            },
+            "truncated": {
+              "type": "boolean",
+              "description": "True when openFDA has more terms than the applied limit, i.e. 'results' is an incomplete ranking."
+            },
+            "truncation_note": {
+              "type": "string",
+              "description": "Present only when 'truncated' is true; states the applied limit and how to retrieve more terms."
+            }
           },
-          "count": {
-            "type": "integer"
-          }
+          "required": [
+            "results",
+            "result_count",
+            "limit",
+            "truncated"
+          ]
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "error": {
+                "type": "string"
+              }
+            }
+          },
+          "description": "Error entries returned when the openFDA request fails."
+        },
+        {
+          "type": "object",
+          "properties": {
+            "status": {
+              "type": "string",
+              "enum": [
+                "error"
+              ]
+            },
+            "error": {
+              "type": "string",
+              "description": "Error message when parameters are invalid or the request fails."
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
-      }
+      ]
     }
   },
   {
     "type": "FDADrugAdverseEventTool",
     "name": "FAERS_count_seriousness_by_drug_event",
-    "description": "Count the number of adverse event reports classified as serious or non-serious. Only medicinalproduct is required; all other filters (patientsex, patientagegroup, occurcountry) are optional. Use filters sparingly to avoid overly restrictive searches. In results, term Serious means: \"The adverse event resulted in death, a life threatening condition, hospitalization, disability, congenital anomaly, or other serious condition\", term Non-serious means \"The adverse event did not result in any of the above\". Data source: FDA Adverse Event Reporting System (FAERS).",
+    "description": "Count the number of adverse event reports classified as serious or non-serious. Only medicinalproduct is required; all other filters (patientsex, patientagegroup, occurcountry) are optional. Use filters sparingly to avoid overly restrictive searches. In results, term Serious means: \"The adverse event resulted in death, a life threatening condition, hospitalization, disability, congenital anomaly, or other serious condition\", term Non-serious means \"The adverse event did not result in any of the above\". Data source: FDA Adverse Event Reporting System (FAERS). Returns an object with 'results' (term/count rows ranked by descending report count), 'result_count', the applied 'limit' (default 100, maximum 1000) and a 'truncated' flag; when 'truncated' is true a 'truncation_note' explains that more terms exist and how to request them. openFDA does not report how many distinct terms exist in total, so a term missing from a truncated list is not evidence it was never reported.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -765,6 +749,13 @@
         "receivedate": {
           "type": "string",
           "description": "Filter by the date FDA received the report. Accepts a single date 'YYYYMMDD' or an openFDA range '[20141001 TO 20141231]' (e.g. 2014 Q4)."
+        },
+        "limit": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1000,
+          "default": 100,
+          "description": "Optional: maximum number of ranked terms to return (default 100, which is openFDA's own page size for count aggregations; maximum 1000, openFDA's documented ceiling). Terms are ranked by descending report count, so a small limit hides the long tail -- a term absent from the response is NOT evidence that it was never reported. The response sets 'truncated' and adds a 'truncation_note' whenever more terms exist beyond the limit. Values above 999 require an openFDA API key in the FDA_API_KEY environment variable."
         }
       },
       "required": [
@@ -812,146 +803,86 @@
       }
     ],
     "return_schema": {
-      "anyOf": [
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "results": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "term": {
+                    "type": "string"
+                  },
+                  "count": {
+                    "type": "integer"
+                  }
+                }
+              },
+              "description": "Term/count rows ordered by descending report count. Empty when no reports match."
+            },
+            "result_count": {
+              "type": "integer",
+              "description": "Number of rows in 'results'."
+            },
+            "limit": {
+              "type": "integer",
+              "description": "Maximum number of terms requested from openFDA."
+            },
+            "truncated": {
+              "type": "boolean",
+              "description": "True when openFDA has more terms than the applied limit, i.e. 'results' is an incomplete ranking."
+            },
+            "truncation_note": {
+              "type": "string",
+              "description": "Present only when 'truncated' is true; states the applied limit and how to retrieve more terms."
+            }
+          },
+          "required": [
+            "results",
+            "result_count",
+            "limit",
+            "truncated"
+          ]
+        },
         {
           "type": "array",
           "items": {
-            "type": "object"
-          }
-        },
-        {
-          "type": "object"
-        }
-      ],
-      "properties": {
-        "error": {
-          "type": "string"
-        },
-        "error_details": {
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string"
-            },
-            "message": {
-              "type": "string"
-            },
-            "retriable": {
-              "type": "boolean"
-            },
-            "next_steps": {
-              "type": "array",
-              "items": {
+            "type": "object",
+            "properties": {
+              "error": {
                 "type": "string"
               }
-            },
-            "details": {
-              "type": "object",
-              "properties": {
-                "validation_error": {
-                  "type": "string"
-                },
-                "path": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "type": {
-                      "type": "string"
-                    },
-                    "properties": {
-                      "type": "object",
-                      "properties": {
-                        "medicinalproduct": {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string"
-                            },
-                            "description": {
-                              "type": "string"
-                            }
-                          }
-                        },
-                        "patientsex": {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string"
-                            },
-                            "enum": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "description": {
-                              "type": "string"
-                            }
-                          }
-                        },
-                        "patientagegroup": {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string"
-                            },
-                            "enum": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "description": {
-                              "type": "string"
-                            }
-                          }
-                        },
-                        "occurcountry": {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string"
-                            },
-                            "pattern": {
-                              "type": "string"
-                            },
-                            "description": {
-                              "type": "string"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "required": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                },
-                "parameter": {
-                  "type": "string"
-                },
-                "expected": {
-                  "type": "string"
-                }
-              }
             }
-          }
+          },
+          "description": "Error entries returned when the openFDA request fails."
+        },
+        {
+          "type": "object",
+          "properties": {
+            "status": {
+              "type": "string",
+              "enum": [
+                "error"
+              ]
+            },
+            "error": {
+              "type": "string",
+              "description": "Error message when parameters are invalid or the request fails."
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
-      }
+      ]
     }
   },
   {
     "type": "FDADrugAdverseEventTool",
     "name": "FAERS_count_outcomes_by_drug_event",
-    "description": "Count the outcome of adverse reactions (recovered, recovering, fatal, unresolved). Only medicinalproduct is required; all other filters (patientsex, patientagegroup, occurcountry) are optional. Use filters sparingly to avoid overly restrictive searches. Data source: FDA Adverse Event Reporting System (FAERS).",
+    "description": "Count the outcome of adverse reactions (recovered, recovering, fatal, unresolved). Only medicinalproduct is required; all other filters (patientsex, patientagegroup, occurcountry) are optional. Use filters sparingly to avoid overly restrictive searches. Data source: FDA Adverse Event Reporting System (FAERS). Returns an object with 'results' (term/count rows ranked by descending report count), 'result_count', the applied 'limit' (default 100, maximum 1000) and a 'truncated' flag; when 'truncated' is true a 'truncation_note' explains that more terms exist and how to request them. openFDA does not report how many distinct terms exist in total, so a term missing from a truncated list is not evidence it was never reported.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -988,6 +919,13 @@
         "receivedate": {
           "type": "string",
           "description": "Filter by the date FDA received the report. Accepts a single date 'YYYYMMDD' or an openFDA range '[20141001 TO 20141231]' (e.g. 2014 Q4)."
+        },
+        "limit": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1000,
+          "default": 100,
+          "description": "Optional: maximum number of ranked terms to return (default 100, which is openFDA's own page size for count aggregations; maximum 1000, openFDA's documented ceiling). Terms are ranked by descending report count, so a small limit hides the long tail -- a term absent from the response is NOT evidence that it was never reported. The response sets 'truncated' and adds a 'truncation_note' whenever more terms exist beyond the limit. Values above 999 require an openFDA API key in the FDA_API_KEY environment variable."
         }
       },
       "required": [
@@ -1039,137 +977,86 @@
       }
     ],
     "return_schema": {
-      "anyOf": [
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "results": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "term": {
+                    "type": "string"
+                  },
+                  "count": {
+                    "type": "integer"
+                  }
+                }
+              },
+              "description": "Term/count rows ordered by descending report count. Empty when no reports match."
+            },
+            "result_count": {
+              "type": "integer",
+              "description": "Number of rows in 'results'."
+            },
+            "limit": {
+              "type": "integer",
+              "description": "Maximum number of terms requested from openFDA."
+            },
+            "truncated": {
+              "type": "boolean",
+              "description": "True when openFDA has more terms than the applied limit, i.e. 'results' is an incomplete ranking."
+            },
+            "truncation_note": {
+              "type": "string",
+              "description": "Present only when 'truncated' is true; states the applied limit and how to retrieve more terms."
+            }
+          },
+          "required": [
+            "results",
+            "result_count",
+            "limit",
+            "truncated"
+          ]
+        },
         {
           "type": "array",
           "items": {
-            "type": "object"
-          }
-        },
-        {
-          "type": "object"
-        }
-      ],
-      "properties": {
-        "error": {
-          "type": "string"
-        },
-        "error_details": {
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string"
-            },
-            "message": {
-              "type": "string"
-            },
-            "retriable": {
-              "type": "boolean"
-            },
-            "next_steps": {
-              "type": "array",
-              "items": {
+            "type": "object",
+            "properties": {
+              "error": {
                 "type": "string"
               }
-            },
-            "details": {
-              "type": "object",
-              "properties": {
-                "validation_error": {
-                  "type": "string"
-                },
-                "path": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "type": {
-                      "type": "string"
-                    },
-                    "properties": {
-                      "type": "object",
-                      "properties": {
-                        "medicinalproduct": {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string"
-                            },
-                            "description": {
-                              "type": "string"
-                            }
-                          }
-                        },
-                        "patientsex": {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string"
-                            },
-                            "enum": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            }
-                          }
-                        },
-                        "patientagegroup": {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string"
-                            },
-                            "enum": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            }
-                          }
-                        },
-                        "occurcountry": {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string"
-                            },
-                            "pattern": {
-                              "type": "string"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "required": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                },
-                "parameter": {
-                  "type": "string"
-                },
-                "expected": {
-                  "type": "string"
-                }
-              }
             }
-          }
+          },
+          "description": "Error entries returned when the openFDA request fails."
+        },
+        {
+          "type": "object",
+          "properties": {
+            "status": {
+              "type": "string",
+              "enum": [
+                "error"
+              ]
+            },
+            "error": {
+              "type": "string",
+              "description": "Error message when parameters are invalid or the request fails."
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
-      }
+      ]
     }
   },
   {
     "type": "FDADrugAdverseEventTool",
     "name": "FAERS_count_drug_routes_by_event",
-    "description": "Count the most common routes of administration for drugs involved in adverse event reports. Only medicinalproduct is required; serious filter is optional. Use filters sparingly to avoid overly restrictive searches. Data source: FDA Adverse Event Reporting System (FAERS).",
+    "description": "Count the most common routes of administration for drugs involved in adverse event reports. Only medicinalproduct is required; serious filter is optional. Use filters sparingly to avoid overly restrictive searches. Data source: FDA Adverse Event Reporting System (FAERS). Returns an object with 'results' (term/count rows ranked by descending report count), 'result_count', the applied 'limit' (default 100, maximum 1000) and a 'truncated' flag; when 'truncated' is true a 'truncation_note' explains that more terms exist and how to request them. openFDA does not report how many distinct terms exist in total, so a term missing from a truncated list is not evidence it was never reported.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -1184,6 +1071,13 @@
             "No"
           ],
           "description": "Optional: Filter by event seriousness. Omit this parameter if you don't want to filter by seriousness."
+        },
+        "limit": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1000,
+          "default": 100,
+          "description": "Optional: maximum number of ranked terms to return (default 100, which is openFDA's own page size for count aggregations; maximum 1000, openFDA's documented ceiling). Terms are ranked by descending report count, so a small limit hides the long tail -- a term absent from the response is NOT evidence that it was never reported. The response sets 'truncated' and adds a 'truncation_note' whenever more terms exist beyond the limit. Values above 999 require an openFDA API key in the FDA_API_KEY environment variable."
         }
       },
       "required": [
@@ -1282,30 +1176,99 @@
       }
     ],
     "return_schema": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "term": {
-            "type": "string"
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "results": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "term": {
+                    "type": "string"
+                  },
+                  "count": {
+                    "type": "integer"
+                  }
+                }
+              },
+              "description": "Term/count rows ordered by descending report count. Empty when no reports match."
+            },
+            "result_count": {
+              "type": "integer",
+              "description": "Number of rows in 'results'."
+            },
+            "limit": {
+              "type": "integer",
+              "description": "Maximum number of terms requested from openFDA."
+            },
+            "truncated": {
+              "type": "boolean",
+              "description": "True when openFDA has more terms than the applied limit, i.e. 'results' is an incomplete ranking."
+            },
+            "truncation_note": {
+              "type": "string",
+              "description": "Present only when 'truncated' is true; states the applied limit and how to retrieve more terms."
+            }
           },
-          "count": {
-            "type": "integer"
-          }
+          "required": [
+            "results",
+            "result_count",
+            "limit",
+            "truncated"
+          ]
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "error": {
+                "type": "string"
+              }
+            }
+          },
+          "description": "Error entries returned when the openFDA request fails."
+        },
+        {
+          "type": "object",
+          "properties": {
+            "status": {
+              "type": "string",
+              "enum": [
+                "error"
+              ]
+            },
+            "error": {
+              "type": "string",
+              "description": "Error message when parameters are invalid or the request fails."
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
-      }
+      ]
     }
   },
   {
     "type": "FDADrugAdverseEventTool",
     "name": "FAERS_count_patient_age_distribution",
-    "description": "Analyze the age distribution of patients experiencing adverse events for a specific drug. Only medicinalproduct is required. The age groups are: Neonate (0-28 days), Infant (29 days - 23 months), Child (2-11 years), Adolescent (12-17 years), Adult (18-64 years), Elderly (65+ years). Data source: FDA Adverse Event Reporting System (FAERS).",
+    "description": "Analyze the age distribution of patients experiencing adverse events for a specific drug. Only medicinalproduct is required. The age groups are: Neonate (0-28 days), Infant (29 days - 23 months), Child (2-11 years), Adolescent (12-17 years), Adult (18-64 years), Elderly (65+ years). Data source: FDA Adverse Event Reporting System (FAERS). Returns an object with 'results' (term/count rows ranked by descending report count), 'result_count', the applied 'limit' (default 100, maximum 1000) and a 'truncated' flag; when 'truncated' is true a 'truncation_note' explains that more terms exist and how to request them. openFDA does not report how many distinct terms exist in total, so a term missing from a truncated list is not evidence it was never reported.",
     "parameter": {
       "type": "object",
       "properties": {
         "medicinalproduct": {
           "type": "string",
           "description": "Drug name."
+        },
+        "limit": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1000,
+          "default": 100,
+          "description": "Optional: maximum number of ranked terms to return (default 100, which is openFDA's own page size for count aggregations; maximum 1000, openFDA's documented ceiling). Terms are ranked by descending report count, so a small limit hides the long tail -- a term absent from the response is NOT evidence that it was never reported. The response sets 'truncated' and adds a 'truncation_note' whenever more terms exist beyond the limit. Values above 999 require an openFDA API key in the FDA_API_KEY environment variable."
         }
       },
       "required": [
@@ -1339,30 +1302,99 @@
       }
     ],
     "return_schema": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "term": {
-            "type": "string"
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "results": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "term": {
+                    "type": "string"
+                  },
+                  "count": {
+                    "type": "integer"
+                  }
+                }
+              },
+              "description": "Term/count rows ordered by descending report count. Empty when no reports match."
+            },
+            "result_count": {
+              "type": "integer",
+              "description": "Number of rows in 'results'."
+            },
+            "limit": {
+              "type": "integer",
+              "description": "Maximum number of terms requested from openFDA."
+            },
+            "truncated": {
+              "type": "boolean",
+              "description": "True when openFDA has more terms than the applied limit, i.e. 'results' is an incomplete ranking."
+            },
+            "truncation_note": {
+              "type": "string",
+              "description": "Present only when 'truncated' is true; states the applied limit and how to retrieve more terms."
+            }
           },
-          "count": {
-            "type": "integer"
-          }
+          "required": [
+            "results",
+            "result_count",
+            "limit",
+            "truncated"
+          ]
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "error": {
+                "type": "string"
+              }
+            }
+          },
+          "description": "Error entries returned when the openFDA request fails."
+        },
+        {
+          "type": "object",
+          "properties": {
+            "status": {
+              "type": "string",
+              "enum": [
+                "error"
+              ]
+            },
+            "error": {
+              "type": "string",
+              "description": "Error message when parameters are invalid or the request fails."
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
-      }
+      ]
     }
   },
   {
     "type": "FDADrugAdverseEventTool",
     "name": "FAERS_count_death_related_by_drug",
-    "description": "Count adverse events associated with patient death for a given drug. Only medicinalproduct is required. Data source: FDA Adverse Event Reporting System (FAERS).",
+    "description": "Count adverse events associated with patient death for a given drug. Only medicinalproduct is required. Data source: FDA Adverse Event Reporting System (FAERS). Returns an object with 'results' (term/count rows ranked by descending report count), 'result_count', the applied 'limit' (default 100, maximum 1000) and a 'truncated' flag; when 'truncated' is true a 'truncation_note' explains that more terms exist and how to request them. openFDA does not report how many distinct terms exist in total, so a term missing from a truncated list is not evidence it was never reported.",
     "parameter": {
       "type": "object",
       "properties": {
         "medicinalproduct": {
           "type": "string",
           "description": "Drug name."
+        },
+        "limit": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1000,
+          "default": 100,
+          "description": "Optional: maximum number of ranked terms to return (default 100, which is openFDA's own page size for count aggregations; maximum 1000, openFDA's documented ceiling). Terms are ranked by descending report count, so a small limit hides the long tail -- a term absent from the response is NOT evidence that it was never reported. The response sets 'truncated' and adds a 'truncation_note' whenever more terms exist beyond the limit. Values above 999 require an openFDA API key in the FDA_API_KEY environment variable."
         }
       },
       "required": [
@@ -1395,24 +1427,86 @@
       }
     ],
     "return_schema": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "term": {
-            "type": "string"
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "results": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "term": {
+                    "type": "string"
+                  },
+                  "count": {
+                    "type": "integer"
+                  }
+                }
+              },
+              "description": "Term/count rows ordered by descending report count. Empty when no reports match."
+            },
+            "result_count": {
+              "type": "integer",
+              "description": "Number of rows in 'results'."
+            },
+            "limit": {
+              "type": "integer",
+              "description": "Maximum number of terms requested from openFDA."
+            },
+            "truncated": {
+              "type": "boolean",
+              "description": "True when openFDA has more terms than the applied limit, i.e. 'results' is an incomplete ranking."
+            },
+            "truncation_note": {
+              "type": "string",
+              "description": "Present only when 'truncated' is true; states the applied limit and how to retrieve more terms."
+            }
           },
-          "count": {
-            "type": "integer"
-          }
+          "required": [
+            "results",
+            "result_count",
+            "limit",
+            "truncated"
+          ]
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "error": {
+                "type": "string"
+              }
+            }
+          },
+          "description": "Error entries returned when the openFDA request fails."
+        },
+        {
+          "type": "object",
+          "properties": {
+            "status": {
+              "type": "string",
+              "enum": [
+                "error"
+              ]
+            },
+            "error": {
+              "type": "string",
+              "description": "Error message when parameters are invalid or the request fails."
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
-      }
+      ]
     }
   },
   {
     "type": "FDACountAdditiveReactionsTool",
     "name": "FAERS_count_additive_adverse_reactions",
-    "description": "Aggregate adverse reaction counts across specified medicinal products. Note: 'medicinalproducts' is combined with OR (union) -- counts are reports mentioning ANY listed product, not reports where all of them co-occur, so results for a multi-drug list can look nearly identical to the single most-reported drug's own counts. For co-occurrence/combination-risk analysis (e.g. checking two specific drugs taken together), use FAERS_search_reports_by_drug_combination (AND) or FAERS_calculate_disproportionality instead. Only medicinalproducts is required; all other filters (patientsex, patientagegroup, occurcountry, serious, seriousnessdeath) are optional. Use filters sparingly to avoid overly restrictive searches that return no results. Data source: FDA Adverse Event Reporting System (FAERS).",
+    "description": "Aggregate adverse reaction counts across specified medicinal products. Note: 'medicinalproducts' is combined with OR (union) -- counts are reports mentioning ANY listed product, not reports where all of them co-occur, so results for a multi-drug list can look nearly identical to the single most-reported drug's own counts. For co-occurrence/combination-risk analysis (e.g. checking two specific drugs taken together), use FAERS_search_reports_by_drug_combination (AND) or FAERS_calculate_disproportionality instead. Only medicinalproducts is required; all other filters (patientsex, patientagegroup, occurcountry, serious, seriousnessdeath) are optional. Use filters sparingly to avoid overly restrictive searches that return no results. Data source: FDA Adverse Event Reporting System (FAERS). Returns an object with 'results' (term/count rows ranked by descending report count), 'result_count', the applied 'limit' (default 100, maximum 1000) and a 'truncated' flag; when 'truncated' is true a 'truncation_note' explains that more terms exist and how to request them. openFDA does not report how many distinct terms exist in total, so a term missing from a truncated list is not evidence it was never reported.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -1470,6 +1564,13 @@
         "receivedate": {
           "type": "string",
           "description": "Filter by the date FDA received the report. Accepts a single date 'YYYYMMDD' or an openFDA range '[20141001 TO 20141231]' (e.g. 2014 Q4)."
+        },
+        "limit": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1000,
+          "default": 100,
+          "description": "Optional: maximum number of ranked terms to return (default 100, which is openFDA's own page size for count aggregations; maximum 1000, openFDA's documented ceiling). Terms are ranked by descending report count, so a small limit hides the long tail -- a term absent from the response is NOT evidence that it was never reported. The response sets 'truncated' and adds a 'truncation_note' whenever more terms exist beyond the limit. Values above 999 require an openFDA API key in the FDA_API_KEY environment variable."
         }
       },
       "required": [
@@ -1520,188 +1621,86 @@
       }
     ],
     "return_schema": {
-      "anyOf": [
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "results": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "term": {
+                    "type": "string"
+                  },
+                  "count": {
+                    "type": "integer"
+                  }
+                }
+              },
+              "description": "Term/count rows ordered by descending report count. Empty when no reports match."
+            },
+            "result_count": {
+              "type": "integer",
+              "description": "Number of rows in 'results'."
+            },
+            "limit": {
+              "type": "integer",
+              "description": "Maximum number of terms requested from openFDA."
+            },
+            "truncated": {
+              "type": "boolean",
+              "description": "True when openFDA has more terms than the applied limit, i.e. 'results' is an incomplete ranking."
+            },
+            "truncation_note": {
+              "type": "string",
+              "description": "Present only when 'truncated' is true; states the applied limit and how to retrieve more terms."
+            }
+          },
+          "required": [
+            "results",
+            "result_count",
+            "limit",
+            "truncated"
+          ]
+        },
         {
           "type": "array",
           "items": {
-            "type": "object"
-          }
-        },
-        {
-          "type": "object"
-        }
-      ],
-      "properties": {
-        "error": {
-          "type": "string"
-        },
-        "error_details": {
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string"
-            },
-            "message": {
-              "type": "string"
-            },
-            "retriable": {
-              "type": "boolean"
-            },
-            "next_steps": {
-              "type": "array",
-              "items": {
+            "type": "object",
+            "properties": {
+              "error": {
                 "type": "string"
               }
-            },
-            "details": {
-              "type": "object",
-              "properties": {
-                "validation_error": {
-                  "type": "string"
-                },
-                "path": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "type": {
-                      "type": "string"
-                    },
-                    "properties": {
-                      "type": "object",
-                      "properties": {
-                        "medicinalproducts": {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string"
-                            },
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "type": {
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            "description": {
-                              "type": "string"
-                            }
-                          }
-                        },
-                        "patientsex": {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string"
-                            },
-                            "enum": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "description": {
-                              "type": "string"
-                            }
-                          }
-                        },
-                        "patientagegroup": {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string"
-                            },
-                            "enum": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "description": {
-                              "type": "string"
-                            }
-                          }
-                        },
-                        "occurcountry": {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string"
-                            },
-                            "pattern": {
-                              "type": "string"
-                            },
-                            "description": {
-                              "type": "string"
-                            }
-                          }
-                        },
-                        "serious": {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string"
-                            },
-                            "enum": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "description": {
-                              "type": "string"
-                            }
-                          }
-                        },
-                        "seriousnessdeath": {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string"
-                            },
-                            "enum": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "description": {
-                              "type": "string"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "required": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                },
-                "parameter": {
-                  "type": "string"
-                },
-                "expected": {
-                  "type": "string"
-                }
-              }
             }
-          }
+          },
+          "description": "Error entries returned when the openFDA request fails."
+        },
+        {
+          "type": "object",
+          "properties": {
+            "status": {
+              "type": "string",
+              "enum": [
+                "error"
+              ]
+            },
+            "error": {
+              "type": "string",
+              "description": "Error message when parameters are invalid or the request fails."
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
-      }
+      ]
     }
   },
   {
     "type": "FDACountAdditiveReactionsTool",
     "name": "FAERS_count_additive_event_reports_by_country",
-    "description": "Aggregate report counts by country of occurrence across specified medicinal products. Only medicinalproducts is required; all other filters (patientsex, patientagegroup, serious) are optional. Use filters sparingly to avoid overly restrictive searches. Data source: FDA Adverse Event Reporting System (FAERS).",
+    "description": "Aggregate report counts by country of occurrence across specified medicinal products. Only medicinalproducts is required; all other filters (patientsex, patientagegroup, serious) are optional. Use filters sparingly to avoid overly restrictive searches. Data source: FDA Adverse Event Reporting System (FAERS). Returns an object with 'results' (term/count rows ranked by descending report count), 'result_count', the applied 'limit' (default 100, maximum 1000) and a 'truncated' flag; when 'truncated' is true a 'truncation_note' explains that more terms exist and how to request them. openFDA does not report how many distinct terms exist in total, so a term missing from a truncated list is not evidence it was never reported.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -1747,6 +1746,13 @@
         "receivedate": {
           "type": "string",
           "description": "Filter by the date FDA received the report. Accepts a single date 'YYYYMMDD' or an openFDA range '[20141001 TO 20141231]' (e.g. 2014 Q4)."
+        },
+        "limit": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1000,
+          "default": 100,
+          "description": "Optional: maximum number of ranked terms to return (default 100, which is openFDA's own page size for count aggregations; maximum 1000, openFDA's documented ceiling). Terms are ranked by descending report count, so a small limit hides the long tail -- a term absent from the response is NOT evidence that it was never reported. The response sets 'truncated' and adds a 'truncation_note' whenever more terms exist beyond the limit. Values above 999 require an openFDA API key in the FDA_API_KEY environment variable."
         }
       },
       "required": [
@@ -1789,24 +1795,86 @@
       }
     ],
     "return_schema": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "term": {
-            "type": "string"
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "results": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "term": {
+                    "type": "string"
+                  },
+                  "count": {
+                    "type": "integer"
+                  }
+                }
+              },
+              "description": "Term/count rows ordered by descending report count. Empty when no reports match."
+            },
+            "result_count": {
+              "type": "integer",
+              "description": "Number of rows in 'results'."
+            },
+            "limit": {
+              "type": "integer",
+              "description": "Maximum number of terms requested from openFDA."
+            },
+            "truncated": {
+              "type": "boolean",
+              "description": "True when openFDA has more terms than the applied limit, i.e. 'results' is an incomplete ranking."
+            },
+            "truncation_note": {
+              "type": "string",
+              "description": "Present only when 'truncated' is true; states the applied limit and how to retrieve more terms."
+            }
           },
-          "count": {
-            "type": "integer"
-          }
+          "required": [
+            "results",
+            "result_count",
+            "limit",
+            "truncated"
+          ]
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "error": {
+                "type": "string"
+              }
+            }
+          },
+          "description": "Error entries returned when the openFDA request fails."
+        },
+        {
+          "type": "object",
+          "properties": {
+            "status": {
+              "type": "string",
+              "enum": [
+                "error"
+              ]
+            },
+            "error": {
+              "type": "string",
+              "description": "Error message when parameters are invalid or the request fails."
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
-      }
+      ]
     }
   },
   {
     "type": "FDACountAdditiveReactionsTool",
     "name": "FAERS_count_additive_reports_by_reporter_country",
-    "description": "Aggregate adverse event reports by primary reporter country across medicinal products. Only medicinalproducts is required; all other filters (patientsex, patientagegroup, serious) are optional. Use filters sparingly to avoid overly restrictive searches. Data source: FDA Adverse Event Reporting System (FAERS).",
+    "description": "Aggregate adverse event reports by primary reporter country across medicinal products. Only medicinalproducts is required; all other filters (patientsex, patientagegroup, serious) are optional. Use filters sparingly to avoid overly restrictive searches. Data source: FDA Adverse Event Reporting System (FAERS). Returns an object with 'results' (term/count rows ranked by descending report count), 'result_count', the applied 'limit' (default 100, maximum 1000) and a 'truncated' flag; when 'truncated' is true a 'truncation_note' explains that more terms exist and how to request them. openFDA does not report how many distinct terms exist in total, so a term missing from a truncated list is not evidence it was never reported.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -1852,6 +1920,13 @@
         "receivedate": {
           "type": "string",
           "description": "Filter by the date FDA received the report. Accepts a single date 'YYYYMMDD' or an openFDA range '[20141001 TO 20141231]' (e.g. 2014 Q4)."
+        },
+        "limit": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1000,
+          "default": 100,
+          "description": "Optional: maximum number of ranked terms to return (default 100, which is openFDA's own page size for count aggregations; maximum 1000, openFDA's documented ceiling). Terms are ranked by descending report count, so a small limit hides the long tail -- a term absent from the response is NOT evidence that it was never reported. The response sets 'truncated' and adds a 'truncation_note' whenever more terms exist beyond the limit. Values above 999 require an openFDA API key in the FDA_API_KEY environment variable."
         }
       },
       "required": [
@@ -1894,24 +1969,86 @@
       }
     ],
     "return_schema": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "term": {
-            "type": "string"
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "results": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "term": {
+                    "type": "string"
+                  },
+                  "count": {
+                    "type": "integer"
+                  }
+                }
+              },
+              "description": "Term/count rows ordered by descending report count. Empty when no reports match."
+            },
+            "result_count": {
+              "type": "integer",
+              "description": "Number of rows in 'results'."
+            },
+            "limit": {
+              "type": "integer",
+              "description": "Maximum number of terms requested from openFDA."
+            },
+            "truncated": {
+              "type": "boolean",
+              "description": "True when openFDA has more terms than the applied limit, i.e. 'results' is an incomplete ranking."
+            },
+            "truncation_note": {
+              "type": "string",
+              "description": "Present only when 'truncated' is true; states the applied limit and how to retrieve more terms."
+            }
           },
-          "count": {
-            "type": "integer"
-          }
+          "required": [
+            "results",
+            "result_count",
+            "limit",
+            "truncated"
+          ]
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "error": {
+                "type": "string"
+              }
+            }
+          },
+          "description": "Error entries returned when the openFDA request fails."
+        },
+        {
+          "type": "object",
+          "properties": {
+            "status": {
+              "type": "string",
+              "enum": [
+                "error"
+              ]
+            },
+            "error": {
+              "type": "string",
+              "description": "Error message when parameters are invalid or the request fails."
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
-      }
+      ]
     }
   },
   {
     "type": "FDACountAdditiveReactionsTool",
     "name": "FAERS_count_additive_seriousness_classification",
-    "description": "Quantify serious vs non-serious classifications across medicinal products. Only medicinalproducts is required; all other filters (patientsex, patientagegroup, occurcountry) are optional. Use filters sparingly to avoid overly restrictive searches. Data source: FDA Adverse Event Reporting System (FAERS).",
+    "description": "Quantify serious vs non-serious classifications across medicinal products. Only medicinalproducts is required; all other filters (patientsex, patientagegroup, occurcountry) are optional. Use filters sparingly to avoid overly restrictive searches. Data source: FDA Adverse Event Reporting System (FAERS). Returns an object with 'results' (term/count rows ranked by descending report count), 'result_count', the applied 'limit' (default 100, maximum 1000) and a 'truncated' flag; when 'truncated' is true a 'truncation_note' explains that more terms exist and how to request them. openFDA does not report how many distinct terms exist in total, so a term missing from a truncated list is not evidence it was never reported.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -1954,6 +2091,13 @@
         "receivedate": {
           "type": "string",
           "description": "Filter by the date FDA received the report. Accepts a single date 'YYYYMMDD' or an openFDA range '[20141001 TO 20141231]' (e.g. 2014 Q4)."
+        },
+        "limit": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1000,
+          "default": 100,
+          "description": "Optional: maximum number of ranked terms to return (default 100, which is openFDA's own page size for count aggregations; maximum 1000, openFDA's documented ceiling). Terms are ranked by descending report count, so a small limit hides the long tail -- a term absent from the response is NOT evidence that it was never reported. The response sets 'truncated' and adds a 'truncation_note' whenever more terms exist beyond the limit. Values above 999 require an openFDA API key in the FDA_API_KEY environment variable."
         }
       },
       "required": [
@@ -2002,154 +2146,86 @@
       }
     ],
     "return_schema": {
-      "anyOf": [
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "results": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "term": {
+                    "type": "string"
+                  },
+                  "count": {
+                    "type": "integer"
+                  }
+                }
+              },
+              "description": "Term/count rows ordered by descending report count. Empty when no reports match."
+            },
+            "result_count": {
+              "type": "integer",
+              "description": "Number of rows in 'results'."
+            },
+            "limit": {
+              "type": "integer",
+              "description": "Maximum number of terms requested from openFDA."
+            },
+            "truncated": {
+              "type": "boolean",
+              "description": "True when openFDA has more terms than the applied limit, i.e. 'results' is an incomplete ranking."
+            },
+            "truncation_note": {
+              "type": "string",
+              "description": "Present only when 'truncated' is true; states the applied limit and how to retrieve more terms."
+            }
+          },
+          "required": [
+            "results",
+            "result_count",
+            "limit",
+            "truncated"
+          ]
+        },
         {
           "type": "array",
           "items": {
-            "type": "object"
-          }
-        },
-        {
-          "type": "object"
-        }
-      ],
-      "properties": {
-        "error": {
-          "type": "string"
-        },
-        "error_details": {
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string"
-            },
-            "message": {
-              "type": "string"
-            },
-            "retriable": {
-              "type": "boolean"
-            },
-            "next_steps": {
-              "type": "array",
-              "items": {
+            "type": "object",
+            "properties": {
+              "error": {
                 "type": "string"
               }
-            },
-            "details": {
-              "type": "object",
-              "properties": {
-                "validation_error": {
-                  "type": "string"
-                },
-                "path": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "type": {
-                      "type": "string"
-                    },
-                    "properties": {
-                      "type": "object",
-                      "properties": {
-                        "medicinalproducts": {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string"
-                            },
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "type": {
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            "description": {
-                              "type": "string"
-                            }
-                          }
-                        },
-                        "patientsex": {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string"
-                            },
-                            "enum": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "description": {
-                              "type": "string"
-                            }
-                          }
-                        },
-                        "patientagegroup": {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string"
-                            },
-                            "enum": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "description": {
-                              "type": "string"
-                            }
-                          }
-                        },
-                        "occurcountry": {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string"
-                            },
-                            "pattern": {
-                              "type": "string"
-                            },
-                            "description": {
-                              "type": "string"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "required": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                },
-                "parameter": {
-                  "type": "string"
-                },
-                "expected": {
-                  "type": "string"
-                }
-              }
             }
-          }
+          },
+          "description": "Error entries returned when the openFDA request fails."
+        },
+        {
+          "type": "object",
+          "properties": {
+            "status": {
+              "type": "string",
+              "enum": [
+                "error"
+              ]
+            },
+            "error": {
+              "type": "string",
+              "description": "Error message when parameters are invalid or the request fails."
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
-      }
+      ]
     }
   },
   {
     "type": "FDACountAdditiveReactionsTool",
     "name": "FAERS_count_additive_reaction_outcomes",
-    "description": "Determine reaction outcome counts (e.g., recovered, resolving, fatal) across medicinal products. Only medicinalproducts is required; all other filters (patientsex, patientagegroup, occurcountry) are optional. Use filters sparingly to avoid overly restrictive searches. Data source: FDA Adverse Event Reporting System (FAERS).",
+    "description": "Determine reaction outcome counts (e.g., recovered, resolving, fatal) across medicinal products. Only medicinalproducts is required; all other filters (patientsex, patientagegroup, occurcountry) are optional. Use filters sparingly to avoid overly restrictive searches. Data source: FDA Adverse Event Reporting System (FAERS). Returns an object with 'results' (term/count rows ranked by descending report count), 'result_count', the applied 'limit' (default 100, maximum 1000) and a 'truncated' flag; when 'truncated' is true a 'truncation_note' explains that more terms exist and how to request them. openFDA does not report how many distinct terms exist in total, so a term missing from a truncated list is not evidence it was never reported.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -2189,6 +2265,13 @@
         "receivedate": {
           "type": "string",
           "description": "Filter by the date FDA received the report. Accepts a single date 'YYYYMMDD' or an openFDA range '[20141001 TO 20141231]' (e.g. 2014 Q4)."
+        },
+        "limit": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1000,
+          "default": 100,
+          "description": "Optional: maximum number of ranked terms to return (default 100, which is openFDA's own page size for count aggregations; maximum 1000, openFDA's documented ceiling). Terms are ranked by descending report count, so a small limit hides the long tail -- a term absent from the response is NOT evidence that it was never reported. The response sets 'truncated' and adds a 'truncation_note' whenever more terms exist beyond the limit. Values above 999 require an openFDA API key in the FDA_API_KEY environment variable."
         }
       },
       "required": [
@@ -2241,145 +2324,86 @@
       }
     ],
     "return_schema": {
-      "anyOf": [
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "results": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "term": {
+                    "type": "string"
+                  },
+                  "count": {
+                    "type": "integer"
+                  }
+                }
+              },
+              "description": "Term/count rows ordered by descending report count. Empty when no reports match."
+            },
+            "result_count": {
+              "type": "integer",
+              "description": "Number of rows in 'results'."
+            },
+            "limit": {
+              "type": "integer",
+              "description": "Maximum number of terms requested from openFDA."
+            },
+            "truncated": {
+              "type": "boolean",
+              "description": "True when openFDA has more terms than the applied limit, i.e. 'results' is an incomplete ranking."
+            },
+            "truncation_note": {
+              "type": "string",
+              "description": "Present only when 'truncated' is true; states the applied limit and how to retrieve more terms."
+            }
+          },
+          "required": [
+            "results",
+            "result_count",
+            "limit",
+            "truncated"
+          ]
+        },
         {
           "type": "array",
           "items": {
-            "type": "object"
-          }
-        },
-        {
-          "type": "object"
-        }
-      ],
-      "properties": {
-        "error": {
-          "type": "string"
-        },
-        "error_details": {
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string"
-            },
-            "message": {
-              "type": "string"
-            },
-            "retriable": {
-              "type": "boolean"
-            },
-            "next_steps": {
-              "type": "array",
-              "items": {
+            "type": "object",
+            "properties": {
+              "error": {
                 "type": "string"
               }
-            },
-            "details": {
-              "type": "object",
-              "properties": {
-                "validation_error": {
-                  "type": "string"
-                },
-                "path": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "type": {
-                      "type": "string"
-                    },
-                    "properties": {
-                      "type": "object",
-                      "properties": {
-                        "medicinalproducts": {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string"
-                            },
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "type": {
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            "description": {
-                              "type": "string"
-                            }
-                          }
-                        },
-                        "patientsex": {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string"
-                            },
-                            "enum": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            }
-                          }
-                        },
-                        "patientagegroup": {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string"
-                            },
-                            "enum": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            }
-                          }
-                        },
-                        "occurcountry": {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string"
-                            },
-                            "pattern": {
-                              "type": "string"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "required": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                },
-                "parameter": {
-                  "type": "string"
-                },
-                "expected": {
-                  "type": "string"
-                }
-              }
             }
-          }
+          },
+          "description": "Error entries returned when the openFDA request fails."
+        },
+        {
+          "type": "object",
+          "properties": {
+            "status": {
+              "type": "string",
+              "enum": [
+                "error"
+              ]
+            },
+            "error": {
+              "type": "string",
+              "description": "Error message when parameters are invalid or the request fails."
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
-      }
+      ]
     }
   },
   {
     "type": "FDACountAdditiveReactionsTool",
     "name": "FAERS_count_additive_administration_routes",
-    "description": "Enumerate and count administration routes for adverse events across specified medicinal products. Only medicinalproducts is required; serious filter is optional. Use filters sparingly to avoid overly restrictive searches. Data source: FDA Adverse Event Reporting System (FAERS).",
+    "description": "Enumerate and count administration routes for adverse events across specified medicinal products. Only medicinalproducts is required; serious filter is optional. Use filters sparingly to avoid overly restrictive searches. Data source: FDA Adverse Event Reporting System (FAERS). Returns an object with 'results' (term/count rows ranked by descending report count), 'result_count', the applied 'limit' (default 100, maximum 1000) and a 'truncated' flag; when 'truncated' is true a 'truncation_note' explains that more terms exist and how to request them. openFDA does not report how many distinct terms exist in total, so a term missing from a truncated list is not evidence it was never reported.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -2397,6 +2421,13 @@
             "No"
           ],
           "description": "Optional: Filter by event seriousness. Omit this parameter if you don't want to filter by seriousness."
+        },
+        "limit": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1000,
+          "default": 100,
+          "description": "Optional: maximum number of ranked terms to return (default 100, which is openFDA's own page size for count aggregations; maximum 1000, openFDA's documented ceiling). Terms are ranked by descending report count, so a small limit hides the long tail -- a term absent from the response is NOT evidence that it was never reported. The response sets 'truncated' and adds a 'truncation_note' whenever more terms exist beyond the limit. Values above 999 require an openFDA API key in the FDA_API_KEY environment variable."
         }
       },
       "required": [
@@ -2496,24 +2527,86 @@
       }
     ],
     "return_schema": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "term": {
-            "type": "string"
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "results": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "term": {
+                    "type": "string"
+                  },
+                  "count": {
+                    "type": "integer"
+                  }
+                }
+              },
+              "description": "Term/count rows ordered by descending report count. Empty when no reports match."
+            },
+            "result_count": {
+              "type": "integer",
+              "description": "Number of rows in 'results'."
+            },
+            "limit": {
+              "type": "integer",
+              "description": "Maximum number of terms requested from openFDA."
+            },
+            "truncated": {
+              "type": "boolean",
+              "description": "True when openFDA has more terms than the applied limit, i.e. 'results' is an incomplete ranking."
+            },
+            "truncation_note": {
+              "type": "string",
+              "description": "Present only when 'truncated' is true; states the applied limit and how to retrieve more terms."
+            }
           },
-          "count": {
-            "type": "integer"
-          }
+          "required": [
+            "results",
+            "result_count",
+            "limit",
+            "truncated"
+          ]
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "error": {
+                "type": "string"
+              }
+            }
+          },
+          "description": "Error entries returned when the openFDA request fails."
+        },
+        {
+          "type": "object",
+          "properties": {
+            "status": {
+              "type": "string",
+              "enum": [
+                "error"
+              ]
+            },
+            "error": {
+              "type": "string",
+              "description": "Error message when parameters are invalid or the request fails."
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
-      }
+      ]
     }
   },
   {
     "type": "FDADrugAdverseEventTool",
     "name": "FAERS_count_indications_by_drug",
-    "description": "Aggregate FDA adverse event (FAERS) reports for a drug by the INDICATION (the medical condition the drug was being used to treat), returning the distribution of indications across all reports for that drug. Answers 'across all adverse-event reports for drug X, what were the top conditions it was prescribed for?'. Only medicinalproduct is required; the optional serious filter restricts to serious/non-serious reports. Use filters sparingly to avoid overly restrictive searches that return no results. Note: 'PRODUCT USED FOR UNKNOWN INDICATION' is a common term when the prescribing indication was not reported. Data source: FDA Adverse Event Reporting System (FAERS).",
+    "description": "Aggregate FDA adverse event (FAERS) reports for a drug by the INDICATION (the medical condition the drug was being used to treat), returning the distribution of indications across all reports for that drug. Answers 'across all adverse-event reports for drug X, what were the top conditions it was prescribed for?'. Only medicinalproduct is required; the optional serious filter restricts to serious/non-serious reports. Use filters sparingly to avoid overly restrictive searches that return no results. Note: 'PRODUCT USED FOR UNKNOWN INDICATION' is a common term when the prescribing indication was not reported. Data source: FDA Adverse Event Reporting System (FAERS). Returns an object with 'results' (term/count rows ranked by descending report count), 'result_count', the applied 'limit' (default 100, maximum 1000) and a 'truncated' flag; when 'truncated' is true a 'truncation_note' explains that more terms exist and how to request them. openFDA does not report how many distinct terms exist in total, so a term missing from a truncated list is not evidence it was never reported.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -2528,6 +2621,13 @@
             "No"
           ],
           "description": "Optional: Filter by event seriousness. Omit this parameter if you don't want to filter by seriousness."
+        },
+        "limit": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1000,
+          "default": 100,
+          "description": "Optional: maximum number of ranked terms to return (default 100, which is openFDA's own page size for count aggregations; maximum 1000, openFDA's documented ceiling). Terms are ranked by descending report count, so a small limit hides the long tail -- a term absent from the response is NOT evidence that it was never reported. The response sets 'truncated' and adds a 'truncation_note' whenever more terms exist beyond the limit. Values above 999 require an openFDA API key in the FDA_API_KEY environment variable."
         }
       },
       "required": [
@@ -2556,21 +2656,60 @@
     "return_schema": {
       "oneOf": [
         {
+          "type": "object",
+          "properties": {
+            "results": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "term": {
+                    "type": "string",
+                    "description": "Drug indication (condition treated), e.g., 'ATRIAL FIBRILLATION'."
+                  },
+                  "count": {
+                    "type": "integer",
+                    "description": "Number of FAERS reports listing this indication for the drug."
+                  }
+                }
+              },
+              "description": "Term/count rows ordered by descending report count. Empty when no reports match."
+            },
+            "result_count": {
+              "type": "integer",
+              "description": "Number of rows in 'results'."
+            },
+            "limit": {
+              "type": "integer",
+              "description": "Maximum number of terms requested from openFDA."
+            },
+            "truncated": {
+              "type": "boolean",
+              "description": "True when openFDA has more terms than the applied limit, i.e. 'results' is an incomplete ranking."
+            },
+            "truncation_note": {
+              "type": "string",
+              "description": "Present only when 'truncated' is true; states the applied limit and how to retrieve more terms."
+            }
+          },
+          "required": [
+            "results",
+            "result_count",
+            "limit",
+            "truncated"
+          ]
+        },
+        {
           "type": "array",
           "items": {
             "type": "object",
             "properties": {
-              "term": {
-                "type": "string",
-                "description": "Drug indication (condition treated), e.g., 'ATRIAL FIBRILLATION'."
-              },
-              "count": {
-                "type": "integer",
-                "description": "Number of FAERS reports listing this indication for the drug."
+              "error": {
+                "type": "string"
               }
             }
           },
-          "description": "Indication distribution ordered by descending count. Empty array when no matching reports are found."
+          "description": "Error entries returned when the openFDA request fails."
         },
         {
           "type": "object",
@@ -2583,7 +2722,7 @@
             },
             "error": {
               "type": "string",
-              "description": "Error message when the request fails or parameters are invalid."
+              "description": "Error message when parameters are invalid or the request fails."
             }
           },
           "required": [
@@ -2596,7 +2735,7 @@
   {
     "type": "FDADrugAdverseEventTool",
     "name": "FAERS_count_drug_characterization",
-    "description": "Aggregate FDA adverse event (FAERS) reports for a drug by drugcharacterization, i.e. the role the drug played in the report: Suspect (the drug is suspected of causing the event), Concomitant (co-administered but not suspected), or Interacting (involved in a drug-drug interaction). Answers 'in what fraction of adverse-event reports is drug X the SUSPECT drug versus merely a concomitant/co-administered drug?'. Only medicinalproduct is required; the optional serious filter restricts to serious/non-serious reports. Data source: FDA Adverse Event Reporting System (FAERS).",
+    "description": "Aggregate FDA adverse event (FAERS) reports for a drug by drugcharacterization, i.e. the role the drug played in the report: Suspect (the drug is suspected of causing the event), Concomitant (co-administered but not suspected), or Interacting (involved in a drug-drug interaction). Answers 'in what fraction of adverse-event reports is drug X the SUSPECT drug versus merely a concomitant/co-administered drug?'. Only medicinalproduct is required; the optional serious filter restricts to serious/non-serious reports. Data source: FDA Adverse Event Reporting System (FAERS). Returns an object with 'results' (term/count rows ranked by descending report count), 'result_count', the applied 'limit' (default 100, maximum 1000) and a 'truncated' flag; when 'truncated' is true a 'truncation_note' explains that more terms exist and how to request them. openFDA does not report how many distinct terms exist in total, so a term missing from a truncated list is not evidence it was never reported.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -2611,6 +2750,13 @@
             "No"
           ],
           "description": "Optional: Filter by event seriousness. Omit this parameter if you don't want to filter by seriousness."
+        },
+        "limit": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1000,
+          "default": 100,
+          "description": "Optional: maximum number of ranked terms to return (default 100, which is openFDA's own page size for count aggregations; maximum 1000, openFDA's documented ceiling). Terms are ranked by descending report count, so a small limit hides the long tail -- a term absent from the response is NOT evidence that it was never reported. The response sets 'truncated' and adds a 'truncation_note' whenever more terms exist beyond the limit. Values above 999 require an openFDA API key in the FDA_API_KEY environment variable."
         }
       },
       "required": [
@@ -2646,21 +2792,60 @@
     "return_schema": {
       "oneOf": [
         {
+          "type": "object",
+          "properties": {
+            "results": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "term": {
+                    "type": "string",
+                    "description": "Drug role: 'Suspect', 'Concomitant', or 'Interacting'."
+                  },
+                  "count": {
+                    "type": "integer",
+                    "description": "Number of FAERS reports in which the drug had this role."
+                  }
+                }
+              },
+              "description": "Term/count rows ordered by descending report count. Empty when no reports match."
+            },
+            "result_count": {
+              "type": "integer",
+              "description": "Number of rows in 'results'."
+            },
+            "limit": {
+              "type": "integer",
+              "description": "Maximum number of terms requested from openFDA."
+            },
+            "truncated": {
+              "type": "boolean",
+              "description": "True when openFDA has more terms than the applied limit, i.e. 'results' is an incomplete ranking."
+            },
+            "truncation_note": {
+              "type": "string",
+              "description": "Present only when 'truncated' is true; states the applied limit and how to retrieve more terms."
+            }
+          },
+          "required": [
+            "results",
+            "result_count",
+            "limit",
+            "truncated"
+          ]
+        },
+        {
           "type": "array",
           "items": {
             "type": "object",
             "properties": {
-              "term": {
-                "type": "string",
-                "description": "Drug role: 'Suspect', 'Concomitant', or 'Interacting'."
-              },
-              "count": {
-                "type": "integer",
-                "description": "Number of FAERS reports in which the drug had this role."
+              "error": {
+                "type": "string"
               }
             }
           },
-          "description": "Drug-characterization distribution ordered by descending count. Empty array when no matching reports are found."
+          "description": "Error entries returned when the openFDA request fails."
         },
         {
           "type": "object",
@@ -2673,7 +2858,7 @@
             },
             "error": {
               "type": "string",
-              "description": "Error message when the request fails or parameters are invalid."
+              "description": "Error message when parameters are invalid or the request fails."
             }
           },
           "required": [
@@ -2686,7 +2871,7 @@
   {
     "type": "FDADrugAdverseEventTool",
     "name": "FAERS_count_reporter_qualification",
-    "description": "Aggregate FDA adverse event (FAERS) reports for a drug by the primary-source reporter qualification (who submitted the report): Physician, Pharmacist, Other health professional, Lawyer, or Consumer or non-health professional. Answers 'what share of adverse-event reports for drug X came from physicians/pharmacists versus consumers/lawyers?' - a report-quality and reliability dimension (clinician-sourced reports are generally considered more reliable). Only medicinalproduct is required; the optional serious filter restricts to serious/non-serious reports. Data source: FDA Adverse Event Reporting System (FAERS).",
+    "description": "Aggregate FDA adverse event (FAERS) reports for a drug by the primary-source reporter qualification (who submitted the report): Physician, Pharmacist, Other health professional, Lawyer, or Consumer or non-health professional. Answers 'what share of adverse-event reports for drug X came from physicians/pharmacists versus consumers/lawyers?' - a report-quality and reliability dimension (clinician-sourced reports are generally considered more reliable). Only medicinalproduct is required; the optional serious filter restricts to serious/non-serious reports. Data source: FDA Adverse Event Reporting System (FAERS). Returns an object with 'results' (term/count rows ranked by descending report count), 'result_count', the applied 'limit' (default 100, maximum 1000) and a 'truncated' flag; when 'truncated' is true a 'truncation_note' explains that more terms exist and how to request them. openFDA does not report how many distinct terms exist in total, so a term missing from a truncated list is not evidence it was never reported.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -2701,6 +2886,13 @@
             "No"
           ],
           "description": "Optional: Filter by event seriousness. Omit this parameter if you don't want to filter by seriousness."
+        },
+        "limit": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1000,
+          "default": 100,
+          "description": "Optional: maximum number of ranked terms to return (default 100, which is openFDA's own page size for count aggregations; maximum 1000, openFDA's documented ceiling). Terms are ranked by descending report count, so a small limit hides the long tail -- a term absent from the response is NOT evidence that it was never reported. The response sets 'truncated' and adds a 'truncation_note' whenever more terms exist beyond the limit. Values above 999 require an openFDA API key in the FDA_API_KEY environment variable."
         }
       },
       "required": [
@@ -2738,21 +2930,60 @@
     "return_schema": {
       "oneOf": [
         {
+          "type": "object",
+          "properties": {
+            "results": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "term": {
+                    "type": "string",
+                    "description": "Reporter qualification, e.g., 'Physician', 'Pharmacist', 'Consumer or non-health professional'."
+                  },
+                  "count": {
+                    "type": "integer",
+                    "description": "Number of FAERS reports submitted by a primary source of this qualification."
+                  }
+                }
+              },
+              "description": "Term/count rows ordered by descending report count. Empty when no reports match."
+            },
+            "result_count": {
+              "type": "integer",
+              "description": "Number of rows in 'results'."
+            },
+            "limit": {
+              "type": "integer",
+              "description": "Maximum number of terms requested from openFDA."
+            },
+            "truncated": {
+              "type": "boolean",
+              "description": "True when openFDA has more terms than the applied limit, i.e. 'results' is an incomplete ranking."
+            },
+            "truncation_note": {
+              "type": "string",
+              "description": "Present only when 'truncated' is true; states the applied limit and how to retrieve more terms."
+            }
+          },
+          "required": [
+            "results",
+            "result_count",
+            "limit",
+            "truncated"
+          ]
+        },
+        {
           "type": "array",
           "items": {
             "type": "object",
             "properties": {
-              "term": {
-                "type": "string",
-                "description": "Reporter qualification, e.g., 'Physician', 'Pharmacist', 'Consumer or non-health professional'."
-              },
-              "count": {
-                "type": "integer",
-                "description": "Number of FAERS reports submitted by a primary source of this qualification."
+              "error": {
+                "type": "string"
               }
             }
           },
-          "description": "Reporter-qualification distribution ordered by descending count. Empty array when no matching reports are found."
+          "description": "Error entries returned when the openFDA request fails."
         },
         {
           "type": "object",
@@ -2765,7 +2996,7 @@
             },
             "error": {
               "type": "string",
-              "description": "Error message when the request fails or parameters are invalid."
+              "description": "Error message when parameters are invalid or the request fails."
             }
           },
           "required": [

--- a/src/tooluniverse/data/ols_tools.json
+++ b/src/tooluniverse/data/ols_tools.json
@@ -32,7 +32,7 @@
         },
         "exact_match": {
           "type": "boolean",
-          "description": "Search for exact matches only (default: false)",
+          "description": "Restrict results to exact matches (default: false). The query must equal a term's label or one of its exact synonyms in full - substring and word-overlap hits are excluded, so 'fibroblast' returns CL:0000057 but not 'skin fibroblast'. If the query is instead an identifier (a CURIE such as 'CL:0000084', the OBO underscore form 'CL_0000084', or a full IRI), the exact match is applied to the obo_id/short_form/iri fields, which returns that identifier in every ontology that declares it - pass `ontology` to narrow it to one.",
           "default": false
         },
         "include_obsolete": {
@@ -173,6 +173,10 @@
             },
             "exact_match": {
               "type": "boolean"
+            },
+            "exact_match_fields": {
+              "type": "string",
+              "description": "Comma-separated OLS fields the exact match was applied to. Present only when exact_match is true."
             },
             "include_obsolete": {
               "type": "boolean"

--- a/src/tooluniverse/data/openfda_label_tools.json
+++ b/src/tooluniverse/data/openfda_label_tools.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "FDA_search_drug_labels",
-    "description": "Search FDA-approved drug labels (prescribing information) by drug name or medical indication. Drug labels contain official clinical guidance: indications, dosing regimens, contraindications, black box warnings, drug interactions, and adverse reactions. Use drug_name for drug-specific lookups (e.g., 'metformin', 'warfarin') or indication for condition-based searches (e.g., 'hypertension', 'type 2 diabetes'). Returns a list of matching drug labels with key clinical sections.",
+    "description": "Search FDA-approved drug labels (prescribing information) by drug name or medical indication. Drug labels contain official clinical guidance: indications, dosing regimens, contraindications, black box warnings, drug interactions, and adverse reactions. Use drug_name for drug-specific lookups (e.g., 'metformin', 'warfarin') or indication for condition-based searches (e.g., 'hypertension', 'type 2 diabetes'). Returns a list of matching drug labels with key clinical sections. This is a compact multi-record summary view: each clinical section is limited to max_section_chars (default 2000) so a 20-record search stays small. Whenever a section is shortened the response carries top-level 'truncated': true and a 'truncation_note' naming the affected sections; raise max_section_chars, or use FDA_get_drug_label for the full text of one drug.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -23,6 +23,14 @@
           "type": "integer",
           "description": "Maximum number of results to return (default: 5, max: 20)",
           "default": 5
+        },
+        "max_section_chars": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Maximum characters returned per clinical section (default: 2000, 0 = no limit). Sections longer than this are cut and the response then carries top-level 'truncated': true plus 'truncation_note' naming the affected sections. Raise this value to retrieve longer sections; note that a 20-result search at a high limit returns a very large response.",
+          "default": 2000
         }
       },
       "required": []
@@ -144,13 +152,21 @@
   },
   {
     "name": "FDA_get_drug_label",
-    "description": "Get the complete FDA-approved prescribing information for a specific drug by name. Returns all clinical sections of the official drug label: indications, dosing regimens, contraindications, black box warnings, drug interactions, use in specific populations (pregnancy, pediatrics, renal/hepatic impairment), pharmacokinetics, mechanism of action, and adverse reactions. This is the authoritative source for FDA-approved drug clinical information in the US.",
+    "description": "Get the complete FDA-approved prescribing information for a specific drug by name. Returns all clinical sections of the official drug label: indications, dosing regimens, contraindications, black box warnings, drug interactions, use in specific populations (pregnancy, pediatrics, renal/hepatic impairment), pharmacokinetics, mechanism of action, and adverse reactions. This is the authoritative source for FDA-approved drug clinical information in the US. Each section is returned up to max_section_chars characters (default 25000, which holds a full clinical section for essentially every label); if any section is longer it is cut and the response carries top-level 'truncated': true plus a 'truncation_note' naming the cut sections, so a shortened section is never presented as complete. Pass max_section_chars=0 for the whole label with no limit.",
     "parameter": {
       "type": "object",
       "properties": {
         "drug_name": {
           "type": "string",
           "description": "Brand or generic drug name (e.g., 'warfarin', 'Eliquis', 'apixaban', 'atorvastatin', 'metformin')"
+        },
+        "max_section_chars": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Maximum characters returned per clinical section (default: 25000, 0 = no limit). Sections longer than this are cut and the response then carries top-level 'truncated': true plus 'truncation_note' naming the affected sections. Raise this value (or pass 0) to retrieve those sections in full; a complete label is roughly 50-110 KB of text.",
+          "default": 25000
         }
       },
       "required": [

--- a/src/tooluniverse/execute_function.py
+++ b/src/tooluniverse/execute_function.py
@@ -47,6 +47,7 @@ from .exceptions import (
     ToolConfigError,
     ToolServerError,
 )
+from .base_tool import resolve_configured_operation
 from .tool_registry import (
     auto_discover_tools,
     get_tool_registry,
@@ -3890,19 +3891,16 @@ class ToolUniverse:
         schema default), so supply it here when the caller left it out. An
         explicitly passed ``operation`` always wins. Mutates ``arguments`` in
         place, before validation, so it applies whether or not validation runs.
+
+        The value is resolved through ``resolve_configured_operation`` because
+        ``BaseTool.validate_parameters`` needs the same answer to tell an
+        auto-supplied ``operation`` apart from a caller-supplied one
+        (Feature-26A-8); resolving it in two places would let them drift.
         """
         if "operation" in arguments:
             return
-        config = self.all_tool_dict.get(function_name)
-        if not isinstance(config, dict):
-            return
-        operation = (config.get("fields") or {}).get("operation")
-        if not operation:
-            schema = config.get("parameter") or {}
-            prop = (schema.get("properties") or {}).get("operation")
-            if isinstance(prop, dict):
-                operation = prop.get("default")
-        if isinstance(operation, str) and operation:
+        operation = resolve_configured_operation(self.all_tool_dict.get(function_name))
+        if operation:
             arguments["operation"] = operation
 
     def _validate_parameters(

--- a/src/tooluniverse/fda_label_tool.py
+++ b/src/tooluniverse/fda_label_tool.py
@@ -23,6 +23,46 @@ FDA_LABEL_URL = "https://api.fda.gov/drug/label.json"
 # Placeholder values users sometimes leave in FDA_API_KEY; treat as "unset".
 _API_KEY_PLACEHOLDERS = {"none", "null", "your_fda_key_here", "your_key_here"}
 
+# Per-section character budget, by query_type.
+#
+# openFDA label sections are unbounded prose. Measured against the live API:
+# a complete Prograf (tacrolimus) label is ~103,000 characters of section text,
+# Humira ~86,000 and a warfarin label ~47,000; the single largest section seen
+# was 28,292 characters (Prograf adverse_reactions).
+#
+# A section longer than the applied budget is cut, and every cut is disclosed
+# at the top level of the response via `truncated` / `truncation_note`; callers
+# override the budget with the `max_section_chars` argument (0 = no limit).
+DEFAULT_SECTION_CHARS = {
+    # FDA_get_drug_label advertises the *complete* prescribing information for
+    # one drug, so its budget has to hold a whole clinical section. 25,000
+    # characters keeps every section of the labels measured above intact except
+    # Prograf's outsized adverse_reactions, and bounds one label at a few
+    # hundred KB instead of being unbounded.
+    "get": 25000,
+    # FDA_search_drug_labels returns up to 20 records at once, so it stays a
+    # deliberately compact summary view -- it just says so now instead of
+    # presenting cut prose as complete.
+    "search": 2000,
+}
+_FALLBACK_SECTION_CHARS = 2000
+
+# Extracted record keys that hold free-text clinical prose and are therefore
+# subject to the per-section budget. Identifier/metadata keys are not.
+_SECTION_FIELDS = (
+    "boxed_warning",
+    "indications_and_usage",
+    "dosage_and_administration",
+    "dosage_forms_and_strengths",
+    "contraindications",
+    "warnings_and_precautions",
+    "adverse_reactions",
+    "drug_interactions",
+    "use_in_specific_populations",
+    "clinical_pharmacology",
+    "mechanism_of_action",
+)
+
 
 def _valid_api_key(value: Any) -> bool:
     if not isinstance(value, str):
@@ -43,8 +83,56 @@ def _ok(data: Any, **metadata: Any) -> dict:
     return {"status": "success", "data": data, "metadata": metadata}
 
 
-def _extract_label(result: dict) -> dict:
-    """Extract key clinical sections from a raw openFDA label record."""
+def _disclose_truncation(
+    response: dict, truncated_fields: list[str], max_chars: int | None
+) -> dict:
+    """Attach the top-level truncation disclosure to a success envelope.
+
+    `truncated` is always present (False when nothing was cut) so callers can
+    rely on the key existing; `truncated_fields` and `truncation_note` appear
+    only when something really was cut. The note names the affected sections,
+    the budget that was applied, and the argument to raise it -- a flag that
+    says "there is more" without saying how to get it is only half a disclosure.
+    """
+    fields = sorted(set(truncated_fields))
+    response["truncated"] = bool(fields)
+    if fields:
+        response["truncated_fields"] = fields
+        response["truncation_note"] = (
+            f"{len(fields)} label section(s) exceeded max_section_chars="
+            f"{max_chars} and were cut mid-text: {', '.join(fields)}. "
+            "Pass a larger max_section_chars (or max_section_chars=0 for no "
+            "limit) to retrieve these sections in full."
+        )
+    return response
+
+
+def _apply_section_limit(record: dict, max_chars: int | None) -> tuple[dict, list[str]]:
+    """Cut every clinical section of an extracted record down to `max_chars`.
+
+    Returns the limited record plus the names of the sections that were cut, so
+    the caller can disclose them. `max_chars=None` means no limit.
+    """
+    if max_chars is None:
+        return record, []
+    truncated_fields: list[str] = []
+    limited = dict(record)
+    for key in _SECTION_FIELDS:
+        text = record.get(key)
+        if isinstance(text, str) and len(text) > max_chars:
+            limited[key] = text[:max_chars]
+            truncated_fields.append(key)
+    return limited, truncated_fields
+
+
+def _extract_label(
+    result: dict, max_chars: int | None = None
+) -> tuple[dict, list[str]]:
+    """Extract key clinical sections from a raw openFDA label record.
+
+    Returns the extracted record plus the names of the sections that had to be
+    cut to fit `max_chars` (empty when `max_chars` is None, meaning no limit).
+    """
     openfda = result.get("openfda", {})
     brand = openfda.get("brand_name", [])
     generic = openfda.get("generic_name", [])
@@ -58,9 +146,9 @@ def _extract_label(result: dict) -> dict:
 
     def section(key):
         val = result.get(key, [])
-        return " ".join(val)[:2000] if val else None
+        return " ".join(val) if val else None
 
-    return {
+    record = {
         "brand_name": first(brand),
         "generic_name": first(generic),
         "manufacturer": first(mfr),
@@ -81,6 +169,7 @@ def _extract_label(result: dict) -> dict:
         "mechanism_of_action": section("mechanism_of_action"),
         "spl_id": result.get("id"),
     }
+    return _apply_section_limit(record, max_chars)
 
 
 @register_tool("FDALabelTool")
@@ -108,6 +197,21 @@ class FDALabelTool(BaseTool):
             kwargs["api_key"] = self.api_key
         return kwargs
 
+    def _max_section_chars(self, arguments: dict) -> int | None:
+        """Resolve the per-section character budget for this call.
+
+        Returns None when the caller asked for no limit (max_section_chars <= 0).
+        """
+        default = DEFAULT_SECTION_CHARS.get(self.query_type, _FALLBACK_SECTION_CHARS)
+        raw = arguments.get("max_section_chars")
+        if raw is None:
+            return default
+        try:
+            value = int(raw)
+        except (TypeError, ValueError):
+            return default
+        return value if value > 0 else None
+
     def run(self, arguments: dict[str, Any]) -> Any:
         try:
             qt = self.query_type
@@ -125,12 +229,15 @@ class FDALabelTool(BaseTool):
         except Exception as e:
             return {"status": "error", "error": f"Unexpected error: {e}"}
 
-    def _query_drug_fields(self, drug_name: str, limit: int) -> list[dict] | None:
+    def _query_drug_fields(
+        self, drug_name: str, limit: int, max_chars: int | None = None
+    ) -> tuple[list[dict] | None, list[str]]:
         """Search generic_name then brand_name with quoted then unquoted fallback.
 
-        Returns extracted label results on first match, or None if no results found.
-        Quoted search finds exact matches; unquoted fallback catches salt forms
-        (e.g., "tofacitinib" matching "TOFACITINIB CITRATE").
+        Returns (extracted label results, truncated section names) on the first
+        match, or (None, []) if no results found. Quoted search finds exact
+        matches; unquoted fallback catches salt forms (e.g., "tofacitinib"
+        matching "TOFACITINIB CITRATE").
         """
         for field in ("openfda.generic_name", "openfda.brand_name"):
             for q in (f'{field}:"{drug_name}"', f"{field}:{drug_name}"):
@@ -144,20 +251,36 @@ class FDALabelTool(BaseTool):
                 resp.raise_for_status()
                 results = resp.json().get("results", [])
                 if results:
-                    return [_extract_label(r) for r in results]
-        return None
+                    labels: list[dict] = []
+                    truncated: list[str] = []
+                    for r in results:
+                        record, cut = _extract_label(r, max_chars)
+                        labels.append(record)
+                        truncated.extend(cut)
+                    return labels, truncated
+        return None, []
 
     def _search(self, arguments: dict) -> Any:
         drug_name = arguments.get("drug_name")
         indication = arguments.get("indication")
         limit = min(int(arguments.get("limit", 5)), 20)
+        max_chars = self._max_section_chars(arguments)
 
         if not drug_name and not indication:
             return {"status": "error", "error": "Provide drug_name or indication"}
 
         if drug_name:
-            labels = self._query_drug_fields(drug_name, limit) or []
-            return _ok(labels, query=drug_name, query_field="drug_name")
+            labels, truncated = self._query_drug_fields(drug_name, limit, max_chars)
+            return _disclose_truncation(
+                _ok(
+                    labels or [],
+                    query=drug_name,
+                    query_field="drug_name",
+                    max_section_chars=max_chars or 0,
+                ),
+                truncated,
+                max_chars,
+            )
 
         q = f'indications_and_usage:"{indication}"'
         resp = requests.get(
@@ -166,17 +289,35 @@ class FDALabelTool(BaseTool):
             timeout=20,
         )
         labels = []
+        truncated = []
         if resp.status_code != 404:
             resp.raise_for_status()
-            labels = [_extract_label(r) for r in resp.json().get("results", [])]
-        return _ok(labels, query=indication, query_field="indication")
+            for r in resp.json().get("results", []):
+                record, cut = _extract_label(r, max_chars)
+                labels.append(record)
+                truncated.extend(cut)
+        return _disclose_truncation(
+            _ok(
+                labels,
+                query=indication,
+                query_field="indication",
+                max_section_chars=max_chars or 0,
+            ),
+            truncated,
+            max_chars,
+        )
 
     def _get_label(self, arguments: dict) -> Any:
         drug_name = arguments.get("drug_name", "")
         if not drug_name:
             return {"status": "error", "error": "drug_name is required"}
 
-        results = self._query_drug_fields(drug_name, limit=10)
+        max_chars = self._max_section_chars(arguments)
+
+        # Fetch candidates untruncated so the best-match choice below is made on
+        # complete records, and only the record we actually return gets cut --
+        # otherwise the disclosure would name sections from discarded matches.
+        results, _ = self._query_drug_fields(drug_name, limit=10, max_chars=None)
         if not results:
             return {"status": "error", "error": f"No FDA label found for '{drug_name}'"}
 
@@ -190,7 +331,12 @@ class FDALabelTool(BaseTool):
             return len(brand) or 999
 
         results.sort(key=_match_score)
-        return _ok(results[0], query=drug_name)
+        label, truncated = _apply_section_limit(results[0], max_chars)
+        return _disclose_truncation(
+            _ok(label, query=drug_name, max_section_chars=max_chars or 0),
+            truncated,
+            max_chars,
+        )
 
     def _list_classes(self, arguments: dict) -> Any:
         limit = min(int(arguments.get("limit", 20)), 100)

--- a/src/tooluniverse/ols_tool.py
+++ b/src/tooluniverse/ols_tool.py
@@ -7,6 +7,7 @@ adapted into a synchronous local tool that fits the ToolUniverse runtime.
 
 from __future__ import annotations
 
+import re
 import urllib.parse
 from typing import Any, Dict, List, Optional
 
@@ -18,6 +19,40 @@ from .tool_registry import register_tool
 
 OLS_BASE_URL = "https://www.ebi.ac.uk/ols4"
 REQUEST_TIMEOUT = 30.0  # 30 second timeout to prevent hanging on slow API responses
+
+# OLS4's `/api/search?exact=true` flag on its own restricts almost nothing: the
+# endpoint defaults to matching across label, synonym, description, iri,
+# short_form and obo_id, so an "exact" hit against a *description* token still
+# drags in the whole neighbourhood. Measured against the live API:
+#   q=fibroblast&ontology=cl&exact=true                     -> 167 of 168 terms
+#   q=fibroblast&ontology=cl&exact=true&queryFields=label   -> 1 term
+#   q=T cell&ontology=cl&exact=true                         -> 6803 terms
+#   q=T cell&ontology=cl&exact=true&queryFields=label,synonym -> 1 term
+# Constraining `queryFields` is therefore what makes `exact` mean what it says.
+# Synonyms are included because an exact hit on an alternative name is a genuine
+# exact match ('T-lymphocyte' -> CL:0000084 'T cell', 'aspirin' -> CHEBI:15365).
+_EXACT_NAME_FIELDS = "label,synonym"
+
+# Identifier-shaped queries are not names, and restricting them to label/synonym
+# returns nothing at all (q=CL:0000084&queryFields=label,synonym -> 0 hits), so
+# they get matched against the identifier fields instead.
+_EXACT_IDENTIFIER_FIELDS = "obo_id,short_form,iri"
+
+# CURIE ('CL:0000084') or OBO underscore form ('CL_0000084'). Deliberately
+# rejects anything containing whitespace so ordinary multi-word labels such as
+# 'type 2 diabetes mellitus' are treated as names.
+_IDENTIFIER_QUERY_RE = re.compile(r"^[A-Za-z][A-Za-z0-9.]*[:_][A-Za-z0-9._-]+$")
+
+
+def _exact_query_fields(query: str) -> str:
+    """Return the OLS4 ``queryFields`` set that makes ``exact=true`` restrictive."""
+
+    candidate = query.strip()
+    if candidate.lower().startswith(("http://", "https://")):
+        return _EXACT_IDENTIFIER_FIELDS
+    if _IDENTIFIER_QUERY_RE.match(candidate):
+        return _EXACT_IDENTIFIER_FIELDS
+    return _EXACT_NAME_FIELDS
 
 
 def url_encode_iri(iri: str) -> str:
@@ -237,6 +272,11 @@ class OLSTool(BaseTool):
             "exact": exact_match,
             "obsoletes": include_obsolete,
         }
+        # Only constrain `queryFields` when exact matching was actually asked
+        # for; the unfiltered search must keep its full-text recall.
+        exact_fields = _exact_query_fields(str(query)) if exact_match else None
+        if exact_fields:
+            params["queryFields"] = exact_fields
         if ontology:
             params["ontology"] = ontology
 
@@ -261,11 +301,17 @@ class OLSTool(BaseTool):
             formatted = self._format_term_collection(data, rows)
 
         formatted["query"] = query
-        formatted["filters"] = {
+        filters = {
             "ontology": ontology,
             "exact_match": exact_match,
             "include_obsolete": include_obsolete,
         }
+        # State which fields the exact match was applied to, so the echoed
+        # `exact_match: true` is a verifiable claim rather than an assertion the
+        # caller has to take on trust.
+        if exact_fields:
+            filters["exact_match_fields"] = exact_fields
+        formatted["filters"] = filters
         return formatted
 
     def _handle_get_ontology_info(self, arguments: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/tooluniverse/openfda_adv_tool.py
+++ b/src/tooluniverse/openfda_adv_tool.py
@@ -7,6 +7,39 @@ from .base_tool import BaseTool
 from .tool_registry import register_tool
 
 
+# ---- openFDA `count=` aggregation paging ----
+#
+# openFDA answers a `count=` query with only the most frequent values and does
+# NOT report how many distinct values exist -- its `meta` block carries just
+# disclaimer/terms/license/last_updated, never a grand total. Measured live
+# 2026-08 against
+#   https://api.fda.gov/drug/event.json?search=...&count=patient.reaction.reactionmeddrapt.exact
+# an unqualified count query returns exactly 100 rows, so 100 is the effective
+# default page size for these aggregations.
+COUNT_DEFAULT_LIMIT = 100
+
+# Documented maximum for `limit`: "Currently, the largest allowed value for the
+# `limit` parameter is 1000." -- https://open.fda.gov/apis/query-parameters/
+COUNT_MAX_LIMIT = 1000
+
+# Measured, undocumented: anonymous callers are capped one below the documented
+# maximum. limit=1000 (and above) answers HTTP 403 {"code": "API_KEY_MISSING"}
+# while limit=999 succeeds, reproduced across both count and plain search
+# queries. Callers with FDA_API_KEY set may use the full documented maximum.
+COUNT_MAX_LIMIT_ANONYMOUS = 999
+
+
+def _is_error_payload(payload):
+    """True when ``_search`` returned an error sentinel rather than count rows."""
+    return (
+        isinstance(payload, list)
+        and len(payload) > 0
+        and isinstance(payload[0], dict)
+        and "error" in payload[0]
+        and "term" not in payload[0]
+    )
+
+
 def _is_range(value):
     """True for a Lucene range such as "[20141001 TO 20141231]".
 
@@ -120,11 +153,110 @@ class FDADrugAdverseEventTool(BaseTool):
         if validation_error:
             return {"status": "error", "error": validation_error}
 
+        limit_error, limit = self._resolve_count_limit(arguments)
+        if limit_error:
+            return {"status": "error", "error": limit_error}
+
         # Store reactionmeddraverse for filtering results
         reaction_filter = arguments.get("reactionmeddraverse")
 
-        response = self._search(arguments)
-        return self._post_process(response, reaction_filter=reaction_filter)
+        response = self._search(arguments, limit=self._fetch_limit(limit))
+        if _is_error_payload(response):
+            return response
+        return self._build_count_envelope(
+            response, limit, reaction_filter=reaction_filter
+        )
+
+    # ---- count paging / truncation disclosure ----
+
+    def _limit_ceiling(self):
+        """Highest `limit` this caller may send to openFDA."""
+        return COUNT_MAX_LIMIT if self.api_key else COUNT_MAX_LIMIT_ANONYMOUS
+
+    def _resolve_count_limit(self, arguments):
+        """Pop and validate `limit`, returning ``(error_message, limit)``."""
+        limit = arguments.pop("limit", COUNT_DEFAULT_LIMIT)
+        if limit is None:
+            limit = COUNT_DEFAULT_LIMIT
+        if isinstance(limit, bool) or not isinstance(limit, int):
+            message = (
+                f"Invalid value '{limit}' for 'limit'. Expected an integer between 1 "
+                f"and {COUNT_MAX_LIMIT}."
+            )
+            return message, None
+        if limit < 1 or limit > COUNT_MAX_LIMIT:
+            message = (
+                f"'limit' must be between 1 and {COUNT_MAX_LIMIT} "
+                f"(openFDA's documented maximum); got {limit}."
+            )
+            return message, None
+        if limit > self._limit_ceiling():
+            message = (
+                f"'limit' above {COUNT_MAX_LIMIT_ANONYMOUS} requires an openFDA API "
+                "key: set the FDA_API_KEY environment variable, or lower 'limit' to "
+                f"{COUNT_MAX_LIMIT_ANONYMOUS} or below."
+            )
+            return message, None
+        return None, limit
+
+    def _fetch_limit(self, limit):
+        """Ask openFDA for one extra row so truncation can be reported exactly.
+
+        openFDA never states how many distinct values a `count=` aggregation has,
+        so the only way to know whether the caller's page is the whole story is
+        to request one row past it and see whether it comes back.
+        """
+        return min(limit + 1, self._limit_ceiling())
+
+    def _build_count_envelope(self, response, limit, reaction_filter=None):
+        """Return count rows alongside a top-level truncation disclosure."""
+        if not isinstance(response, list):
+            response = []
+
+        fetch_limit = self._fetch_limit(limit)
+        probed = fetch_limit > limit
+        if probed:
+            # The probe row came back, so more terms definitely exist.
+            truncated = len(response) > limit
+        else:
+            # Already at the ceiling: a full page is all we can observe, so the
+            # honest answer is "possibly incomplete", not "complete".
+            truncated = len(response) >= limit
+
+        rows = self._post_process(response[:limit], reaction_filter=reaction_filter)
+
+        envelope = {
+            "results": rows,
+            "result_count": len(rows),
+            "limit": limit,
+            "truncated": truncated,
+        }
+        if truncated:
+            certainty = (
+                "more terms exist beyond that limit"
+                if probed
+                else "openFDA filled the page exactly, so more terms may exist beyond it"
+            )
+            # When a term filter is applied client-side, 'results' is a subset of
+            # the ranked list; say so, so the flag is not read as "your one row
+            # is incomplete".
+            scope = (
+                " 'results' was then narrowed to the requested term, so the "
+                "truncation applies to the underlying ranking rather than to the "
+                "rows shown."
+                if reaction_filter
+                else ""
+            )
+            envelope["truncation_note"] = (
+                f"openFDA returned only the {min(len(response), limit)} most-reported "
+                f"terms for this query (limit={limit}), ranked by descending report "
+                f"count; {certainty}. openFDA's count endpoint does not report how "
+                "many distinct terms there are in total, so the size of the remainder "
+                f"is unknown. Pass a larger 'limit' (maximum {COUNT_MAX_LIMIT}) to "
+                "retrieve more. A term missing from this list is NOT evidence that it "
+                f"was never reported -- query the term directly to check.{scope}"
+            )
+        return envelope
 
     def validate_enum_arguments(self, arguments):
         """Validate that enum-based arguments match the allowed values"""
@@ -180,7 +312,7 @@ class FDADrugAdverseEventTool(BaseTool):
 
         return mapped_results
 
-    def _search(self, arguments):
+    def _search(self, arguments, limit=None):
         search_parts = []
         for param_name, value in arguments.items():
             # Only forward parameters defined in the search-field map; an
@@ -237,13 +369,16 @@ class FDADrugAdverseEventTool(BaseTool):
         search_query = "+AND+".join(search_parts)
         search_encoded = urllib.parse.quote(search_query, safe='+:"')
 
-        # Build URL
+        # Build URL. `limit` is appended after `count` so it is never mistaken
+        # for part of the Lucene search clause.
         if self.api_key:
             url = f"{self.endpoint_url}?api_key={self.api_key}&search={search_encoded}&count={self.count_field}"
         else:
             url = (
                 f"{self.endpoint_url}?search={search_encoded}&count={self.count_field}"
             )
+        if limit is not None:
+            url = f"{url}&limit={limit}"
 
         # API request (30s timeout so a hung connection cannot block the caller)
         try:
@@ -333,6 +468,10 @@ class FDACountAdditiveReactionsTool(FDADrugAdverseEventTool):
         if validation_error:
             return {"status": "error", "error": validation_error}
 
+        limit_error, limit = self._resolve_count_limit(arguments)
+        if limit_error:
+            return {"status": "error", "error": limit_error}
+
         # Build OR clause for multiple drugs
         escaped = []
         for d in drugs:
@@ -370,7 +509,8 @@ class FDACountAdditiveReactionsTool(FDADrugAdverseEventTool):
         # URL encode the search query, preserving +, :, and " as safe chars
         search_encoded = urllib.parse.quote(search_query, safe='+:"')
 
-        # Call API
+        # Call API. `limit` is appended after `count` so it is never mistaken
+        # for part of the Lucene search clause.
         if self.api_key:
             url = (
                 f"{self.endpoint_url}?api_key={self.api_key}"
@@ -380,23 +520,24 @@ class FDACountAdditiveReactionsTool(FDADrugAdverseEventTool):
             url = (
                 f"{self.endpoint_url}?search={search_encoded}&count={self.count_field}"
             )
+        url = f"{url}&limit={self._fetch_limit(limit)}"
 
         try:
             resp = requests.get(url)
-            # Handle 404 as "no matches found" - return empty list instead of error
+            # Handle 404 as "no matches found" - return an empty (but explicitly
+            # non-truncated) envelope instead of an error.
             if resp.status_code == 404:
                 try:
                     error_data = resp.json()
                     if "error" in error_data and "No matches found" in str(
                         error_data.get("error", {})
                     ):
-                        return []  # Return empty list for no matches
+                        return self._build_count_envelope([], limit)
                 except (ValueError, KeyError):
                     pass
             resp.raise_for_status()
             results = resp.json().get("results", [])
-            results = self._post_process(results)
-            return results
+            return self._build_count_envelope(results, limit)
         except requests.exceptions.RequestException as e:
             return {"status": "error", "error": f"API request failed: {str(e)}"}
 

--- a/src/tooluniverse/tools/FAERS_count_additive_administration_routes.py
+++ b/src/tooluniverse/tools/FAERS_count_additive_administration_routes.py
@@ -11,11 +11,12 @@ from ._shared_client import get_shared_client
 def FAERS_count_additive_administration_routes(
     medicinalproducts: list[str],
     serious: Optional[str] = None,
+    limit: Optional[int] = 100,
     *,
     stream_callback: Optional[Callable[[str], None]] = None,
     use_cache: bool = False,
     validate: bool = True,
-) -> list[Any]:
+) -> Any:
     """
     Enumerate and count administration routes for adverse events across specified medicinal products....
 
@@ -25,6 +26,8 @@ def FAERS_count_additive_administration_routes(
         Array of medicinal product names.
     serious : str
         Optional: Filter by event seriousness. Omit this parameter if you don't want ...
+    limit : int
+        Optional: maximum number of ranked terms to return (default 100, which is ope...
     stream_callback : Callable, optional
         Callback for streaming output
     use_cache : bool, default False
@@ -34,14 +37,18 @@ def FAERS_count_additive_administration_routes(
 
     Returns
     -------
-    list[Any]
+    Any
     """
     # Handle mutable defaults to avoid B006 linting error
 
     # Strip None values so optional parameters don't trigger schema validation errors
     _args = {
         k: v
-        for k, v in {"medicinalproducts": medicinalproducts, "serious": serious}.items()
+        for k, v in {
+            "medicinalproducts": medicinalproducts,
+            "serious": serious,
+            "limit": limit,
+        }.items()
         if v is not None
     }
     return get_shared_client().run_one_function(

--- a/src/tooluniverse/tools/FAERS_count_additive_adverse_reactions.py
+++ b/src/tooluniverse/tools/FAERS_count_additive_adverse_reactions.py
@@ -15,6 +15,7 @@ def FAERS_count_additive_adverse_reactions(
     occurcountry: Optional[str] = None,
     serious: Optional[str] = None,
     seriousnessdeath: Optional[str] = None,
+    limit: Optional[int] = 100,
     *,
     stream_callback: Optional[Callable[[str], None]] = None,
     use_cache: bool = False,
@@ -37,6 +38,8 @@ def FAERS_count_additive_adverse_reactions(
         Optional: Filter by event seriousness. Omit this parameter if you don't want ...
     seriousnessdeath : str
         Optional: Pass 'Yes' to filter for reports where death was an outcome. Omit t...
+    limit : int
+        Optional: maximum number of ranked terms to return (default 100, which is ope...
     stream_callback : Callable, optional
         Callback for streaming output
     use_cache : bool, default False
@@ -60,6 +63,7 @@ def FAERS_count_additive_adverse_reactions(
             "occurcountry": occurcountry,
             "serious": serious,
             "seriousnessdeath": seriousnessdeath,
+            "limit": limit,
         }.items()
         if v is not None
     }

--- a/src/tooluniverse/tools/FAERS_count_additive_event_reports_by_country.py
+++ b/src/tooluniverse/tools/FAERS_count_additive_event_reports_by_country.py
@@ -13,11 +13,12 @@ def FAERS_count_additive_event_reports_by_country(
     patientsex: Optional[str] = None,
     patientagegroup: Optional[str] = None,
     serious: Optional[str] = None,
+    limit: Optional[int] = 100,
     *,
     stream_callback: Optional[Callable[[str], None]] = None,
     use_cache: bool = False,
     validate: bool = True,
-) -> list[Any]:
+) -> Any:
     """
     Aggregate report counts by country of occurrence across specified medicinal products. Only medici...
 
@@ -31,6 +32,8 @@ def FAERS_count_additive_event_reports_by_country(
         Optional: Filter by patient age group. Omit this parameter if you don't want ...
     serious : str
         Optional: Filter by event seriousness. Omit this parameter if you don't want ...
+    limit : int
+        Optional: maximum number of ranked terms to return (default 100, which is ope...
     stream_callback : Callable, optional
         Callback for streaming output
     use_cache : bool, default False
@@ -40,7 +43,7 @@ def FAERS_count_additive_event_reports_by_country(
 
     Returns
     -------
-    list[Any]
+    Any
     """
     # Handle mutable defaults to avoid B006 linting error
 
@@ -52,6 +55,7 @@ def FAERS_count_additive_event_reports_by_country(
             "patientsex": patientsex,
             "patientagegroup": patientagegroup,
             "serious": serious,
+            "limit": limit,
         }.items()
         if v is not None
     }

--- a/src/tooluniverse/tools/FAERS_count_additive_reaction_outcomes.py
+++ b/src/tooluniverse/tools/FAERS_count_additive_reaction_outcomes.py
@@ -13,6 +13,7 @@ def FAERS_count_additive_reaction_outcomes(
     patientsex: Optional[str] = None,
     patientagegroup: Optional[str] = None,
     occurcountry: Optional[str] = None,
+    limit: Optional[int] = 100,
     *,
     stream_callback: Optional[Callable[[str], None]] = None,
     use_cache: bool = False,
@@ -31,6 +32,8 @@ def FAERS_count_additive_reaction_outcomes(
 
     occurcountry : str
 
+    limit : int
+        Optional: maximum number of ranked terms to return (default 100, which is ope...
     stream_callback : Callable, optional
         Callback for streaming output
     use_cache : bool, default False
@@ -52,6 +55,7 @@ def FAERS_count_additive_reaction_outcomes(
             "patientsex": patientsex,
             "patientagegroup": patientagegroup,
             "occurcountry": occurcountry,
+            "limit": limit,
         }.items()
         if v is not None
     }

--- a/src/tooluniverse/tools/FAERS_count_additive_reports_by_reporter_country.py
+++ b/src/tooluniverse/tools/FAERS_count_additive_reports_by_reporter_country.py
@@ -13,11 +13,12 @@ def FAERS_count_additive_reports_by_reporter_country(
     patientsex: Optional[str] = None,
     patientagegroup: Optional[str] = None,
     serious: Optional[str] = None,
+    limit: Optional[int] = 100,
     *,
     stream_callback: Optional[Callable[[str], None]] = None,
     use_cache: bool = False,
     validate: bool = True,
-) -> list[Any]:
+) -> Any:
     """
     Aggregate adverse event reports by primary reporter country across medicinal products. Only medic...
 
@@ -31,6 +32,8 @@ def FAERS_count_additive_reports_by_reporter_country(
         Optional: Filter by patient age group. Omit this parameter if you don't want ...
     serious : str
         Optional: Filter by event seriousness. Omit this parameter if you don't want ...
+    limit : int
+        Optional: maximum number of ranked terms to return (default 100, which is ope...
     stream_callback : Callable, optional
         Callback for streaming output
     use_cache : bool, default False
@@ -40,7 +43,7 @@ def FAERS_count_additive_reports_by_reporter_country(
 
     Returns
     -------
-    list[Any]
+    Any
     """
     # Handle mutable defaults to avoid B006 linting error
 
@@ -52,6 +55,7 @@ def FAERS_count_additive_reports_by_reporter_country(
             "patientsex": patientsex,
             "patientagegroup": patientagegroup,
             "serious": serious,
+            "limit": limit,
         }.items()
         if v is not None
     }

--- a/src/tooluniverse/tools/FAERS_count_additive_seriousness_classification.py
+++ b/src/tooluniverse/tools/FAERS_count_additive_seriousness_classification.py
@@ -13,6 +13,7 @@ def FAERS_count_additive_seriousness_classification(
     patientsex: Optional[str] = None,
     patientagegroup: Optional[str] = None,
     occurcountry: Optional[str] = None,
+    limit: Optional[int] = 100,
     *,
     stream_callback: Optional[Callable[[str], None]] = None,
     use_cache: bool = False,
@@ -31,6 +32,8 @@ def FAERS_count_additive_seriousness_classification(
         Optional: Filter by patient age group. Omit this parameter if you don't want ...
     occurcountry : str
         Optional: Filter by country where event occurred (ISO2 code, e.g., 'US', 'GB'...
+    limit : int
+        Optional: maximum number of ranked terms to return (default 100, which is ope...
     stream_callback : Callable, optional
         Callback for streaming output
     use_cache : bool, default False
@@ -52,6 +55,7 @@ def FAERS_count_additive_seriousness_classification(
             "patientsex": patientsex,
             "patientagegroup": patientagegroup,
             "occurcountry": occurcountry,
+            "limit": limit,
         }.items()
         if v is not None
     }

--- a/src/tooluniverse/tools/FAERS_count_country_by_drug_event.py
+++ b/src/tooluniverse/tools/FAERS_count_country_by_drug_event.py
@@ -13,11 +13,12 @@ def FAERS_count_country_by_drug_event(
     patientsex: Optional[str] = None,
     patientagegroup: Optional[str] = None,
     serious: Optional[str] = None,
+    limit: Optional[int] = 100,
     *,
     stream_callback: Optional[Callable[[str], None]] = None,
     use_cache: bool = False,
     validate: bool = True,
-) -> list[Any]:
+) -> Any:
     """
     Count the number of adverse event reports per country of occurrence. Only medicinalproduct is req...
 
@@ -31,6 +32,8 @@ def FAERS_count_country_by_drug_event(
         Optional: Filter by patient age group. Omit this parameter if you don't want ...
     serious : str
         Optional: Filter by event seriousness. Omit this parameter if you don't want ...
+    limit : int
+        Optional: maximum number of ranked terms to return (default 100, which is ope...
     stream_callback : Callable, optional
         Callback for streaming output
     use_cache : bool, default False
@@ -40,7 +43,7 @@ def FAERS_count_country_by_drug_event(
 
     Returns
     -------
-    list[Any]
+    Any
     """
     # Handle mutable defaults to avoid B006 linting error
 
@@ -52,6 +55,7 @@ def FAERS_count_country_by_drug_event(
             "patientsex": patientsex,
             "patientagegroup": patientagegroup,
             "serious": serious,
+            "limit": limit,
         }.items()
         if v is not None
     }

--- a/src/tooluniverse/tools/FAERS_count_death_related_by_drug.py
+++ b/src/tooluniverse/tools/FAERS_count_death_related_by_drug.py
@@ -10,11 +10,12 @@ from ._shared_client import get_shared_client
 
 def FAERS_count_death_related_by_drug(
     medicinalproduct: str,
+    limit: Optional[int] = 100,
     *,
     stream_callback: Optional[Callable[[str], None]] = None,
     use_cache: bool = False,
     validate: bool = True,
-) -> list[Any]:
+) -> Any:
     """
     Count adverse events associated with patient death for a given drug. Only medicinalproduct is req...
 
@@ -22,6 +23,8 @@ def FAERS_count_death_related_by_drug(
     ----------
     medicinalproduct : str
         Drug name.
+    limit : int
+        Optional: maximum number of ranked terms to return (default 100, which is ope...
     stream_callback : Callable, optional
         Callback for streaming output
     use_cache : bool, default False
@@ -31,13 +34,15 @@ def FAERS_count_death_related_by_drug(
 
     Returns
     -------
-    list[Any]
+    Any
     """
     # Handle mutable defaults to avoid B006 linting error
 
     # Strip None values so optional parameters don't trigger schema validation errors
     _args = {
-        k: v for k, v in {"medicinalproduct": medicinalproduct}.items() if v is not None
+        k: v
+        for k, v in {"medicinalproduct": medicinalproduct, "limit": limit}.items()
+        if v is not None
     }
     return get_shared_client().run_one_function(
         {

--- a/src/tooluniverse/tools/FAERS_count_drug_characterization.py
+++ b/src/tooluniverse/tools/FAERS_count_drug_characterization.py
@@ -11,6 +11,7 @@ from ._shared_client import get_shared_client
 def FAERS_count_drug_characterization(
     medicinalproduct: str,
     serious: Optional[str] = None,
+    limit: Optional[int] = 100,
     *,
     stream_callback: Optional[Callable[[str], None]] = None,
     use_cache: bool = False,
@@ -25,6 +26,8 @@ def FAERS_count_drug_characterization(
         Drug name (brand or generic, e.g., 'WARFARIN', 'METFORMIN').
     serious : str
         Optional: Filter by event seriousness. Omit this parameter if you don't want ...
+    limit : int
+        Optional: maximum number of ranked terms to return (default 100, which is ope...
     stream_callback : Callable, optional
         Callback for streaming output
     use_cache : bool, default False
@@ -41,7 +44,11 @@ def FAERS_count_drug_characterization(
     # Strip None values so optional parameters don't trigger schema validation errors
     _args = {
         k: v
-        for k, v in {"medicinalproduct": medicinalproduct, "serious": serious}.items()
+        for k, v in {
+            "medicinalproduct": medicinalproduct,
+            "serious": serious,
+            "limit": limit,
+        }.items()
         if v is not None
     }
     return get_shared_client().run_one_function(

--- a/src/tooluniverse/tools/FAERS_count_drug_routes_by_event.py
+++ b/src/tooluniverse/tools/FAERS_count_drug_routes_by_event.py
@@ -11,11 +11,12 @@ from ._shared_client import get_shared_client
 def FAERS_count_drug_routes_by_event(
     medicinalproduct: str,
     serious: Optional[str] = None,
+    limit: Optional[int] = 100,
     *,
     stream_callback: Optional[Callable[[str], None]] = None,
     use_cache: bool = False,
     validate: bool = True,
-) -> list[Any]:
+) -> Any:
     """
     Count the most common routes of administration for drugs involved in adverse event reports. Only ...
 
@@ -25,6 +26,8 @@ def FAERS_count_drug_routes_by_event(
         Drug name.
     serious : str
         Optional: Filter by event seriousness. Omit this parameter if you don't want ...
+    limit : int
+        Optional: maximum number of ranked terms to return (default 100, which is ope...
     stream_callback : Callable, optional
         Callback for streaming output
     use_cache : bool, default False
@@ -34,14 +37,18 @@ def FAERS_count_drug_routes_by_event(
 
     Returns
     -------
-    list[Any]
+    Any
     """
     # Handle mutable defaults to avoid B006 linting error
 
     # Strip None values so optional parameters don't trigger schema validation errors
     _args = {
         k: v
-        for k, v in {"medicinalproduct": medicinalproduct, "serious": serious}.items()
+        for k, v in {
+            "medicinalproduct": medicinalproduct,
+            "serious": serious,
+            "limit": limit,
+        }.items()
         if v is not None
     }
     return get_shared_client().run_one_function(

--- a/src/tooluniverse/tools/FAERS_count_drugs_by_drug_event.py
+++ b/src/tooluniverse/tools/FAERS_count_drugs_by_drug_event.py
@@ -13,6 +13,7 @@ def FAERS_count_drugs_by_drug_event(
     patientagegroup: Optional[str] = None,
     occurcountry: Optional[str] = None,
     serious: Optional[str] = None,
+    limit: Optional[int] = 100,
     *,
     stream_callback: Optional[Callable[[str], None]] = None,
     use_cache: bool = False,
@@ -31,6 +32,8 @@ def FAERS_count_drugs_by_drug_event(
         Optional: Filter by country where event occurred (ISO2 code, e.g., 'US', 'GB'...
     serious : str
         Optional: Filter by event seriousness. Omit this parameter if you don't want ...
+    limit : int
+        Optional: maximum number of ranked terms to return (default 100, which is ope...
     stream_callback : Callable, optional
         Callback for streaming output
     use_cache : bool, default False
@@ -52,6 +55,7 @@ def FAERS_count_drugs_by_drug_event(
             "patientagegroup": patientagegroup,
             "occurcountry": occurcountry,
             "serious": serious,
+            "limit": limit,
         }.items()
         if v is not None
     }

--- a/src/tooluniverse/tools/FAERS_count_indications_by_drug.py
+++ b/src/tooluniverse/tools/FAERS_count_indications_by_drug.py
@@ -11,6 +11,7 @@ from ._shared_client import get_shared_client
 def FAERS_count_indications_by_drug(
     medicinalproduct: str,
     serious: Optional[str] = None,
+    limit: Optional[int] = 100,
     *,
     stream_callback: Optional[Callable[[str], None]] = None,
     use_cache: bool = False,
@@ -25,6 +26,8 @@ def FAERS_count_indications_by_drug(
         Drug name (brand or generic, e.g., 'WARFARIN', 'METFORMIN').
     serious : str
         Optional: Filter by event seriousness. Omit this parameter if you don't want ...
+    limit : int
+        Optional: maximum number of ranked terms to return (default 100, which is ope...
     stream_callback : Callable, optional
         Callback for streaming output
     use_cache : bool, default False
@@ -41,7 +44,11 @@ def FAERS_count_indications_by_drug(
     # Strip None values so optional parameters don't trigger schema validation errors
     _args = {
         k: v
-        for k, v in {"medicinalproduct": medicinalproduct, "serious": serious}.items()
+        for k, v in {
+            "medicinalproduct": medicinalproduct,
+            "serious": serious,
+            "limit": limit,
+        }.items()
         if v is not None
     }
     return get_shared_client().run_one_function(

--- a/src/tooluniverse/tools/FAERS_count_outcomes_by_drug_event.py
+++ b/src/tooluniverse/tools/FAERS_count_outcomes_by_drug_event.py
@@ -13,6 +13,7 @@ def FAERS_count_outcomes_by_drug_event(
     patientsex: Optional[str] = None,
     patientagegroup: Optional[str] = None,
     occurcountry: Optional[str] = None,
+    limit: Optional[int] = 100,
     *,
     stream_callback: Optional[Callable[[str], None]] = None,
     use_cache: bool = False,
@@ -31,6 +32,8 @@ def FAERS_count_outcomes_by_drug_event(
 
     occurcountry : str
 
+    limit : int
+        Optional: maximum number of ranked terms to return (default 100, which is ope...
     stream_callback : Callable, optional
         Callback for streaming output
     use_cache : bool, default False
@@ -52,6 +55,7 @@ def FAERS_count_outcomes_by_drug_event(
             "patientsex": patientsex,
             "patientagegroup": patientagegroup,
             "occurcountry": occurcountry,
+            "limit": limit,
         }.items()
         if v is not None
     }

--- a/src/tooluniverse/tools/FAERS_count_patient_age_distribution.py
+++ b/src/tooluniverse/tools/FAERS_count_patient_age_distribution.py
@@ -10,11 +10,12 @@ from ._shared_client import get_shared_client
 
 def FAERS_count_patient_age_distribution(
     medicinalproduct: str,
+    limit: Optional[int] = 100,
     *,
     stream_callback: Optional[Callable[[str], None]] = None,
     use_cache: bool = False,
     validate: bool = True,
-) -> list[Any]:
+) -> Any:
     """
     Analyze the age distribution of patients experiencing adverse events for a specific drug. Only me...
 
@@ -22,6 +23,8 @@ def FAERS_count_patient_age_distribution(
     ----------
     medicinalproduct : str
         Drug name.
+    limit : int
+        Optional: maximum number of ranked terms to return (default 100, which is ope...
     stream_callback : Callable, optional
         Callback for streaming output
     use_cache : bool, default False
@@ -31,13 +34,15 @@ def FAERS_count_patient_age_distribution(
 
     Returns
     -------
-    list[Any]
+    Any
     """
     # Handle mutable defaults to avoid B006 linting error
 
     # Strip None values so optional parameters don't trigger schema validation errors
     _args = {
-        k: v for k, v in {"medicinalproduct": medicinalproduct}.items() if v is not None
+        k: v
+        for k, v in {"medicinalproduct": medicinalproduct, "limit": limit}.items()
+        if v is not None
     }
     return get_shared_client().run_one_function(
         {

--- a/src/tooluniverse/tools/FAERS_count_reactions_by_drug_event.py
+++ b/src/tooluniverse/tools/FAERS_count_reactions_by_drug_event.py
@@ -16,6 +16,7 @@ def FAERS_count_reactions_by_drug_event(
     serious: Optional[str] = None,
     seriousnessdeath: Optional[str] = None,
     reactionmeddraverse: Optional[str] = None,
+    limit: Optional[int] = 100,
     *,
     stream_callback: Optional[Callable[[str], None]] = None,
     use_cache: bool = False,
@@ -40,6 +41,8 @@ def FAERS_count_reactions_by_drug_event(
         Optional: Pass 'Yes' to filter for reports where death was an outcome. Omit t...
     reactionmeddraverse : str
         Optional: Filter by MedDRA reaction term (Lowest Level Term). When omitted, r...
+    limit : int
+        Optional: maximum number of ranked terms to return (default 100, which is ope...
     stream_callback : Callable, optional
         Callback for streaming output
     use_cache : bool, default False
@@ -64,6 +67,7 @@ def FAERS_count_reactions_by_drug_event(
             "serious": serious,
             "seriousnessdeath": seriousnessdeath,
             "reactionmeddraverse": reactionmeddraverse,
+            "limit": limit,
         }.items()
         if v is not None
     }

--- a/src/tooluniverse/tools/FAERS_count_reporter_qualification.py
+++ b/src/tooluniverse/tools/FAERS_count_reporter_qualification.py
@@ -11,6 +11,7 @@ from ._shared_client import get_shared_client
 def FAERS_count_reporter_qualification(
     medicinalproduct: str,
     serious: Optional[str] = None,
+    limit: Optional[int] = 100,
     *,
     stream_callback: Optional[Callable[[str], None]] = None,
     use_cache: bool = False,
@@ -25,6 +26,8 @@ def FAERS_count_reporter_qualification(
         Drug name (brand or generic, e.g., 'WARFARIN', 'METFORMIN').
     serious : str
         Optional: Filter by event seriousness. Omit this parameter if you don't want ...
+    limit : int
+        Optional: maximum number of ranked terms to return (default 100, which is ope...
     stream_callback : Callable, optional
         Callback for streaming output
     use_cache : bool, default False
@@ -41,7 +44,11 @@ def FAERS_count_reporter_qualification(
     # Strip None values so optional parameters don't trigger schema validation errors
     _args = {
         k: v
-        for k, v in {"medicinalproduct": medicinalproduct, "serious": serious}.items()
+        for k, v in {
+            "medicinalproduct": medicinalproduct,
+            "serious": serious,
+            "limit": limit,
+        }.items()
         if v is not None
     }
     return get_shared_client().run_one_function(

--- a/src/tooluniverse/tools/FAERS_count_reportercountry_by_drug_event.py
+++ b/src/tooluniverse/tools/FAERS_count_reportercountry_by_drug_event.py
@@ -13,11 +13,12 @@ def FAERS_count_reportercountry_by_drug_event(
     patientsex: Optional[str] = None,
     patientagegroup: Optional[str] = None,
     serious: Optional[str] = None,
+    limit: Optional[int] = 100,
     *,
     stream_callback: Optional[Callable[[str], None]] = None,
     use_cache: bool = False,
     validate: bool = True,
-) -> list[Any]:
+) -> Any:
     """
     Count the number of FDA adverse event reports grouped by the country of the primary reporter. Onl...
 
@@ -31,6 +32,8 @@ def FAERS_count_reportercountry_by_drug_event(
         Optional: Filter by patient age group. Omit this parameter if you don't want ...
     serious : str
         Optional: Filter by event seriousness. Omit this parameter if you don't want ...
+    limit : int
+        Optional: maximum number of ranked terms to return (default 100, which is ope...
     stream_callback : Callable, optional
         Callback for streaming output
     use_cache : bool, default False
@@ -40,7 +43,7 @@ def FAERS_count_reportercountry_by_drug_event(
 
     Returns
     -------
-    list[Any]
+    Any
     """
     # Handle mutable defaults to avoid B006 linting error
 
@@ -52,6 +55,7 @@ def FAERS_count_reportercountry_by_drug_event(
             "patientsex": patientsex,
             "patientagegroup": patientagegroup,
             "serious": serious,
+            "limit": limit,
         }.items()
         if v is not None
     }

--- a/src/tooluniverse/tools/FAERS_count_seriousness_by_drug_event.py
+++ b/src/tooluniverse/tools/FAERS_count_seriousness_by_drug_event.py
@@ -13,6 +13,7 @@ def FAERS_count_seriousness_by_drug_event(
     patientsex: Optional[str] = None,
     patientagegroup: Optional[str] = None,
     occurcountry: Optional[str] = None,
+    limit: Optional[int] = 100,
     *,
     stream_callback: Optional[Callable[[str], None]] = None,
     use_cache: bool = False,
@@ -31,6 +32,8 @@ def FAERS_count_seriousness_by_drug_event(
         Optional: Filter by patient age group. Omit this parameter if you don't want ...
     occurcountry : str
         Optional: Filter by country where event occurred (ISO2 code, e.g., 'US', 'GB'...
+    limit : int
+        Optional: maximum number of ranked terms to return (default 100, which is ope...
     stream_callback : Callable, optional
         Callback for streaming output
     use_cache : bool, default False
@@ -52,6 +55,7 @@ def FAERS_count_seriousness_by_drug_event(
             "patientsex": patientsex,
             "patientagegroup": patientagegroup,
             "occurcountry": occurcountry,
+            "limit": limit,
         }.items()
         if v is not None
     }

--- a/src/tooluniverse/tools/FDA_get_drug_label.py
+++ b/src/tooluniverse/tools/FDA_get_drug_label.py
@@ -10,6 +10,7 @@ from ._shared_client import get_shared_client
 
 def FDA_get_drug_label(
     drug_name: str,
+    max_section_chars: Optional[int | Any] = None,
     *,
     stream_callback: Optional[Callable[[str], None]] = None,
     use_cache: bool = False,
@@ -22,6 +23,8 @@ def FDA_get_drug_label(
     ----------
     drug_name : str
         Brand or generic drug name (e.g., 'warfarin', 'Eliquis', 'apixaban', 'atorvas...
+    max_section_chars : int | Any
+        Maximum characters returned per clinical section (default: 25000, 0 = no limi...
     stream_callback : Callable, optional
         Callback for streaming output
     use_cache : bool, default False
@@ -36,7 +39,14 @@ def FDA_get_drug_label(
     # Handle mutable defaults to avoid B006 linting error
 
     # Strip None values so optional parameters don't trigger schema validation errors
-    _args = {k: v for k, v in {"drug_name": drug_name}.items() if v is not None}
+    _args = {
+        k: v
+        for k, v in {
+            "drug_name": drug_name,
+            "max_section_chars": max_section_chars,
+        }.items()
+        if v is not None
+    }
     return get_shared_client().run_one_function(
         {
             "name": "FDA_get_drug_label",

--- a/src/tooluniverse/tools/FDA_search_drug_labels.py
+++ b/src/tooluniverse/tools/FDA_search_drug_labels.py
@@ -12,6 +12,7 @@ def FDA_search_drug_labels(
     limit: int,
     drug_name: Optional[str | Any] = None,
     indication: Optional[str | Any] = None,
+    max_section_chars: Optional[int | Any] = None,
     *,
     stream_callback: Optional[Callable[[str], None]] = None,
     use_cache: bool = False,
@@ -28,6 +29,8 @@ def FDA_search_drug_labels(
         Medical condition to search in indications sections (e.g., 'hypertension', 't...
     limit : int
         Maximum number of results to return (default: 5, max: 20)
+    max_section_chars : int | Any
+        Maximum characters returned per clinical section (default: 2000, 0 = no limit...
     stream_callback : Callable, optional
         Callback for streaming output
     use_cache : bool, default False
@@ -48,6 +51,7 @@ def FDA_search_drug_labels(
             "drug_name": drug_name,
             "indication": indication,
             "limit": limit,
+            "max_section_chars": max_section_chars,
         }.items()
         if v is not None
     }

--- a/src/tooluniverse/tools/ols_search_terms.py
+++ b/src/tooluniverse/tools/ols_search_terms.py
@@ -38,7 +38,7 @@ def ols_search_terms(
     ontology : str
         Filter by specific ontology (optional)
     exact_match : bool
-        Search for exact matches only (default: false)
+        Restrict results to exact matches (default: false). The query must equal a te...
     include_obsolete : bool
         Include obsolete terms (default: false)
     limit : int | Any

--- a/tests/unit/test_auto_operation_not_blamed_on_caller.py
+++ b/tests/unit/test_auto_operation_not_blamed_on_caller.py
@@ -1,0 +1,192 @@
+"""Regression guard for Feature-26A-8: the framework injected an `operation`
+parameter and then blamed the caller for it.
+
+`ToolUniverse._apply_operation_default` fills `operation` into `arguments` from
+the tool's own config before validation, because many single-operation
+registrations still read `arguments["operation"]`. Validation treated that
+injected key as caller-supplied, so
+`Pharos_get_target_expression {"target": "EGFR"}` was answered with
+"Unrecognized parameter(s): 'target', 'operation'" -- naming a parameter the
+caller never sent and cannot remove.
+
+The auto-supplied value is now recognized (it is exactly what the config would
+have supplied) and left out of both the message and
+`details["unknown_parameters"]`, while a caller-supplied `operation` saying
+anything else is still reported. Leaving it out of the argument set the
+unknown-key check sees also keeps the Feature-14A-01 total-mismatch guard
+honest: the injected key must pad neither the "recognized" side (for the 348
+configs that declare `operation`) nor the "unknown" side (for the 235 that do
+not).
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tooluniverse.base_tool import BaseTool, resolve_configured_operation
+
+pytestmark = pytest.mark.unit
+
+_DATA_DIR = Path(__file__).parent.parent.parent / "src" / "tooluniverse" / "data"
+
+# A tool class that reads its operation from the config, so the schema never
+# declares `operation` -- the shape that produced the reported message.
+_PHAROS_TOOL = "Pharos_get_target_expression"
+
+# The other shape in the corpus: `operation` declared as a schema property.
+_DECLARED_OPERATION_CONFIG = {
+    "name": "Fake_declared_operation_tool",
+    "parameter": {
+        "type": "object",
+        "properties": {
+            "operation": {"type": "string"},
+            "query": {"type": "string"},
+        },
+        "required": [],
+    },
+    "fields": {"operation": "search"},
+}
+
+
+def _config(name, filename):
+    configs = json.loads((_DATA_DIR / filename).read_text())
+    for cfg in configs:
+        if cfg["name"] == name:
+            return cfg
+    raise AssertionError(f"{name} not found in {filename}")
+
+
+def _pharos_tool():
+    return BaseTool(_config(_PHAROS_TOOL, "pharos_tools.json"))
+
+
+class TestConfiguredOperationResolution:
+    def test_reads_fields_operation(self):
+        assert (
+            resolve_configured_operation(_config(_PHAROS_TOOL, "pharos_tools.json"))
+            == "get_target_expression"
+        )
+
+    def test_falls_back_to_schema_default(self):
+        cfg = {
+            "parameter": {"properties": {"operation": {"default": "search"}}},
+        }
+        assert resolve_configured_operation(cfg) == "search"
+
+    def test_returns_none_when_no_operation_is_configured(self):
+        assert resolve_configured_operation({"parameter": {"properties": {}}}) is None
+
+
+class TestAutoSuppliedOperationIsNotBlamed:
+    """The injected key must never look caller-supplied."""
+
+    def test_message_names_only_the_caller_supplied_key(self):
+        error = _pharos_tool().validate_parameters(
+            {"target": "EGFR", "operation": "get_target_expression"}
+        )
+
+        assert error is not None
+        assert "'target'" in str(error)
+        assert "operation" not in str(error)
+        # The corrective half of the message must survive.
+        assert "This tool accepts: gene, uniprot." in str(error)
+
+    def test_details_do_not_list_the_injected_key(self):
+        error = _pharos_tool().validate_parameters(
+            {"target": "EGFR", "operation": "get_target_expression"}
+        )
+
+        assert error.details["unknown_parameters"] == ["target"]
+
+    def test_valid_call_with_injected_operation_still_validates(self):
+        assert (
+            _pharos_tool().validate_parameters(
+                {"gene": "EGFR", "operation": "get_target_expression"}
+            )
+            is None
+        )
+
+    def test_injected_operation_alone_is_not_reported(self):
+        assert (
+            _pharos_tool().validate_parameters({"operation": "get_target_expression"})
+            is None
+        )
+
+
+class TestCallerSuppliedOperationIsStillReported:
+    """A genuinely wrong `operation` from the caller must still be named."""
+
+    def test_bogus_operation_is_rejected(self):
+        error = _pharos_tool().validate_parameters({"operation": "totally_bogus"})
+
+        assert error is not None
+        assert "'operation'" in str(error)
+        assert error.details["unknown_parameters"] == ["operation"]
+
+    def test_bogus_operation_is_reported_even_though_a_default_exists(self):
+        # The tool has fields.operation set; only the *matching* value is
+        # treated as auto-supplied.
+        error = _pharos_tool().validate_parameters(
+            {"operation": "get_target_expression_v2"}
+        )
+
+        assert error is not None
+        assert "'operation'" in str(error)
+
+
+class TestTotalMismatchGuardNotWeakened:
+    """Feature-14A-01: a fully unrecognized parameter set must be rejected."""
+
+    def test_guard_fires_when_operation_is_declared_in_the_schema(self):
+        tool = BaseTool(_DECLARED_OPERATION_CONFIG)
+
+        error = tool.validate_parameters(
+            {"zzz_bogus": "x", "operation": "search"}  # operation auto-supplied
+        )
+
+        assert error is not None
+        assert "'zzz_bogus'" in str(error)
+        assert error.details["unknown_parameters"] == ["zzz_bogus"]
+
+    def test_guard_fires_when_operation_is_not_declared(self):
+        error = _pharos_tool().validate_parameters(
+            {"target": "EGFR", "operation": "get_target_expression"}
+        )
+
+        assert error is not None
+
+    def test_recognized_parameter_mixed_with_the_injected_key_is_accepted(self):
+        tool = BaseTool(_DECLARED_OPERATION_CONFIG)
+
+        assert (
+            tool.validate_parameters({"query": "kinase", "operation": "search"}) is None
+        )
+
+
+class TestInjectionItselfIsUnchanged:
+    """Only the reporting changes -- tool classes that read
+    arguments["operation"] must keep receiving it."""
+
+    def test_operation_is_still_injected_before_the_tool_runs(self):
+        from tooluniverse import ToolUniverse
+
+        engine = ToolUniverse()
+        engine.load_tools(tool_type=["pharos"])
+
+        args = {"gene": "EGFR"}
+        engine._apply_operation_default(_PHAROS_TOOL, args)
+
+        assert args["operation"] == "get_target_expression"
+
+    def test_end_to_end_message_does_not_name_the_injected_key(self):
+        from tooluniverse import ToolUniverse
+
+        engine = ToolUniverse()
+        engine.load_tools(tool_type=["pharos"])
+
+        result = engine.run({"name": _PHAROS_TOOL, "arguments": {"target": "EGFR"}})
+
+        assert result["status"] == "error"
+        assert "operation" not in result["error"]
+        assert result["error_details"]["details"]["unknown_parameters"] == ["target"]

--- a/tests/unit/test_civic_gene_prefixed_variant_name.py
+++ b/tests/unit/test_civic_gene_prefixed_variant_name.py
@@ -1,0 +1,263 @@
+"""Unit test: CIViC must not lose the curated record for gene-prefixed spellings.
+
+Regression: clinical writing joins the gene symbol and the variant designation
+into one token ("EGFRvIII", "BRAFV600E", "KRASG12C"), but CIViC stores the
+variant under the bare designation ("VIII") and names its molecular profile
+"<GENE> <designation>" ("EGFR VIII"). Every CIViC name filter is a
+case-insensitive *substring* match, so the joined spelling could only ever reach
+a differently-named record: `variant_name="EGFRvIII"` returned exactly one node
+— an empty duplicate stub (id 1516, molecularProfileScore 0.0) — while the
+curated record (id 312, "VIII", score 69.0, with variantTypes and
+hgvsDescriptions) was silently dropped, and
+`molecular_profile="EGFRvIII"` returned 1 of 6 evidence items.
+
+The tool now also queries the gene-stripped designation whenever (and only
+when) the input carries a gene prefix, merges both result sets de-duplicated by
+id, and discloses the expansion in `normalization_note`.
+"""
+
+import glob
+import json
+from unittest.mock import patch
+
+import pytest
+
+from tooluniverse.civic_tool import CIViCTool, _split_gene_prefixed_name
+
+
+def _load(name):
+    for f in glob.glob("src/tooluniverse/data/*.json"):
+        try:
+            data = json.load(open(f))
+        except ValueError:
+            continue
+        if isinstance(data, list):
+            for tool in data:
+                if isinstance(tool, dict) and tool.get("name") == name:
+                    return tool
+    raise AssertionError(f"tool config not found: {name}")
+
+
+class _Resp:
+    """Minimal stand-in for a requests.Response carrying a GraphQL payload."""
+
+    status_code = 200
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        pass
+
+
+# --------------------------------------------------------------------------
+# The split heuristic itself: general, no per-entity special cases.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("EGFRvIII", ("EGFR", "vIII")),
+        ("BRAFV600E", ("BRAF", "V600E")),
+        ("KRASG12C", ("KRAS", "G12C")),
+        ("TP53R175H", ("TP53", "R175H")),
+        ("ERBB2V777L", ("ERBB2", "V777L")),
+    ],
+)
+def test_gene_prefixed_spellings_split(name, expected):
+    assert _split_gene_prefixed_name(name) == expected
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "name",
+    [
+        "BRAF V600E",  # already separated — CIViC matches it natively
+        "EGFR VIII",
+        "V600E",  # bare designation, no gene prefix
+        "T790M",
+        "ERBB2",  # a gene symbol carrying digits must never split
+        "TP53",
+        "EGFR",
+        "EGFR Amplification",
+        "BCR::ABL1 Fusion",
+    ],
+)
+def test_non_prefixed_input_does_not_split(name):
+    assert _split_gene_prefixed_name(name) is None
+
+
+@pytest.mark.unit
+def test_named_gene_makes_the_prefix_authoritative():
+    assert _split_gene_prefixed_name("EGFRvIII", "EGFR") == ("EGFR", "vIII")
+    assert _split_gene_prefixed_name("EGFR-vIII", "EGFR") == ("EGFR", "vIII")
+    # Variant that does not start with the named gene is left alone.
+    assert _split_gene_prefixed_name("L858R", "EGFR") is None
+    # Gene symbol on its own leaves no designation behind.
+    assert _split_gene_prefixed_name("EGFR", "EGFR") is None
+
+
+# --------------------------------------------------------------------------
+# civic_search_variants: gene_name + gene-prefixed variant_name
+# --------------------------------------------------------------------------
+
+_EGFR_VARIANTS = [
+    {"id": 1516, "name": "EGFRVIII", "feature": {"id": 19, "name": "EGFR"}},
+    {"id": 312, "name": "VIII", "feature": {"id": 19, "name": "EGFR"}},
+    {"id": 33, "name": "L858R", "feature": {"id": 19, "name": "EGFR"}},
+]
+
+_BRAF_VARIANTS = [
+    {"id": 12, "name": "V600E", "feature": {"id": 5, "name": "BRAF"}},
+    {"id": 704, "name": "V600E+V600K", "feature": {"id": 5, "name": "BRAF"}},
+    {"id": 250, "name": "AMPLIFICATION", "feature": {"id": 5, "name": "BRAF"}},
+]
+
+
+def _variants_transport(gene_id, gene_name, variants, calls):
+    """Serve the gene-id lookup and the gene-variants page from a fixture."""
+
+    def _post(url, json=None, **kwargs):
+        calls.append(json)
+        query = (json or {}).get("query", "")
+        if "genes(entrezSymbols" in query:
+            return _Resp(
+                {"data": {"genes": {"nodes": [{"id": gene_id, "name": gene_name}]}}}
+            )
+        return _Resp(
+            {
+                "data": {
+                    "gene": {
+                        "id": gene_id,
+                        "name": gene_name,
+                        "variants": {
+                            "nodes": list(variants),
+                            "pageInfo": {"hasNextPage": False, "endCursor": None},
+                        },
+                    }
+                }
+            }
+        )
+
+    return _post
+
+
+@pytest.mark.unit
+def test_gene_prefixed_variant_name_returns_bare_designation_record():
+    calls = []
+    tool = CIViCTool(_load("civic_search_variants"))
+    with patch(
+        "tooluniverse.civic_tool.requests.post",
+        side_effect=_variants_transport(19, "EGFR", _EGFR_VARIANTS, calls),
+    ):
+        result = tool.run({"gene_name": "EGFR", "variant_name": "EGFRvIII"})
+
+    nodes = result["data"]["gene"]["variants"]["nodes"]
+    ids = [n["id"] for n in nodes]
+    # The curated record stored under the bare designation is no longer dropped...
+    assert 312 in ids
+    # ...and the same-spelled duplicate is still returned, not silently replaced.
+    assert 1516 in ids
+    # Unrelated variants of the same gene stay filtered out.
+    assert 33 not in ids
+    # The union is disclosed: both spellings are named.
+    note = result.get("normalization_note", "")
+    assert "EGFRvIII" in note and "vIII" in note
+    assert "merged" in note
+
+
+@pytest.mark.unit
+def test_non_prefixed_variant_name_is_unchanged_and_costs_no_extra_query():
+    calls = []
+    tool = CIViCTool(_load("civic_search_variants"))
+    with patch(
+        "tooluniverse.civic_tool.requests.post",
+        side_effect=_variants_transport(5, "BRAF", _BRAF_VARIANTS, calls),
+    ):
+        result = tool.run({"gene_name": "BRAF", "variant_name": "V600E"})
+
+    ids = [n["id"] for n in result["data"]["gene"]["variants"]["nodes"]]
+    assert ids == [12, 704]
+    assert "normalization_note" not in result
+    # Exactly the gene-id lookup + one variants page: no speculative extra call.
+    assert len(calls) == 2
+
+
+# --------------------------------------------------------------------------
+# civic_search_evidence_items: gene-prefixed molecular_profile
+# --------------------------------------------------------------------------
+
+
+def _evidence_item(item_id, profile_name):
+    return {
+        "id": item_id,
+        "description": "",
+        "evidenceType": "PREDICTIVE",
+        "significance": "SENSITIVITYRESPONSE",
+        "status": "ACCEPTED",
+        "disease": {"name": "Glioblastoma"},
+        "therapies": [],
+        "molecularProfile": {"id": 400, "name": profile_name},
+    }
+
+
+def _evidence_transport(by_profile, calls):
+    def _post(url, json=None, **kwargs):
+        profile = (json or {}).get("variables", {}).get("molecularProfileName")
+        calls.append(profile)
+        return _Resp(
+            {"data": {"evidenceItems": {"nodes": list(by_profile.get(profile, []))}}}
+        )
+
+    return _post
+
+
+@pytest.mark.unit
+def test_gene_prefixed_molecular_profile_surfaces_the_full_evidence_set():
+    calls = []
+    by_profile = {
+        # The joined spelling reaches only a compound profile — 1 plausible item.
+        "EGFRvIII": [_evidence_item(773, "EGFR Amplification AND EGFR EGFRVIII")],
+        # CIViC's actual profile name holds the rest.
+        "EGFR vIII": [
+            _evidence_item(i, "EGFR VIII") for i in (772, 848, 971, 1017, 1128, 4500)
+        ],
+    }
+    tool = CIViCTool(_load("civic_search_evidence_items"))
+    with patch(
+        "tooluniverse.civic_tool.requests.post",
+        side_effect=_evidence_transport(by_profile, calls),
+    ):
+        result = tool.run({"molecular_profile": "EGFRvIII", "limit": 20})
+
+    ids = [n["id"] for n in result["data"]["evidenceItems"]["nodes"]]
+    assert {971, 1128, 772}.issubset(set(ids))
+    # Nothing found under the caller's own spelling is dropped either.
+    assert 773 in ids
+    assert len(ids) == len(set(ids)) == 7
+    note = result.get("normalization_note", "")
+    assert "EGFRvIII" in note and "EGFR vIII" in note
+    assert "merged" in note
+    # Exactly one extra round-trip, and only because the prefix condition held.
+    assert calls == ["EGFRvIII", "EGFR vIII"]
+
+
+@pytest.mark.unit
+def test_separated_molecular_profile_makes_a_single_query():
+    calls = []
+    by_profile = {"BRAF V600E": [_evidence_item(1409, "BRAF V600E")]}
+    tool = CIViCTool(_load("civic_search_evidence_items"))
+    with patch(
+        "tooluniverse.civic_tool.requests.post",
+        side_effect=_evidence_transport(by_profile, calls),
+    ):
+        result = tool.run({"molecular_profile": "BRAF V600E", "limit": 5})
+
+    assert [n["id"] for n in result["data"]["evidenceItems"]["nodes"]] == [1409]
+    assert "normalization_note" not in result
+    assert calls == ["BRAF V600E"]

--- a/tests/unit/test_cpic_pairs_url_reflects_filters.py
+++ b/tests/unit/test_cpic_pairs_url_reflects_filters.py
@@ -1,0 +1,102 @@
+"""Regression guard for Feature-26C-4: CPIC_search_gene_drug_pairs advertised a
+provenance `url` that did not reproduce its own result.
+
+The tool's PostgREST filters (`genesymbol=eq.HLA-B`, `cpiclevel=eq.A`, `limit`)
+travel as request query params, but the reported `url` was the bare endpoint
+template. Confirmed live that `{"gene": "HLA-B"}` (13 rows) and `{}` (635 rows)
+returned a byte-identical url, and that pasting it returns all 635 rows -- so a
+caller spot-checking provenance concludes the gene filter was ignored. The url
+is now taken from the response requests actually issued, so it cannot drift
+from the params used to build the request.
+"""
+
+import json
+import unittest.mock as mock
+from pathlib import Path
+
+import pytest
+import requests
+
+from tooluniverse.cpic_search_pairs_tool import CPICSearchPairsTool
+
+pytestmark = pytest.mark.unit
+
+_DATA_DIR = Path(__file__).parent.parent.parent / "src" / "tooluniverse" / "data"
+
+_ROWS = [
+    {"genesymbol": "HLA-B", "drugid": "RxNorm:190521", "cpiclevel": "A"},
+    {"genesymbol": "HLA-B", "drugid": "RxNorm:2002", "cpiclevel": "A"},
+]
+
+
+def _tool_config(name):
+    configs = json.loads((_DATA_DIR / "cpic_tools.json").read_text())
+    for cfg in configs:
+        if cfg["name"] == name:
+            return cfg
+    raise AssertionError(f"{name} not found in cpic_tools.json")
+
+
+def _run(name, arguments):
+    """Run the tool with the HTTP layer replaced, returning (result, sent_url).
+
+    The fake response's `url` is built with requests' own preparation step, so
+    it is exactly the URL a real request would have carried.
+    """
+    tool = CPICSearchPairsTool(_tool_config(name))
+    sent = {}
+
+    def fake_request(session, method, url, params=None, **kwargs):
+        prepared = requests.Request(method, url, params=params).prepare()
+        sent["url"] = prepared.url
+        response = mock.MagicMock()
+        response.status_code = 200
+        response.url = prepared.url
+        response.json.return_value = _ROWS
+        response.text = json.dumps(_ROWS)
+        response.headers = {"content-type": "application/json"}
+        return response
+
+    with mock.patch(
+        "tooluniverse.base_rest_tool.request_with_retry", side_effect=fake_request
+    ):
+        result = tool.run(arguments)
+    return result, sent["url"]
+
+
+class TestReportedUrlIsTheRequestedUrl:
+    def test_gene_filter_appears_in_reported_url(self):
+        result, sent_url = _run("CPIC_search_gene_drug_pairs", {"gene": "HLA-B"})
+
+        assert result["status"] == "success"
+        assert result["url"] == sent_url
+        assert "genesymbol=eq.HLA-B" in result["url"]
+
+    def test_filtered_and_unfiltered_urls_differ(self):
+        # The failure this guards: two different answers advertising the same
+        # provenance url.
+        filtered, _ = _run("CPIC_search_gene_drug_pairs", {"gene": "HLA-B"})
+        unfiltered, _ = _run("CPIC_search_gene_drug_pairs", {})
+
+        assert filtered["url"] != unfiltered["url"]
+        assert "genesymbol=" not in unfiltered["url"]
+
+    def test_level_and_limit_filters_appear_in_reported_url(self):
+        result, sent_url = _run(
+            "CPIC_search_gene_drug_pairs", {"cpiclevel": "A", "limit": 10}
+        )
+
+        assert result["url"] == sent_url
+        assert "cpiclevel=eq.A" in result["url"]
+        assert "limit=10" in result["url"]
+
+    def test_select_clause_is_still_reported(self):
+        result, _ = _run("CPIC_search_gene_drug_pairs", {"gene": "HLA-B"})
+
+        assert "select=" in result["url"]
+
+    def test_sibling_tool_on_the_same_class_also_reports_its_filter(self):
+        result, sent_url = _run("CPIC_get_gene_drug_pairs", {"gene": "CYP2D6"})
+
+        assert result["url"] == sent_url
+        assert "genesymbol=eq.CYP2D6" in result["url"]

--- a/tests/unit/test_faers_count_truncation_disclosure.py
+++ b/tests/unit/test_faers_count_truncation_disclosure.py
@@ -1,0 +1,322 @@
+"""FAERS count tools must never present a truncated ranking as the complete set.
+
+openFDA answers a ``count=`` aggregation with only its most frequent values --
+100 rows when no ``limit`` is sent -- and its ``meta`` block carries no total, so
+a caller has no way to tell a complete ranking from a clipped one. The tools
+used to return that bare 100-row list while their descriptions promised "all"
+adverse reactions, which turns any term ranked below 100th into a confident
+false negative ("not reported for this drug").
+
+The contract pinned here:
+  * the response is an object with a top-level ``truncated`` flag,
+    ``result_count`` matching ``len(results)`` and the applied ``limit``;
+  * ``truncation_note`` appears only when the ranking really is clipped, and
+    names the parameter that retrieves more;
+  * a query whose full ranking fits inside the limit is NOT flagged.
+
+No network: the openFDA HTTP call is mocked throughout.
+"""
+
+import json
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+pytestmark = pytest.mark.unit
+
+_JSON_PATH = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "..",
+    "src",
+    "tooluniverse",
+    "data",
+    "fda_drug_adverse_event_tools.json",
+)
+
+
+def _load_config(tool_name):
+    with open(_JSON_PATH) as fh:
+        configs = json.load(fh)
+    for cfg in configs:
+        if cfg.get("name") == tool_name:
+            return cfg
+    raise AssertionError(f"tool config not found: {tool_name}")
+
+
+def _make_tool(tool_name="FAERS_count_reactions_by_drug_event"):
+    from tooluniverse.openfda_adv_tool import FDADrugAdverseEventTool
+
+    # api_key is passed explicitly so a developer's FDA_API_KEY does not change
+    # the anonymous ceiling these tests assert against.
+    return FDADrugAdverseEventTool(_load_config(tool_name), api_key=None)
+
+
+def _make_additive_tool(tool_name="FAERS_count_additive_adverse_reactions"):
+    from tooluniverse.openfda_adv_tool import FDACountAdditiveReactionsTool
+
+    return FDACountAdditiveReactionsTool(_load_config(tool_name))
+
+
+def _rows(n, start=1000):
+    """n synthetic term/count rows in descending-count order."""
+    return [{"term": f"REACTION {i}", "count": start - i} for i in range(n)]
+
+
+def _response(rows):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {"results": rows}
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+class TestTruncationDisclosure(unittest.TestCase):
+    def test_clipped_ranking_is_flagged_and_explains_how_to_get_more(self):
+        """More terms than the limit -> truncated flag + actionable note."""
+        tool = _make_tool()
+        # openFDA is asked for limit+1 rows; getting all 101 back proves there
+        # is at least one term past the caller's page.
+        with patch(
+            "tooluniverse.openfda_adv_tool.requests.get",
+            return_value=_response(_rows(101)),
+        ) as get:
+            out = tool.run({"medicinalproduct": "TACROLIMUS"})
+            url = get.call_args.args[0]
+
+        self.assertIsInstance(out, dict)
+        self.assertTrue(out["truncated"])
+        self.assertEqual(out["limit"], 100)
+        self.assertEqual(out["result_count"], 100)
+        self.assertEqual(out["result_count"], len(out["results"]))
+        # The probe row must not leak into the caller's page.
+        self.assertEqual(out["results"][-1]["term"], "REACTION 99")
+
+        note = out["truncation_note"]
+        self.assertIn("limit", note)
+        self.assertIn("100", note)
+        self.assertIn("1000", note)  # the documented maximum
+        self.assertIn("NOT evidence", note)
+
+        # limit rides after count= so it can never be read as a search clause.
+        self.assertIn("&limit=101", url)
+        self.assertNotIn("limit", url.split("count=")[0])
+
+    def test_complete_ranking_is_not_flagged(self):
+        """Fewer terms than the limit -> no truncation flag, no note."""
+        tool = _make_tool()
+        with patch(
+            "tooluniverse.openfda_adv_tool.requests.get",
+            return_value=_response(_rows(12)),
+        ):
+            out = tool.run({"medicinalproduct": "SOME RARE DRUG"})
+
+        self.assertFalse(out["truncated"])
+        self.assertNotIn("truncation_note", out)
+        self.assertEqual(out["result_count"], 12)
+        self.assertEqual(out["result_count"], len(out["results"]))
+
+    def test_exactly_limit_terms_is_not_flagged(self):
+        """A ranking that exactly fills the page is complete, not truncated.
+
+        The probe row is what makes this exact: 100 rows come back from a
+        request for 101, so there is nothing beyond the page.
+        """
+        tool = _make_tool()
+        with patch(
+            "tooluniverse.openfda_adv_tool.requests.get",
+            return_value=_response(_rows(100)),
+        ):
+            out = tool.run({"medicinalproduct": "SOME DRUG"})
+
+        self.assertFalse(out["truncated"])
+        self.assertNotIn("truncation_note", out)
+        self.assertEqual(out["result_count"], 100)
+
+    def test_empty_result_is_not_flagged_as_truncated(self):
+        """No matching reports is a complete answer, not a clipped one."""
+        tool = _make_tool()
+        with patch(
+            "tooluniverse.openfda_adv_tool.requests.get",
+            return_value=_response([]),
+        ):
+            out = tool.run({"medicinalproduct": "NOT A DRUG"})
+
+        self.assertEqual(out["results"], [])
+        self.assertEqual(out["result_count"], 0)
+        self.assertFalse(out["truncated"])
+
+
+class TestLimitParameter(unittest.TestCase):
+    def test_limit_is_forwarded_and_widens_the_page(self):
+        tool = _make_tool()
+        with patch(
+            "tooluniverse.openfda_adv_tool.requests.get",
+            return_value=_response(_rows(250)),
+        ) as get:
+            out = tool.run({"medicinalproduct": "TACROLIMUS", "limit": 250})
+            url = get.call_args.args[0]
+
+        self.assertIn("&limit=251", url)
+        self.assertEqual(out["limit"], 250)
+        self.assertEqual(out["result_count"], 250)
+        self.assertFalse(out["truncated"])
+
+    def test_limit_is_declared_in_the_shipped_config(self):
+        """Every FAERS count tool advertises the pagination parameter."""
+        with open(_JSON_PATH) as fh:
+            configs = json.load(fh)
+        count_tools = [
+            c
+            for c in configs
+            if c.get("type")
+            in {"FDADrugAdverseEventTool", "FDACountAdditiveReactionsTool"}
+        ]
+        self.assertTrue(count_tools)
+        for cfg in count_tools:
+            prop = cfg["parameter"]["properties"].get("limit")
+            self.assertIsNotNone(prop, cfg["name"])
+            self.assertEqual(prop["type"], "integer", cfg["name"])
+            self.assertEqual(prop["default"], 100, cfg["name"])
+            self.assertEqual(prop["maximum"], 1000, cfg["name"])
+            self.assertNotIn("limit", cfg["parameter"].get("required", []))
+
+    def test_description_no_longer_promises_every_reaction(self):
+        cfg = _load_config("FAERS_count_reactions_by_drug_event")
+        self.assertNotIn("returns all adverse reactions", cfg["description"])
+        self.assertIn("truncated", cfg["description"])
+        self.assertIn("ranked by descending report count", cfg["description"])
+
+    def test_limit_beyond_documented_maximum_is_rejected(self):
+        tool = _make_tool()
+        with patch("tooluniverse.openfda_adv_tool.requests.get") as get:
+            out = tool.run({"medicinalproduct": "TACROLIMUS", "limit": 1001})
+        get.assert_not_called()
+        self.assertEqual(out["status"], "error")
+        self.assertIn("1000", out["error"])
+
+    def test_limit_at_documented_maximum_requires_an_api_key(self):
+        """Anonymous callers are capped one below openFDA's documented ceiling.
+
+        Measured live: limit=1000 without a key answers HTTP 403
+        API_KEY_MISSING, so the tool rejects it up front with the fix rather
+        than letting the caller discover it as an opaque request failure.
+        """
+        tool = _make_tool()
+        with patch("tooluniverse.openfda_adv_tool.requests.get") as get:
+            out = tool.run({"medicinalproduct": "TACROLIMUS", "limit": 1000})
+        get.assert_not_called()
+        self.assertEqual(out["status"], "error")
+        self.assertIn("FDA_API_KEY", out["error"])
+
+        keyed = _make_tool()
+        keyed.api_key = "test-key"
+        with patch(
+            "tooluniverse.openfda_adv_tool.requests.get",
+            return_value=_response(_rows(1000)),
+        ) as get:
+            out = keyed.run({"medicinalproduct": "TACROLIMUS", "limit": 1000})
+            url = get.call_args.args[0]
+        # At the ceiling there is no probe row, so a full page can only be
+        # reported as possibly-incomplete -- never as complete.
+        self.assertIn("&limit=1000", url)
+        self.assertTrue(out["truncated"])
+        self.assertIn("may exist", out["truncation_note"])
+
+    def test_non_integer_limit_is_rejected(self):
+        tool = _make_tool()
+        with patch("tooluniverse.openfda_adv_tool.requests.get") as get:
+            out = tool.run({"medicinalproduct": "TACROLIMUS", "limit": "many"})
+        get.assert_not_called()
+        self.assertEqual(out["status"], "error")
+
+
+class TestFilteredAndErrorPaths(unittest.TestCase):
+    def test_reaction_filter_still_narrows_to_the_requested_term(self):
+        tool = _make_tool()
+        rows = _rows(50) + [
+            {"term": "PROGRESSIVE MULTIFOCAL LEUKOENCEPHALOPATHY", "count": 561}
+        ]
+        with patch(
+            "tooluniverse.openfda_adv_tool.requests.get",
+            return_value=_response(rows),
+        ):
+            out = tool.run(
+                {
+                    "medicinalproduct": "TACROLIMUS",
+                    "reactionmeddraverse": "progressive multifocal leukoencephalopathy",
+                }
+            )
+
+        self.assertEqual(out["results"], [rows[-1]])
+        self.assertEqual(out["result_count"], 1)
+        self.assertFalse(out["truncated"])
+
+    def test_filtered_note_says_truncation_applies_to_the_ranking(self):
+        tool = _make_tool()
+        rows = _rows(100) + [
+            {"term": "PROGRESSIVE MULTIFOCAL LEUKOENCEPHALOPATHY", "count": 561}
+        ]
+        with patch(
+            "tooluniverse.openfda_adv_tool.requests.get",
+            return_value=_response(rows),
+        ):
+            out = tool.run(
+                {
+                    "medicinalproduct": "TACROLIMUS",
+                    "reactionmeddraverse": "progressive multifocal leukoencephalopathy",
+                }
+            )
+        self.assertTrue(out["truncated"])
+        self.assertIn("narrowed to the requested term", out["truncation_note"])
+
+    def test_api_failure_still_surfaces_an_error_not_a_clean_envelope(self):
+        """A transport failure must never look like an empty, complete result."""
+        tool = _make_tool()
+        with patch(
+            "tooluniverse.openfda_adv_tool.requests.get",
+            side_effect=requests.exceptions.ConnectionError("boom"),
+        ):
+            out = tool.run({"medicinalproduct": "TACROLIMUS"})
+
+        self.assertIsInstance(out, list)
+        self.assertIn("error", out[0])
+        self.assertIn("API request failed", out[0]["error"])
+
+
+class TestAdditiveCountTool(unittest.TestCase):
+    def test_multi_drug_counts_carry_the_same_disclosure(self):
+        tool = _make_additive_tool()
+        with patch(
+            "tooluniverse.openfda_adv_tool.requests.get",
+            return_value=_response(_rows(101)),
+        ) as get:
+            out = tool.run({"medicinalproducts": ["TACROLIMUS", "CYCLOSPORINE"]})
+            url = get.call_args.args[0]
+
+        self.assertIn("&limit=101", url)
+        self.assertTrue(out["truncated"])
+        self.assertEqual(out["result_count"], 100)
+        self.assertIn("truncation_note", out)
+
+    def test_multi_drug_complete_ranking_is_not_flagged(self):
+        tool = _make_additive_tool()
+        with patch(
+            "tooluniverse.openfda_adv_tool.requests.get",
+            return_value=_response(_rows(7)),
+        ):
+            out = tool.run(
+                {"medicinalproducts": ["TACROLIMUS", "CYCLOSPORINE"], "limit": 20}
+            )
+
+        self.assertFalse(out["truncated"])
+        self.assertNotIn("truncation_note", out)
+        self.assertEqual(out["result_count"], 7)
+        self.assertEqual(out["limit"], 20)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_faers_unknown_param.py
+++ b/tests/unit/test_faers_unknown_param.py
@@ -1,9 +1,13 @@
 """FAERS / openFDA adverse-event tools: unrecognized params must not corrupt the query.
 
-Regression for a silent-failure bug: an unknown argument (e.g. a stray 'limit')
-was forwarded into the openFDA search query as a bogus filter ('limit:2'),
-which matches nothing and returns a silent empty result. The tool must now
-ignore params not in its search-field map.
+Regression for a silent failure: an unknown argument was forwarded into the
+openFDA search query as a bogus Lucene filter (e.g. 'limit:2'), which matches
+nothing and returns a silent empty result. The tool must ignore params not in
+its search-field map.
+
+'limit' is now a real pagination parameter rather than an unknown one, so it is
+covered here too: it must reach openFDA as the '&limit=' query argument and
+never as part of the search clause.
 """
 
 import unittest
@@ -46,11 +50,19 @@ class TestUnknownParam(unittest.TestCase):
         self.assertIn("SIMVASTATIN", url)
 
     def test_unknown_param_is_ignored_not_forwarded(self):
-        # 'limit' is not in search_fields -> must NOT appear as a bogus filter
+        # 'not_a_field' is not in search_fields -> must NOT appear as a bogus filter
+        url = self._run_and_capture_url(
+            {"medicinalproduct": "SIMVASTATIN", "not_a_field": 2}
+        )
+        self.assertIn("patient.drug.medicinalproduct", url)  # the real query survives
+        self.assertNotIn("not_a_field", url)  # the stray param is dropped
+
+    def test_limit_is_a_query_argument_not_a_search_filter(self):
         url = self._run_and_capture_url({"medicinalproduct": "SIMVASTATIN", "limit": 2})
         self.assertIn("patient.drug.medicinalproduct", url)  # the real query survives
-        self.assertNotIn("limit:2", url)  # the stray param is dropped
+        self.assertNotIn("limit:2", url)  # never a Lucene term filter
         self.assertNotIn("limit", url.split("count=")[0])  # not in the search clause
+        self.assertIn("&limit=", url)  # forwarded as openFDA paging instead
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_fda_label_truncation_disclosure.py
+++ b/tests/unit/test_fda_label_truncation_disclosure.py
@@ -1,0 +1,195 @@
+"""Round 026: FDALabelTool must never present a shortened label section as complete.
+
+Regression for Feature-026C-1. Every long clinical section used to be cut at a
+hard-coded 2000 characters, mid-word, with nothing in the response saying so --
+which silently dropped e.g. the section 12.5 Pharmacogenomics content from the
+tacrolimus label while the answer still read as the complete prescribing
+information.
+
+The fix: a caller-controllable `max_section_chars` budget (generous by default
+for FDA_get_drug_label, deliberately compact for the multi-record
+FDA_search_drug_labels), plus a top-level `truncated` flag that is always
+present and a `truncation_note` naming the cut sections and how to get them.
+
+All tests here mock the HTTP layer -- no network.
+"""
+
+from unittest.mock import patch
+
+from tooluniverse.fda_label_tool import DEFAULT_SECTION_CHARS, FDALabelTool
+
+
+def _cfg(query_type):
+    return {
+        "name": f"FDA_{query_type}",
+        "type": "FDALabelTool",
+        "fields": {
+            "endpoint": "https://api.fda.gov/drug/label.json",
+            "query_type": query_type,
+        },
+        "parameter": {"type": "object", "properties": {}},
+    }
+
+
+class _Resp:
+    status_code = 200
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._payload
+
+
+def _record(brand="PROGRAF", **sections):
+    return {"openfda": {"brand_name": [brand]}, "id": "spl-1", **sections}
+
+
+def _run(query_type, arguments, results):
+    tool = FDALabelTool(_cfg(query_type))
+    payload = {"results": results}
+    with patch("tooluniverse.fda_label_tool.requests.get", return_value=_Resp(payload)):
+        return tool.run(arguments)
+
+
+# A section longer than the FDA_get_drug_label default budget, whose tail can
+# only be reached by raising max_section_chars.
+_TAIL = "PHARMACOGENOMIC-TAIL-MARKER"
+_LONG = ("x" * (DEFAULT_SECTION_CHARS["get"] + 500)) + _TAIL
+
+
+def test_long_section_sets_top_level_truncation_flag_and_note():
+    out = _run(
+        "get",
+        {"drug_name": "Prograf"},
+        [_record(clinical_pharmacology=[_LONG])],
+    )
+
+    assert out["status"] == "success"
+    assert out["truncated"] is True
+    assert out["truncated_fields"] == ["clinical_pharmacology"]
+
+    note = out["truncation_note"]
+    # The note has to name the affected section, the budget applied, and the
+    # argument that retrieves the rest -- a flag with no remedy is half a fix.
+    assert "clinical_pharmacology" in note
+    assert str(DEFAULT_SECTION_CHARS["get"]) in note
+    assert "max_section_chars" in note
+
+    # The applied budget is also echoed in metadata, and the data really is cut.
+    assert out["metadata"]["max_section_chars"] == DEFAULT_SECTION_CHARS["get"]
+    assert len(out["data"]["clinical_pharmacology"]) == DEFAULT_SECTION_CHARS["get"]
+    assert _TAIL not in out["data"]["clinical_pharmacology"]
+
+
+def test_short_sections_are_not_flagged_as_truncated():
+    short = "Tacrolimus is a calcineurin inhibitor."
+    out = _run(
+        "get",
+        {"drug_name": "Prograf"},
+        [
+            _record(
+                clinical_pharmacology=[short], indications_and_usage=["Prophylaxis."]
+            )
+        ],
+    )
+
+    assert out["status"] == "success"
+    # `truncated` is always present so callers can rely on the key; it must be
+    # False, and the note/field list must not appear at all.
+    assert out["truncated"] is False
+    assert "truncation_note" not in out
+    assert "truncated_fields" not in out
+    assert out["data"]["clinical_pharmacology"] == short
+
+
+def test_max_section_chars_zero_returns_the_section_in_full():
+    out = _run(
+        "get",
+        {"drug_name": "Prograf", "max_section_chars": 0},
+        [_record(clinical_pharmacology=[_LONG])],
+    )
+
+    assert out["truncated"] is False
+    assert "truncation_note" not in out
+    assert out["data"]["clinical_pharmacology"] == _LONG
+    assert _TAIL in out["data"]["clinical_pharmacology"]
+    assert out["metadata"]["max_section_chars"] == 0
+
+
+def test_raising_max_section_chars_recovers_the_cut_content():
+    args = {"drug_name": "Prograf", "max_section_chars": len(_LONG)}
+    out = _run("get", args, [_record(clinical_pharmacology=[_LONG])])
+
+    assert out["truncated"] is False
+    assert _TAIL in out["data"]["clinical_pharmacology"]
+
+
+def test_get_default_budget_holds_a_whole_clinical_section():
+    """The default must be generous enough for a real clinical section.
+
+    Measured against the live openFDA API, a complete Prograf
+    clinical_pharmacology section is ~19,500 characters and its pharmacogenomics
+    discussion starts ~6,600 characters in -- so a default that cuts at a few
+    thousand characters removes it from every label that has one.
+    """
+    assert DEFAULT_SECTION_CHARS["get"] >= 20000
+
+    realistic = "y" * 19517
+    out = _run(
+        "get",
+        {"drug_name": "Prograf"},
+        [_record(clinical_pharmacology=[realistic])],
+    )
+    assert out["truncated"] is False
+    assert out["data"]["clinical_pharmacology"] == realistic
+
+
+def test_search_keeps_a_compact_budget_but_discloses_it():
+    """FDA_search_drug_labels returns many records, so it stays a summary view --
+    it just has to say so instead of presenting cut prose as complete."""
+    out = _run(
+        "search",
+        {"drug_name": "Prograf", "limit": 1},
+        [_record(clinical_pharmacology=[_LONG], adverse_reactions=[_LONG])],
+    )
+
+    assert out["truncated"] is True
+    assert out["truncated_fields"] == ["adverse_reactions", "clinical_pharmacology"]
+    assert out["metadata"]["max_section_chars"] == DEFAULT_SECTION_CHARS["search"]
+    assert (
+        len(out["data"][0]["clinical_pharmacology"])
+        == (DEFAULT_SECTION_CHARS["search"])
+    )
+
+
+def test_get_disclosure_describes_only_the_record_actually_returned():
+    """_get_label fetches several candidates and returns the best match; the
+    disclosure must not name sections belonging to the discarded candidates."""
+    out = _run(
+        "get",
+        {"drug_name": "Prograf"},
+        [
+            _record(brand="OTHER BRAND", adverse_reactions=[_LONG]),
+            _record(brand="PROGRAF", clinical_pharmacology=["Short and complete."]),
+        ],
+    )
+
+    assert out["data"]["brand_name"] == "PROGRAF"
+    assert out["truncated"] is False
+    assert "truncated_fields" not in out
+
+
+def test_search_by_indication_also_discloses_truncation():
+    out = _run(
+        "search",
+        {"indication": "organ rejection", "limit": 1},
+        [_record(indications_and_usage=[_LONG])],
+    )
+
+    assert out["truncated"] is True
+    assert out["truncated_fields"] == ["indications_and_usage"]
+    assert "max_section_chars" in out["truncation_note"]

--- a/tests/unit/test_ols_exact_match_query_fields.py
+++ b/tests/unit/test_ols_exact_match_query_fields.py
@@ -1,0 +1,119 @@
+"""Regression tests for ``ols_search_terms``'s ``exact_match`` filter.
+
+OLS4's ``/api/search?exact=true`` flag restricts nothing on its own: the endpoint
+searches label, synonym, description, iri, short_form and obo_id by default, so
+an "exact" hit against a description token still returns the whole
+neighbourhood. ``q=fibroblast&ontology=cl&exact=true`` returned 167 of the 168
+terms that the unfiltered search returns, while the response echoed
+``"exact_match": true`` back to the caller as though the filter had been applied.
+
+The fix constrains ``queryFields`` whenever exact matching is requested. These
+tests pin the request-parameter construction without touching the network.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from tooluniverse.ols_tool import OLSTool
+
+EMPTY_SOLR_RESPONSE = {"response": {"docs": [], "numFound": 0}}
+
+
+def _params(mock_get_json):
+    """Return the query params handed to the single ``_get_json`` call."""
+
+    mock_get_json.assert_called_once()
+    return mock_get_json.call_args[1]["params"]
+
+
+@pytest.fixture
+def tool():
+    return OLSTool({"name": "test_ols"})
+
+
+@pytest.mark.unit
+class TestExactMatchQueryFields:
+    """``exact_match`` must constrain the fields OLS matches against."""
+
+    @patch.object(OLSTool, "_get_json")
+    def test_exact_match_sends_query_fields(self, mock_get_json, tool):
+        mock_get_json.return_value = EMPTY_SOLR_RESPONSE
+        tool._handle_search_terms(
+            {"operation": "search_terms", "query": "fibroblast", "exact_match": True}
+        )
+        params = _params(mock_get_json)
+        assert params["exact"] is True
+        assert params["queryFields"] == "label,synonym"
+
+    @patch.object(OLSTool, "_get_json")
+    def test_non_exact_search_sends_no_query_fields(self, mock_get_json, tool):
+        mock_get_json.return_value = EMPTY_SOLR_RESPONSE
+        tool._handle_search_terms(
+            {"operation": "search_terms", "query": "fibroblast", "exact_match": False}
+        )
+        params = _params(mock_get_json)
+        assert params["exact"] is False
+        assert "queryFields" not in params
+
+    @patch.object(OLSTool, "_get_json")
+    def test_exact_match_defaults_to_off(self, mock_get_json, tool):
+        mock_get_json.return_value = EMPTY_SOLR_RESPONSE
+        tool._handle_search_terms({"operation": "search_terms", "query": "fibroblast"})
+        assert "queryFields" not in _params(mock_get_json)
+
+    @pytest.mark.parametrize(
+        "query",
+        ["CL:0000084", "CL_0000084", "http://purl.obolibrary.org/obo/CL_0000084"],
+    )
+    @patch.object(OLSTool, "_get_json")
+    def test_identifier_queries_match_identifier_fields(
+        self, mock_get_json, tool, query
+    ):
+        """Constraining an ID lookup to label/synonym would return zero hits."""
+
+        mock_get_json.return_value = EMPTY_SOLR_RESPONSE
+        tool._handle_search_terms(
+            {"operation": "search_terms", "query": query, "exact_match": True}
+        )
+        assert _params(mock_get_json)["queryFields"] == "obo_id,short_form,iri"
+
+    @pytest.mark.parametrize(
+        "query",
+        ["type 2 diabetes mellitus", "T-lymphocyte", "T cell", "5-HT"],
+    )
+    @patch.object(OLSTool, "_get_json")
+    def test_name_queries_match_name_fields(self, mock_get_json, tool, query):
+        mock_get_json.return_value = EMPTY_SOLR_RESPONSE
+        tool._handle_search_terms(
+            {"operation": "search_terms", "query": query, "exact_match": True}
+        )
+        assert _params(mock_get_json)["queryFields"] == "label,synonym"
+
+
+@pytest.mark.unit
+class TestExactMatchFiltersEcho:
+    """The echoed ``filters`` block must be a verifiable claim."""
+
+    @patch.object(OLSTool, "_get_json")
+    def test_filters_report_the_matched_fields(self, mock_get_json, tool):
+        mock_get_json.return_value = EMPTY_SOLR_RESPONSE
+        result = tool._handle_search_terms(
+            {
+                "operation": "search_terms",
+                "query": "fibroblast",
+                "ontology": "cl",
+                "exact_match": True,
+            }
+        )
+        assert result["filters"]["exact_match"] is True
+        assert result["filters"]["exact_match_fields"] == "label,synonym"
+
+    @patch.object(OLSTool, "_get_json")
+    def test_filters_omit_matched_fields_when_not_exact(self, mock_get_json, tool):
+        mock_get_json.return_value = EMPTY_SOLR_RESPONSE
+        result = tool._handle_search_terms(
+            {"operation": "search_terms", "query": "fibroblast", "ontology": "cl"}
+        )
+        assert result["filters"]["exact_match"] is False
+        assert "exact_match_fields" not in result["filters"]

--- a/tests/unit/test_pharmacovigilance_faers_depth.py
+++ b/tests/unit/test_pharmacovigilance_faers_depth.py
@@ -85,9 +85,12 @@ class TestIndicationsByDrug(unittest.TestCase):
             url = get.call_args.args[0]
         self.assertIn("count=patient.drug.drugindication.exact", url)
         self.assertIn("WARFARIN", url)
-        self.assertEqual(out[0]["term"], "PRODUCT USED FOR UNKNOWN INDICATION")
-        self.assertEqual(out[0]["count"], 36767)
-        self.assertEqual(out[1]["term"], "ATRIAL FIBRILLATION")
+        rows = out["results"]
+        self.assertEqual(rows[0]["term"], "PRODUCT USED FOR UNKNOWN INDICATION")
+        self.assertEqual(rows[0]["count"], 36767)
+        self.assertEqual(rows[1]["term"], "ATRIAL FIBRILLATION")
+        # The ranking is short, so it must not be advertised as clipped.
+        self.assertFalse(out["truncated"])
 
     def test_api_failure_returns_error_not_raise(self):
         """A network failure surfaces an error entry and never raises."""
@@ -134,7 +137,7 @@ class TestDrugCharacterization(unittest.TestCase):
             out = tool.run({"medicinalproduct": "WARFARIN"})
             url = get.call_args.args[0]
         self.assertIn("count=patient.drug.drugcharacterization", url)
-        terms = {r["term"]: r["count"] for r in out}
+        terms = {r["term"]: r["count"] for r in out["results"]}
         self.assertEqual(terms["Suspect"], 132943)
         self.assertEqual(terms["Concomitant"], 105667)
         self.assertEqual(terms["Interacting"], 5371)
@@ -148,8 +151,8 @@ class TestDrugCharacterization(unittest.TestCase):
             return_value=_patched_get(rows),
         ):
             out = tool.run({"medicinalproduct": "METFORMIN"})
-        self.assertEqual(out[0]["term"], "4")
-        self.assertEqual(out[0]["count"], 15)
+        self.assertEqual(out["results"][0]["term"], "4")
+        self.assertEqual(out["results"][0]["count"], 15)
 
     def test_api_failure_returns_error_not_raise(self):
         """A network failure surfaces an error entry and never raises."""
@@ -197,7 +200,7 @@ class TestReporterQualification(unittest.TestCase):
             out = tool.run({"medicinalproduct": "WARFARIN"})
             url = get.call_args.args[0]
         self.assertIn("count=primarysource.qualification", url)
-        terms = {r["term"]: r["count"] for r in out}
+        terms = {r["term"]: r["count"] for r in out["results"]}
         self.assertEqual(terms["Consumer or non-health professional"], 39363)
         self.assertEqual(terms["Physician"], 29597)
         self.assertEqual(terms["Lawyer"], 1106)


### PR DESCRIPTION
Six issues surfaced by three researcher personas (neuro-oncology, single-cell atlases/aging biology, transplant immunology), each CLI-verified against live APIs before any fix was written.

The shape this round hunted: a well-formed response that quietly stands in for a larger or different answer, leaving the caller no way to tell it is incomplete.

## Fixes

**CIViC — a gene-prefixed variant name returns the wrong, empty record** (`civic_tool.py`)
CIViC filters variant and molecular-profile names by substring and stores variants under a bare designation (`VIII`, profile `EGFR VIII`), but clinical writing joins gene and designation into one token (`EGFRvIII`). A joined token can never be a substring of the separated record, so:
- `civic_search_variants{gene_name:"EGFR", variant_name:"EGFRvIII"}` returned only an empty duplicate stub (id 1516, `molecularProfileScore 0.0`, no HGVS) and dropped the curated record (id 312, score 69.0).
- `civic_search_evidence_items{molecular_profile:"EGFRvIII"}` returned 1 of 7 reachable evidence items, losing the Rindopepimut (971), gefitinib/erlotinib (1128) and EGFR-TKI class (772) glioblastoma records.

Gene-prefixed names are now split and unioned with the bare designation, both spellings disclosed via the existing `normalization_note`. Entity-agnostic — the designation patterns require a character after the digits, so `ERBB2`/`TP53` never split. `molecular_profile:"BRAFV600E"` goes from 0 items to the full `BRAF V600E` set.

**OLS — `exact_match` did nothing and reported that it had** (`ols_tool.py`)
OLS4's `exact` flag selects *how* the query matches, not *what* it matches against; the default field set includes `description`, so "exact" matched nearly everything: `fibroblast`/cl returned 167 of 168 terms, `T cell`/cl returned 6803 including `mesenchymal stem cell`. The response then echoed `exact_match: true`, asserting a filter that had removed one result in 168. Constraining `queryFields` is what makes the flag restrictive (`label,synonym`; `obo_id,short_form,iri` for CURIE/IRI queries so identifier lookups keep working). `filters.exact_match_fields` now makes the claim checkable. Non-exact queries are byte-for-byte unchanged.

**FDA labels — every section silently cut at 2000 characters** (`fda_label_tool.py`)
A hard-coded, undocumented, non-overridable slice applied to all eleven prose sections. Prograf's `clinical_pharmacology` is 19,517 chars and its CYP3A5 expresser/non-expresser dosing guidance — the single most important tacrolimus dosing fact — sits ~6,600 chars in, so the tool reported in fluent prose that the tacrolimus label says nothing about CYP3A5, while its own description promised "all clinical sections". Truncation is now disclosed at the top level (`truncated`/`truncated_fields`/`truncation_note`) and the budget is caller-controllable via `max_section_chars`.

**FAERS — 100 rows described as "all"** (`openfda_adv_tool.py`)
Count queries sent no `limit`, so openFDA returned exactly its default 100 rows. Progressive multifocal leukoencephalopathy (561 reports) ranks 202nd for tacrolimus and was therefore absent — a false negative in a pharmacovigilance review. All 18 count tools now accept `limit` (default 100, max 1000) and report `result_count`/`truncated`; the fetch requests `limit+1` so an exactly-full page is not misreported as clipped. openFDA returns no grand total for count aggregations, so none is invented. Success shape changes from a bare list to an object to carry the disclosure.

**CPIC — advertised provenance URL did not reproduce the result** (`cpic_search_pairs_tool.py`)
PostgREST filters travelled in query params while the reported `url` was the bare endpoint template, so the 13-row filtered answer and the 635-row unfiltered answer cited byte-identical URLs. The data was always correct; only the citation was wrong. The reported URL is now taken from the request actually issued, so the two cannot drift.

**Parameter validation — the framework blamed the caller for its own injected argument** (`base_tool.py`, `execute_function.py`)
`_apply_operation_default` injects an `operation` argument before validation; the validator then counted it as caller-supplied. `Pharos_get_target_expression{"target":"EGFR"}` answered `Unrecognized parameter(s): 'target', 'operation'` — naming a parameter the caller never sent. The injected value is now excluded from the report only when it matches exactly what the config would supply, so a caller-supplied bogus `operation` is still reported.

This also restores the unknown-parameter guard for the 348 configs that *declare* `operation`, where the injected key had been padding the `len(unknown) == len(arguments)` denominator and silently suppressing it. A differential sweep across all 2,573 tool configs and 4,356 test examples: **6 tools fixed** (no-arg calls like `PanglaoDB_list_cell_types` that previously errored), **152 all-bogus calls newly rejected** (the intended tightening), **0 tools newly broken**.

## Verification

Every fix re-run through the CLI with its original failing arguments; each now returns the complete or correctly-identified answer.

- `tests/unit`: 3816 collected, **0 failed**.
- `tests/tools` + `tests/examples`: 5 failures, **reproduced identically on a clean `origin/main` worktree** — pre-existing and unrelated (BRENDA credentials, Complex Portal 503, Ensembl homology timeout, CLI rendering, embedding ranking).
- Validator sweep over the changed surface: all 4 JSON configs valid; all 18 rewritten FAERS `return_schema`s match the new shape with zero double-wrapped envelopes; 21 hand-edited wrappers consistent with their configs; no new lint findings in the project's enforced rule set.
- Grep for tests asserting the old behaviour was run per-fix and at round level. Two test files legitimately encoded the old FAERS list shape and are updated; nothing else did.

Deliberately avoided every file owned by open PR #499 to keep this conflict-free.