### PR TITLE
Fix Round 28: answers that quietly stand in for the question asked

### DIFF
--- a/src/tooluniverse/bvbrc_tool.py
+++ b/src/tooluniverse/bvbrc_tool.py
@@ -117,13 +117,113 @@ class BVBRCTool(BaseTool):
 
         return "&".join(parts)
 
-    def _make_request(self, endpoint: str, query: str) -> Any:
-        """Make a request to BV-BRC API."""
+    @staticmethod
+    def _parse_content_range_total(header: Any) -> Optional[int]:
+        """Extract the upstream match count from a ``Content-Range`` header.
+
+        BV-BRC answers list queries with a header shaped like
+        ``items 0-9/2431``, where the value after the slash is the number of
+        records matching the query upstream -- independent of how many rows
+        the current page returned.
+
+        Returns ``None`` whenever the total cannot be determined (header
+        absent, malformed, or reporting an unknown total as ``*``). This
+        never raises: an unparseable header simply means "total unknown".
+        """
+        if not isinstance(header, str):
+            return None
+        try:
+            total_part = header.rsplit("/", 1)[-1].strip()
+            if not total_part or total_part == "*":
+                return None
+            total = int(total_part)
+        except (ValueError, TypeError):
+            return None
+        return total if total >= 0 else None
+
+    def _make_request_with_total(self, endpoint: str, query: str) -> Any:
+        """Make a request to BV-BRC API, returning ``(payload, upstream_total)``.
+
+        ``upstream_total`` is the number of records matching the query on the
+        server (from the ``Content-Range`` header), or ``None`` when BV-BRC
+        did not report one.
+        """
         url = f"{BVBRC_BASE_URL}/{endpoint}/?{query}"
         headers = {"Accept": "application/json"}
         response = requests.get(url, headers=headers, timeout=self.timeout)
         response.raise_for_status()
-        return response.json()
+
+        response_headers = getattr(response, "headers", None)
+        try:
+            content_range = response_headers.get(
+                "Content-Range"
+            ) or response_headers.get("X-Content-Range")
+        except (AttributeError, TypeError):
+            content_range = None
+
+        return response.json(), self._parse_content_range_total(content_range)
+
+    def _make_request(self, endpoint: str, query: str) -> Any:
+        """Make a request to BV-BRC API and return the decoded payload."""
+        data, _ = self._make_request_with_total(endpoint, query)
+        return data
+
+    def _search_metadata(
+        self,
+        results: List[Any],
+        limit: int,
+        upstream_total: Optional[int],
+        **query_fields: Any,
+    ) -> Dict[str, Any]:
+        """Build the metadata block shared by every BV-BRC search operation.
+
+        Distinguishes the rows on this page (``returned_results``) from the
+        number of records matching the query upstream (``total_results``), and
+        states plainly when the response was truncated.
+        """
+        returned = len(results)
+
+        if isinstance(upstream_total, int) and upstream_total >= returned:
+            total = upstream_total
+            total_known = True
+        else:
+            total = returned
+            total_known = False
+
+        metadata: Dict[str, Any] = {
+            "source": "BV-BRC",
+            "returned_results": returned,
+            "total_results": total,
+            "limit": limit,
+        }
+
+        if not total_known:
+            # Only worth saying when it is not true: otherwise total_results
+            # means what its name says, and a constant description string on
+            # every response is noise.
+            metadata["total_results_note"] = (
+                "BV-BRC did not report a total; this is the number of rows "
+                "returned and may undercount the true number of matches"
+            )
+
+        if total_known and total > returned:
+            metadata["truncated"] = True
+            metadata["truncation_note"] = (
+                f"Showing {returned} of {total} matching records. "
+                f"Raise 'limit' (maximum 100) to retrieve more."
+            )
+        elif not total_known and returned >= limit:
+            metadata["truncated"] = True
+            metadata["truncation_note"] = (
+                f"BV-BRC did not report a total and this page is full at the "
+                f"requested limit of {limit}, so more matching records may exist. "
+                f"Raise 'limit' (maximum 100) to retrieve more."
+            )
+        else:
+            metadata["truncated"] = False
+
+        metadata.update(query_fields)
+        return metadata
 
     def _get_genome(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Get a specific genome by ID."""
@@ -198,17 +298,18 @@ class BVBRCTool(BaseTool):
             select_fields=select_fields,
         )
 
-        data = self._make_request("genome", query)
+        data, upstream_total = self._make_request_with_total("genome", query)
 
         results = data if isinstance(data, list) else [data] if data else []
         return {
             "status": "success",
             "data": results,
-            "metadata": {
-                "source": "BV-BRC",
-                "total_results": len(results),
-                "query": keyword,
-            },
+            "metadata": self._search_metadata(
+                results,
+                limit,
+                upstream_total,
+                query=keyword,
+            ),
         }
 
     def _search_amr(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
@@ -251,18 +352,19 @@ class BVBRCTool(BaseTool):
         query = self._build_query_string(
             conditions, limit=limit, select_fields=select_fields
         )
-        data = self._make_request("genome_amr", query)
+        data, upstream_total = self._make_request_with_total("genome_amr", query)
 
         results = data if isinstance(data, list) else [data] if data else []
         return {
             "status": "success",
             "data": results,
-            "metadata": {
-                "source": "BV-BRC",
-                "total_results": len(results),
-                "query_antibiotic": antibiotic,
-                "query_genome_id": genome_id,
-            },
+            "metadata": self._search_metadata(
+                results,
+                limit,
+                upstream_total,
+                query_antibiotic=antibiotic,
+                query_genome_id=genome_id,
+            ),
         }
 
     def _search_features(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
@@ -308,18 +410,19 @@ class BVBRCTool(BaseTool):
         query = self._build_query_string(
             conditions, limit=limit, select_fields=select_fields
         )
-        data = self._make_request("genome_feature", query)
+        data, upstream_total = self._make_request_with_total("genome_feature", query)
 
         results = data if isinstance(data, list) else [data] if data else []
         return {
             "status": "success",
             "data": results,
-            "metadata": {
-                "source": "BV-BRC",
-                "total_results": len(results),
-                "query_gene": gene,
-                "query_product": product,
-            },
+            "metadata": self._search_metadata(
+                results,
+                limit,
+                upstream_total,
+                query_gene=gene,
+                query_product=product,
+            ),
         }
 
     def _search_epitopes(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
@@ -365,18 +468,19 @@ class BVBRCTool(BaseTool):
         query = self._build_query_string(
             conditions, limit=limit, select_fields=select_fields
         )
-        data = self._make_request("epitope", query)
+        data, upstream_total = self._make_request_with_total("epitope", query)
 
         results = data if isinstance(data, list) else [data] if data else []
         return {
             "status": "success",
             "data": results,
-            "metadata": {
-                "source": "BV-BRC",
-                "total_results": len(results),
-                "query_taxon_id": taxon_id,
-                "query_protein_name": protein_name,
-            },
+            "metadata": self._search_metadata(
+                results,
+                limit,
+                upstream_total,
+                query_taxon_id=taxon_id,
+                query_protein_name=protein_name,
+            ),
         }
 
     def _search_surveillance(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
@@ -429,18 +533,19 @@ class BVBRCTool(BaseTool):
         query = self._build_query_string(
             conditions, limit=limit, select_fields=select_fields
         )
-        data = self._make_request("surveillance", query)
+        data, upstream_total = self._make_request_with_total("surveillance", query)
 
         results = data if isinstance(data, list) else [data] if data else []
         return {
             "status": "success",
             "data": results,
-            "metadata": {
-                "source": "BV-BRC",
-                "total_results": len(results),
-                "query_subtype": subtype,
-                "query_geographic_group": geographic_group,
-            },
+            "metadata": self._search_metadata(
+                results,
+                limit,
+                upstream_total,
+                query_subtype=subtype,
+                query_geographic_group=geographic_group,
+            ),
         }
 
     def _search_specialty_genes(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
@@ -487,18 +592,19 @@ class BVBRCTool(BaseTool):
         query = self._build_query_string(
             conditions, limit=limit, select_fields=select_fields
         )
-        data = self._make_request("sp_gene", query)
+        data, upstream_total = self._make_request_with_total("sp_gene", query)
 
         results = data if isinstance(data, list) else [data] if data else []
         return {
             "status": "success",
             "data": results,
-            "metadata": {
-                "source": "BV-BRC",
-                "total_results": len(results),
-                "query_gene": gene,
-                "query_property": prop,
-            },
+            "metadata": self._search_metadata(
+                results,
+                limit,
+                upstream_total,
+                query_gene=gene,
+                query_property=prop,
+            ),
         }
 
     def _get_protein_structure(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
@@ -564,18 +670,19 @@ class BVBRCTool(BaseTool):
         query = self._build_query_string(
             conditions, limit=limit, select_fields=select_fields
         )
-        data = self._make_request("protein_structure", query)
+        data, upstream_total = self._make_request_with_total("protein_structure", query)
 
         results = data if isinstance(data, list) else [data] if data else []
         return {
             "status": "success",
             "data": results,
-            "metadata": {
-                "source": "BV-BRC",
-                "total_results": len(results),
-                "query_taxon_id": taxon_id,
-                "query_gene": gene,
-            },
+            "metadata": self._search_metadata(
+                results,
+                limit,
+                upstream_total,
+                query_taxon_id=taxon_id,
+                query_gene=gene,
+            ),
         }
 
     def _get_taxonomy(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
@@ -640,17 +747,18 @@ class BVBRCTool(BaseTool):
             limit=limit,
             select_fields=select_fields,
         )
-        data = self._make_request("taxonomy", query)
+        data, upstream_total = self._make_request_with_total("taxonomy", query)
 
         results = data if isinstance(data, list) else [data] if data else []
         return {
             "status": "success",
             "data": results,
-            "metadata": {
-                "source": "BV-BRC",
-                "total_results": len(results),
-                "query": keyword,
-            },
+            "metadata": self._search_metadata(
+                results,
+                limit,
+                upstream_total,
+                query=keyword,
+            ),
         }
 
     def _search_pathways(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
@@ -705,18 +813,19 @@ class BVBRCTool(BaseTool):
         query = self._build_query_string(
             conditions, limit=limit, select_fields=select_fields
         )
-        data = self._make_request("pathway", query)
+        data, upstream_total = self._make_request_with_total("pathway", query)
 
         results = data if isinstance(data, list) else [data] if data else []
         return {
             "status": "success",
             "data": results,
-            "metadata": {
-                "source": "BV-BRC",
-                "total_results": len(results),
-                "query_taxon_id": taxon_id,
-                "query_pathway_name": pathway_name,
-            },
+            "metadata": self._search_metadata(
+                results,
+                limit,
+                upstream_total,
+                query_taxon_id=taxon_id,
+                query_pathway_name=pathway_name,
+            ),
         }
 
     def _search_subsystems(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
@@ -765,16 +874,17 @@ class BVBRCTool(BaseTool):
         query = self._build_query_string(
             conditions, limit=limit, select_fields=select_fields
         )
-        data = self._make_request("subsystem", query)
+        data, upstream_total = self._make_request_with_total("subsystem", query)
 
         results = data if isinstance(data, list) else [data] if data else []
         return {
             "status": "success",
             "data": results,
-            "metadata": {
-                "source": "BV-BRC",
-                "total_results": len(results),
-                "query_taxon_id": taxon_id,
-                "query_subsystem_name": subsystem_name,
-            },
+            "metadata": self._search_metadata(
+                results,
+                limit,
+                upstream_total,
+                query_taxon_id=taxon_id,
+                query_subsystem_name=subsystem_name,
+            ),
         }

--- a/src/tooluniverse/compound_gene_disease_tool.py
+++ b/src/tooluniverse/compound_gene_disease_tool.py
@@ -191,10 +191,34 @@ class CompoundGeneDiseaseAssociationTool(BaseTool):
                     "error": f"No target match for gene '{gene}'",
                 }
 
+            # Fix-R28D-2: OpenTargets_get_target_id_description_by_name is a
+            # fuzzy free-text search, so an unrecognised symbol still comes back
+            # with a full hit list ranked by text relevance. Falling back to
+            # hits[0] when nothing matched exactly made the tool answer about a
+            # DIFFERENT gene with no signal at all -- confirmed live that
+            # {"gene": "THP"} (the clinical alias for uromodulin) returned
+            # GLI2's holoprosencephaly associations at score 0.80, shaped
+            # exactly like a correct answer. The hits carry only id/name/
+            # description -- no synonym fields -- so the alias is genuinely
+            # unresolvable here; report it as unresolved and name the
+            # candidates instead of guessing.
             gene_upper = gene.upper()
             match = next(
-                (h for h in hits if h.get("name", "").upper() == gene_upper), hits[0]
+                (h for h in hits if h.get("name", "").upper() == gene_upper), None
             )
+            if match is None:
+                candidates = [h.get("name", "") for h in hits if h.get("name")][:8]
+                candidate_text = ", ".join(candidates) if candidates else "none named"
+                msg = (
+                    f"'{gene}' did not exactly match any OpenTargets target "
+                    f"symbol, so no associated diseases were fetched (answering "
+                    f"with another target's diseases would misattribute them to "
+                    f"'{gene}'). The fuzzy target search returned these "
+                    f"candidate symbols: {candidate_text}. Re-query with the "
+                    f"exact approved symbol you mean."
+                )
+                sources_failed.append(f"OpenTargets: {msg}")
+                return {"status": "error", "error": msg}
             ensembl_id = match.get("id")
 
             result = tu.run_one_function(

--- a/src/tooluniverse/data/proteins_api_tools.json
+++ b/src/tooluniverse/data/proteins_api_tools.json
@@ -255,7 +255,7 @@
         },
         "organism": {
           "type": "string",
-          "description": "Restrict the search to an organism by name (e.g. 'Klebsiella pneumoniae', 'Escherichia coli'). By default a gene/protein-name search is biased toward human (taxid 9606); set this for non-human proteins. If omitted and no human match is found, the search auto-widens to all organisms."
+          "description": "Restrict the search to an organism by NAME (e.g. 'Klebsiella pneumoniae', 'Escherichia coli'); use 'taxid' for numeric NCBI taxonomy ids. A purely numeric value here (e.g. '9606') is auto-corrected to a taxid lookup and the response reports it in 'normalization_note'. By default a gene/protein-name search is biased toward human (taxid 9606); set this for non-human proteins. If omitted and no human match is found, the search auto-widens to all organisms."
         },
         "taxid": {
           "type": "string",

--- a/src/tooluniverse/proteins_api_tool.py
+++ b/src/tooluniverse/proteins_api_tool.py
@@ -19,6 +19,22 @@ _UNIPROT_ACCESSION_RE = re.compile(
 )
 
 
+def _numeric_organism_as_taxid(args: dict[str, Any]) -> str | None:
+    """Return the taxonomy id when ``organism`` was supplied as a bare number.
+
+    The Proteins API documents these as two distinct query parameters --
+    ``organism`` is "Organism name" and ``taxid`` is "Organism taxon ID"
+    (https://www.ebi.ac.uk/proteins/api/doc/) -- and matches nothing when a
+    taxon id is sent as ``organism=``. Since no organism name is all digits,
+    a purely numeric value is unambiguously a taxonomy id and is routed to
+    ``taxid=`` instead of silently returning an empty success.
+    """
+    if not isinstance(args, dict) or "organism" not in args:
+        return None
+    value = str(args["organism"]).strip()
+    return value if value.isdigit() else None
+
+
 @register_tool("ProteinsAPIRESTTool")
 class ProteinsAPIRESTTool(BaseTool):
     """
@@ -110,7 +126,15 @@ class ProteinsAPIRESTTool(BaseTool):
             if "reviewed" in args:
                 params["reviewed"] = str(args["reviewed"]).lower()
             if "organism" in args:
-                params["organism"] = args["organism"]
+                # A purely numeric organism is a taxonomy id, not a name; send
+                # it as taxid= so it actually filters instead of matching
+                # nothing (see _numeric_organism_as_taxid). run() discloses the
+                # correction via 'normalization_note'.
+                numeric_taxid = _numeric_organism_as_taxid(args)
+                if numeric_taxid:
+                    params["taxid"] = numeric_taxid
+                else:
+                    params["organism"] = args["organism"]
             elif "taxid" in args:
                 params["taxid"] = args["taxid"]
             elif "accession" not in params:
@@ -490,6 +514,7 @@ class ProteinsAPIRESTTool(BaseTool):
             ):
                 query = arguments.get("query", "")
                 used_gene = "gene" in params
+                used_protein = "protein" in params
 
                 def _retry_params(use_gene: bool, keep_human: bool) -> Dict[str, Any]:
                     # Carry the original request forward and change only the
@@ -507,11 +532,24 @@ class ProteinsAPIRESTTool(BaseTool):
                         p.pop("taxid", None)
                     return p
 
-                # Order: swap field but keep human; then drop the human filter
-                # (same field, then swapped field) so any-organism hits surface.
+                # Order: swap field but keep the caller's scoping; then drop the
+                # human filter (same field, then swapped field) so any-organism
+                # hits surface.
+                #
+                # The field swap must be symmetric. The _build_params routing
+                # heuristic sends anything longer than 10 characters to
+                # protein=, so realistic queries land there ('blaCTX-M-15', the
+                # most common ESBL gene worldwide, is 11 characters and only
+                # matches under gene=). Guarding this candidate on used_gene
+                # meant a protein=-routed query was never retried as gene=, and
+                # when the caller also supplied organism/taxid the auto_human
+                # branch below was skipped too -- leaving no retry at all and a
+                # silent empty success for data that exists upstream.
                 candidates = []
-                if used_gene:
-                    candidates.append(_retry_params(use_gene=False, keep_human=True))
+                if used_gene or used_protein:
+                    candidates.append(
+                        _retry_params(use_gene=not used_gene, keep_human=True)
+                    )
                 if auto_human:
                     candidates.append(
                         _retry_params(use_gene=used_gene, keep_human=False)
@@ -567,6 +605,16 @@ class ProteinsAPIRESTTool(BaseTool):
                 "data": data,
                 "url": response.url,
             }
+            normalized_taxid = _numeric_organism_as_taxid(arguments)
+            if normalized_taxid:
+                # Silent input mutation is its own defect: say what was changed.
+                response_data["normalization_note"] = (
+                    f"Input auto-normalized: organism '{normalized_taxid}' is "
+                    "purely numeric, so it was sent as taxid="
+                    f"'{normalized_taxid}'. The Proteins API 'organism' "
+                    "parameter takes an organism name (e.g. 'Homo sapiens'); "
+                    "'taxid' takes an NCBI taxonomy id."
+                )
             if widened_organism:
                 response_data["note"] = (
                     "No human matches found; the search was automatically "

--- a/src/tooluniverse/pubmed_tool.py
+++ b/src/tooluniverse/pubmed_tool.py
@@ -493,6 +493,70 @@ class PubMedRESTTool(BaseRESTTool):
             result["count"] = len(articles)
         return result
 
+    @staticmethod
+    def _search_warning_metadata(esearch_result: dict) -> dict:
+        """Surface NCBI's own report that it did not run the query as asked.
+
+        esearch silently drops quoted phrases it cannot match and then answers
+        a broader query. NCBI discloses this in ``esearchresult.warninglist``;
+        without propagating it a caller cannot tell that the returned articles
+        answer a different question than the one they submitted.
+
+        Returns an empty dict when NCBI reported no warnings, so unaffected
+        queries keep their existing metadata shape.
+        """
+        if not isinstance(esearch_result, dict):
+            return {}
+
+        warning_list = esearch_result.get("warninglist")
+        if not isinstance(warning_list, dict):
+            return {}
+
+        def _as_list(value: Any) -> list:
+            if isinstance(value, str):
+                return [value] if value.strip() else []
+            if isinstance(value, (list, tuple)):
+                return [v for v in value if v]
+            return []
+
+        not_found = _as_list(warning_list.get("quotedphrasesnotfound"))
+        ignored = _as_list(warning_list.get("phrasesignored"))
+        messages = _as_list(warning_list.get("outputmessages"))
+
+        if not (not_found or ignored or messages):
+            return {}
+
+        metadata: dict = {}
+        if not_found:
+            metadata["quoted_phrases_not_found"] = not_found
+        if ignored:
+            metadata["phrases_ignored"] = ignored
+        if messages:
+            metadata["ncbi_messages"] = messages
+
+        translation = esearch_result.get("querytranslation")
+        if isinstance(translation, str) and translation.strip():
+            metadata["executed_query"] = translation.strip()
+
+        # Top-level, unmissable statement of the mismatch for any caller that
+        # reads metadata but not the individual warning keys.
+        notes = []
+        if not_found:
+            notes.append(
+                "PubMed could not match the quoted phrase(s) "
+                f"{not_found}; they were dropped and these results answer a "
+                "BROADER query than the one submitted."
+            )
+        if ignored:
+            notes.append(f"PubMed ignored the phrase(s) {ignored}.")
+        if messages:
+            notes.append("; ".join(str(m) for m in messages))
+        if notes:
+            metadata["query_not_executed_as_submitted"] = True
+            metadata["warning"] = " ".join(notes)
+
+        return metadata
+
     def _fetch_abstracts(self, pmid_list: list[str]) -> Dict[str, str]:
         """Best-effort abstract fetch via efetch XML for a list of PMIDs."""
         pmids = [str(p).strip() for p in (pmid_list or []) if str(p).strip()]
@@ -601,6 +665,13 @@ class PubMedRESTTool(BaseRESTTool):
                     # If this is a search request (has 'query' in arguments),
                     # fetch article summaries and return the standard envelope.
                     if "query" in arguments:
+                        # NCBI reports quoted phrases it could not match; that
+                        # report must reach the caller or the answer looks like
+                        # it came from the query they actually submitted.
+                        search_warnings = self._search_warning_metadata(
+                            esearch_result
+                        )
+
                         # A search that matched nothing must still return the
                         # same {status, data, metadata} envelope as a search
                         # that matched — otherwise zero-hit queries fall through
@@ -615,6 +686,7 @@ class PubMedRESTTool(BaseRESTTool):
                                     "total": int(esearch_result.get("count", 0)),
                                     "query": arguments.get("query"),
                                     "source": "PubMed",
+                                    **search_warnings,
                                 },
                             }
 
@@ -701,6 +773,7 @@ class PubMedRESTTool(BaseRESTTool):
                                 ),
                                 "query": arguments.get("query"),
                                 "source": "PubMed",
+                                **search_warnings,
                             },
                         }
 

--- a/src/tooluniverse/pubmed_tool.py
+++ b/src/tooluniverse/pubmed_tool.py
@@ -668,9 +668,7 @@ class PubMedRESTTool(BaseRESTTool):
                         # NCBI reports quoted phrases it could not match; that
                         # report must reach the caller or the answer looks like
                         # it came from the query they actually submitted.
-                        search_warnings = self._search_warning_metadata(
-                            esearch_result
-                        )
+                        search_warnings = self._search_warning_metadata(esearch_result)
 
                         # A search that matched nothing must still return the
                         # same {status, data, metadata} envelope as a search

--- a/tests/unit/test_bvbrc_total_reflects_upstream_count.py
+++ b/tests/unit/test_bvbrc_total_reflects_upstream_count.py
@@ -1,0 +1,226 @@
+"""Regression guard: BV-BRC searches must report the upstream match count.
+
+Every BV-BRC search operation computed ``metadata.total_results`` as
+``len(results)`` -- the number of rows on the page just returned. It therefore
+always equalled the requested ``limit``, so a caller counting how widespread a
+resistance gene is could not tell "these are all the matches" from "there are
+hundreds more". Confirmed live: ``BVBRC_search_genome_features`` for gene
+blaOXA-48 reported ``total_results: 3`` at ``limit=3`` and ``10`` at
+``limit=10``, while BV-BRC's own ``Content-Range: items 0-3/13`` response
+header stated the true total.
+
+Fixed by reading ``Content-Range`` in ``_make_request_with_total`` and building
+every search's metadata through the shared ``_search_metadata`` helper, which
+separates ``returned_results`` (this page) from ``total_results`` (upstream)
+and flags truncation explicitly.
+
+These tests never touch the network.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.bvbrc_tool import BVBRCTool
+
+pytestmark = pytest.mark.unit
+
+
+def _feature_tool():
+    return BVBRCTool(
+        {
+            "name": "bvbrc_test_features",
+            "fields": {"data_type": "genome_feature", "action": "search"},
+        }
+    )
+
+
+def _genome_tool():
+    return BVBRCTool(
+        {
+            "name": "bvbrc_test_genomes",
+            "fields": {"data_type": "genome", "action": "search"},
+        }
+    )
+
+
+def _rows(n):
+    return [{"patric_id": f"fig|562.{i}.peg.1", "gene": "blaOXA-48"} for i in range(n)]
+
+
+def _fake_get(rows, response_headers):
+    def fake_get(url, headers=None, timeout=None, **kwargs):
+        r = MagicMock()
+        r.raise_for_status = MagicMock()
+        r.json.return_value = rows
+        r.headers = response_headers
+        return r
+
+    return fake_get
+
+
+def _run(tool, arguments, rows, response_headers):
+    with patch(
+        "tooluniverse.bvbrc_tool.requests.get",
+        side_effect=_fake_get(rows, response_headers),
+    ):
+        return tool.run(arguments)
+
+
+def test_total_results_comes_from_content_range_not_page_size():
+    result = _run(
+        _feature_tool(),
+        {"gene": "blaOXA-48", "limit": 3},
+        _rows(3),
+        {"Content-Range": "items 0-3/26"},
+    )
+
+    assert result["status"] == "success"
+    meta = result["metadata"]
+    assert meta["total_results"] == 26
+    assert meta["returned_results"] == 3
+    assert len(result["data"]) == 3
+
+
+def test_truncation_is_flagged_with_actionable_note():
+    meta = _run(
+        _feature_tool(),
+        {"gene": "blaOXA-48", "limit": 3},
+        _rows(3),
+        {"Content-Range": "items 0-3/26"},
+    )["metadata"]
+
+    assert meta["truncated"] is True
+    assert "26" in meta["truncation_note"]
+    assert "limit" in meta["truncation_note"]
+
+
+def test_upstream_total_is_stable_across_limits():
+    small = _run(
+        _feature_tool(),
+        {"gene": "blaOXA-48", "limit": 3},
+        _rows(3),
+        {"Content-Range": "items 0-3/26"},
+    )["metadata"]
+    large = _run(
+        _feature_tool(),
+        {"gene": "blaOXA-48", "limit": 10},
+        _rows(10),
+        {"Content-Range": "items 0-10/26"},
+    )["metadata"]
+
+    assert small["total_results"] == large["total_results"] == 26
+    assert small["returned_results"] == 3
+    assert large["returned_results"] == 10
+
+
+def test_complete_result_set_is_not_flagged_as_truncated():
+    meta = _run(
+        _feature_tool(),
+        {"gene": "blaOXA-48", "limit": 25},
+        _rows(4),
+        {"Content-Range": "items 0-4/4"},
+    )["metadata"]
+
+    assert meta["total_results"] == 4
+    assert meta["returned_results"] == 4
+    assert meta["truncated"] is False
+    assert "truncation_note" not in meta
+
+
+def test_shared_helper_applies_to_other_search_operations():
+    meta = _run(
+        _genome_tool(),
+        {"keyword": "Klebsiella pneumoniae", "limit": 2},
+        _rows(2),
+        {"Content-Range": "items 0-2/48384"},
+    )["metadata"]
+
+    assert meta["total_results"] == 48384
+    assert meta["returned_results"] == 2
+    assert meta["truncated"] is True
+    assert meta["query"] == "Klebsiella pneumoniae"
+
+
+@pytest.mark.parametrize(
+    "response_headers",
+    [
+        {},
+        {"Content-Range": ""},
+        {"Content-Range": "items 0-3/*"},
+        {"Content-Range": "totally malformed"},
+        {"Content-Range": "items 0-3/not-a-number"},
+        {"Content-Range": None},
+        {"Content-Range": 12345},
+    ],
+)
+def test_missing_or_malformed_header_degrades_gracefully(response_headers):
+    result = _run(
+        _feature_tool(),
+        {"gene": "blaOXA-48", "limit": 10},
+        _rows(3),
+        response_headers,
+    )
+
+    assert result["status"] == "success"
+    assert len(result["data"]) == 3
+    meta = result["metadata"]
+    # Falls back to the page count, says so, and does not over-claim truncation.
+    assert meta["total_results"] == 3
+    assert meta["returned_results"] == 3
+    assert meta["truncated"] is False
+    assert "did not report a total" in meta["total_results_note"]
+
+
+def test_full_page_without_header_warns_more_may_exist():
+    meta = _run(
+        _feature_tool(),
+        {"gene": "blaOXA-48", "limit": 3},
+        _rows(3),
+        {},
+    )["metadata"]
+
+    assert meta["truncated"] is True
+    assert "may exist" in meta["truncation_note"]
+
+
+def test_header_smaller_than_page_is_ignored():
+    """A nonsensical upstream total must never undercount the rows returned."""
+    meta = _run(
+        _feature_tool(),
+        {"gene": "blaOXA-48", "limit": 10},
+        _rows(5),
+        {"Content-Range": "items 0-5/2"},
+    )["metadata"]
+
+    assert meta["total_results"] == 5
+    assert meta["returned_results"] == 5
+
+
+def test_parse_content_range_total_never_raises():
+    parse = BVBRCTool._parse_content_range_total
+    assert parse("items 0-3/26") == 26
+    assert parse("items 0-3/*") is None
+    assert parse("") is None
+    assert parse(None) is None
+    assert parse(object()) is None
+    assert parse("items 0-3/-1") is None
+
+
+def test_single_record_get_metadata_is_untouched():
+    tool = BVBRCTool(
+        {"name": "bvbrc_test_get", "fields": {"data_type": "genome", "action": "get"}}
+    )
+    result = _run(
+        tool,
+        {"genome_id": "562.85926"},
+        [{"genome_id": "562.85926", "genome_name": "Escherichia coli"}],
+        {"Content-Range": "items 0-1/1"},
+    )
+
+    assert result["status"] == "success"
+    assert result["metadata"] == {"source": "BV-BRC", "query_genome_id": "562.85926"}

--- a/tests/unit/test_gene_disease_no_wrong_target_substitution.py
+++ b/tests/unit/test_gene_disease_no_wrong_target_substitution.py
@@ -1,0 +1,193 @@
+"""Regression guard for Fix-R28D-2: CompoundGeneDiseaseAssociationTool's
+OpenTargets sub-query silently answered about a DIFFERENT gene.
+
+`OpenTargets_get_target_id_description_by_name` is a fuzzy free-text search,
+so an unrecognised symbol still comes back with a full, relevance-ranked hit
+list. `_opentargets_gene_diseases` picked the exact name match when there was
+one and otherwise fell back to `hits[0]` -- the top fuzzy hit -- and then
+fetched THAT target's associated diseases. Confirmed live that
+{"gene": "THP"} (the historical clinical alias for uromodulin/UMOD, a kidney
+gene) returned GLI2's "holoprosencephaly 9" at score 0.80 and the rest of
+GLI2's disease list, shaped exactly like a correct answer with nothing
+anywhere signalling the substitution.
+
+The hits carry only id/name/description -- no synonym fields -- so the alias
+is genuinely unresolvable from this response. The fix reports the symbol as
+unresolved and names the candidate symbols the search did return, instead of
+guessing one.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.compound_gene_disease_tool import CompoundGeneDiseaseAssociationTool
+
+pytestmark = pytest.mark.unit
+
+
+DISEASES_TOOL = "OpenTargets_get_diseases_phenotypes_by_target_ensembl"
+SEARCH_TOOL = "OpenTargets_get_target_id_description_by_name"
+
+# The live hit list for targetName="THP", in order. No hit is named "THP".
+_FUZZY_SEARCH_RESPONSE = {
+    "status": "success",
+    "data": {
+        "search": {
+            "hits": [
+                {"id": "ENSG00000074047", "name": "GLI2", "description": "..."},
+                {"id": "ENSG00000169344", "name": "UMOD", "description": "..."},
+                {"id": "ENSG00000090534", "name": "THPO", "description": "..."},
+                {"id": "ENSG00000184500", "name": "PROS1", "description": "..."},
+                {"id": "ENSG00000115718", "name": "PROC", "description": "..."},
+            ]
+        }
+    },
+}
+
+# GLI2's diseases -- what the old fallback misattributed to "THP".
+_WRONG_TARGET_DISEASES = {
+    "status": "success",
+    "data": {
+        "target": {
+            "id": "ENSG00000074047",
+            "approvedSymbol": "GLI2",
+            "associatedDiseases": {
+                "count": 1,
+                "rows": [
+                    {
+                        "disease": {
+                            "id": "MONDO_0012322",
+                            "name": "holoprosencephaly 9",
+                        },
+                        "score": 0.7985980288493254,
+                    }
+                ],
+            },
+        }
+    },
+}
+
+_EXACT_SEARCH_RESPONSE = {
+    "status": "success",
+    "data": {
+        "search": {
+            "hits": [
+                {"id": "ENSG00000074047", "name": "GLI2", "description": "..."},
+                {"id": "ENSG00000169344", "name": "UMOD", "description": "..."},
+            ]
+        }
+    },
+}
+
+_UMOD_DISEASES = {
+    "status": "success",
+    "data": {
+        "target": {
+            "id": "ENSG00000169344",
+            "approvedSymbol": "UMOD",
+            "associatedDiseases": {
+                "count": 1,
+                "rows": [
+                    {
+                        "disease": {
+                            "id": "MONDO_0008170",
+                            "name": "familial juvenile hyperuricemic nephropathy",
+                        },
+                        "score": 0.9,
+                    }
+                ],
+            },
+        }
+    },
+}
+
+
+def _tool():
+    return CompoundGeneDiseaseAssociationTool({"name": "gather_test"})
+
+
+def _fake_tu(responses):
+    """A ToolUniverse stub that answers by tool name and records every call."""
+    tu = MagicMock()
+    tu.run_one_function.side_effect = lambda call: responses[call["name"]]
+    return tu
+
+
+def _called_names(tu):
+    return [c.args[0]["name"] for c in tu.run_one_function.call_args_list]
+
+
+class TestNoWrongTargetSubstitution:
+    def test_non_matching_symbol_never_fetches_another_targets_diseases(self):
+        tu = _fake_tu(
+            {SEARCH_TOOL: _FUZZY_SEARCH_RESPONSE, DISEASES_TOOL: _WRONG_TARGET_DISEASES}
+        )
+        sources_failed = []
+
+        result = _tool()._opentargets_gene_diseases(tu, "THP", sources_failed)
+
+        # The diseases-by-Ensembl lookup must not happen at all.
+        assert DISEASES_TOOL not in _called_names(tu)
+        assert result["status"] == "error"
+
+    def test_non_matching_symbol_reports_an_actionable_failure(self):
+        tu = _fake_tu(
+            {SEARCH_TOOL: _FUZZY_SEARCH_RESPONSE, DISEASES_TOOL: _WRONG_TARGET_DISEASES}
+        )
+        sources_failed = []
+
+        result = _tool()._opentargets_gene_diseases(tu, "THP", sources_failed)
+
+        assert len(sources_failed) == 1
+        msg = sources_failed[0]
+        assert msg.startswith("OpenTargets: ")
+        assert "THP" in msg
+        # Names the candidates the search actually returned, so the caller can
+        # re-query with a real symbol.
+        for candidate in ("GLI2", "UMOD", "THPO"):
+            assert candidate in msg
+        assert msg.endswith(result["error"])
+
+    def test_wrong_targets_diseases_never_reach_the_extracted_items(self):
+        tu = _fake_tu(
+            {SEARCH_TOOL: _FUZZY_SEARCH_RESPONSE, DISEASES_TOOL: _WRONG_TARGET_DISEASES}
+        )
+        tool = _tool()
+
+        result = tool._opentargets_gene_diseases(tu, "THP", [])
+        items = tool._extract_genes_or_diseases(result, "OpenTargets")
+
+        assert items == []
+
+    def test_case_insensitive_exact_match_still_resolves(self):
+        tu = _fake_tu(
+            {SEARCH_TOOL: _EXACT_SEARCH_RESPONSE, DISEASES_TOOL: _UMOD_DISEASES}
+        )
+        sources_failed = []
+
+        result = _tool()._opentargets_gene_diseases(tu, "umod", sources_failed)
+
+        assert result == _UMOD_DISEASES
+        assert sources_failed == []
+        # Resolved to UMOD's Ensembl ID, not the higher-ranked GLI2 hit.
+        second_call = tu.run_one_function.call_args_list[1].args[0]
+        assert second_call["name"] == DISEASES_TOOL
+        assert second_call["arguments"] == {"ensemblId": "ENSG00000169344"}
+
+    def test_exact_match_behind_a_higher_ranked_fuzzy_hit_is_unchanged(self):
+        tu = _fake_tu(
+            {SEARCH_TOOL: _EXACT_SEARCH_RESPONSE, DISEASES_TOOL: _UMOD_DISEASES}
+        )
+        tool = _tool()
+
+        result = tool._opentargets_gene_diseases(tu, "UMOD", [])
+        names = [
+            i["name"] for i in tool._extract_genes_or_diseases(result, "OpenTargets")
+        ]
+
+        assert names == ["familial juvenile hyperuricemic nephropathy"]

--- a/tests/unit/test_proteins_api_search_no_silent_empty.py
+++ b/tests/unit/test_proteins_api_search_no_silent_empty.py
@@ -1,0 +1,202 @@
+"""proteins_api_search must never answer a findable query with a silent empty.
+
+Two defects produced the same harm -- ``status: success``, ``count: 0``, no
+explanation -- for queries whose data demonstrably exists upstream:
+
+1. The empty-result field-swap retry was asymmetric. ``_build_params`` routes
+   any query longer than 10 characters to ``protein=``, but the retry that
+   swaps the field while keeping the caller's organism/taxid scoping was
+   guarded on the gene->protein direction only. A scoped ``protein=`` query
+   (e.g. ``blaCTX-M-15`` in *Klebsiella pneumoniae*, 11 characters, which only
+   matches under ``gene=``) therefore got no retry at all.
+2. A purely numeric ``organism`` was sent to the API's ``organism=``
+   parameter, which takes an organism *name* ("Organism name" vs "Organism
+   taxon ID" in https://www.ebi.ac.uk/proteins/api/doc/), so
+   ``organism='9606'`` matched nothing. It is now routed to ``taxid=`` and the
+   response discloses the correction.
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _make_tool():
+    from tooluniverse.proteins_api_tool import ProteinsAPIRESTTool
+
+    return ProteinsAPIRESTTool(
+        {"name": "proteins_api_search", "type": "ProteinsAPIRESTTool", "fields": {}}
+    )
+
+
+def _resp(status_code, payload):
+    r = MagicMock()
+    r.status_code = status_code
+    r.json.return_value = payload
+    r.url = "https://www.ebi.ac.uk/proteins/api/proteins"
+    r.raise_for_status.return_value = None
+    return r
+
+
+class TestSymmetricFieldSwapRetry(unittest.TestCase):
+    """Defect 1: a scoped protein= query must be retried as gene=."""
+
+    def test_scoped_protein_query_retries_as_gene(self):
+        tool = _make_tool()
+        hit = [{"accession": "A0A077JMT3", "id": "A0A077JMT3_KLEPN"}]
+        # protein=blaCTX-M-15 is empty upstream; gene=blaCTX-M-15 is the hit.
+        tool.session.get = MagicMock(side_effect=[_resp(200, []), _resp(200, hit)])
+
+        result = tool.run(
+            {
+                "query": "blaCTX-M-15",
+                "organism": "Klebsiella pneumoniae",
+                "size": 3,
+            }
+        )
+
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["count"], 1)
+        self.assertEqual(result["data"][0]["accession"], "A0A077JMT3")
+        self.assertEqual(tool.session.get.call_count, 2)
+
+        first_params = tool.session.get.call_args_list[0].kwargs["params"]
+        self.assertEqual(first_params.get("protein"), "blaCTX-M-15")
+
+        retry_params = tool.session.get.call_args_list[1].kwargs["params"]
+        self.assertEqual(retry_params.get("gene"), "blaCTX-M-15")
+        self.assertNotIn("protein", retry_params)
+        # The caller's scoping must survive the swap (see the wheat/insect
+        # incident recorded in the retry helper).
+        self.assertEqual(retry_params.get("organism"), "Klebsiella pneumoniae")
+        self.assertEqual(retry_params.get("size"), 3)
+        # The caller scoped the query, so no human default was ever injected.
+        self.assertNotIn("taxid", retry_params)
+
+    def test_scoped_gene_query_still_retries_as_protein(self):
+        """The gene->protein direction (the one that already worked) is kept."""
+        tool = _make_tool()
+        tool.session.get = MagicMock(
+            side_effect=[_resp(200, []), _resp(200, [{"accession": "X"}])]
+        )
+
+        result = tool.run({"query": "FT1", "organism": "Triticum aestivum"})
+
+        self.assertEqual(result["count"], 1)
+        retry_params = tool.session.get.call_args_list[1].kwargs["params"]
+        self.assertEqual(retry_params.get("protein"), "FT1")
+        self.assertNotIn("gene", retry_params)
+        self.assertEqual(retry_params.get("organism"), "Triticum aestivum")
+
+    def test_accession_query_is_not_retried_under_a_name_field(self):
+        """An accession lookup must not be re-issued as gene=/protein=."""
+        tool = _make_tool()
+        tool.session.get = MagicMock(return_value=_resp(200, []))
+
+        result = tool.run({"query": "P05067"})
+
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["count"], 0)
+        self.assertEqual(tool.session.get.call_count, 1)
+
+    def test_no_upstream_match_under_either_field_stays_empty_without_crashing(self):
+        tool = _make_tool()
+        tool.session.get = MagicMock(return_value=_resp(200, []))
+
+        result = tool.run(
+            {"query": "KPC-2 carbapenemase", "organism": "Klebsiella pneumoniae"}
+        )
+
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["count"], 0)
+        # Exactly one retry: the symmetric protein->gene swap.
+        self.assertEqual(tool.session.get.call_count, 2)
+
+
+class TestNumericOrganismIsATaxid(unittest.TestCase):
+    """Defect 2: organism='9606' must not silently return nothing."""
+
+    def test_numeric_organism_routes_to_taxid(self):
+        tool = _make_tool()
+        params = tool._build_params({"query": "JAK2", "organism": "9606"})
+        self.assertEqual(params.get("taxid"), "9606")
+        self.assertNotIn("organism", params)
+
+    def test_numeric_organism_accepts_int_and_surrounding_whitespace(self):
+        tool = _make_tool()
+        self.assertEqual(
+            tool._build_params({"query": "JAK2", "organism": 9606}).get("taxid"), "9606"
+        )
+        self.assertEqual(
+            tool._build_params({"query": "JAK2", "organism": " 9606 "}).get("taxid"),
+            "9606",
+        )
+
+    def test_named_organism_is_untouched(self):
+        tool = _make_tool()
+        params = tool._build_params(
+            {"query": "blaKPC", "organism": "Klebsiella pneumoniae"}
+        )
+        self.assertEqual(params.get("organism"), "Klebsiella pneumoniae")
+        self.assertNotIn("taxid", params)
+
+    def test_numeric_organism_returns_hits_and_discloses_the_correction(self):
+        tool = _make_tool()
+        hit = [{"accession": "O60674", "id": "JAK2_HUMAN"}]
+        tool.session.get = MagicMock(return_value=_resp(200, hit))
+
+        result = tool.run({"gene": "JAK2", "organism": "9606"})
+
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["count"], 1)
+        self.assertEqual(result["data"][0]["accession"], "O60674")
+        # Silent input mutation is its own defect: the response must say so.
+        self.assertIn("normalization_note", result)
+        note = result["normalization_note"]
+        self.assertIn("9606", note)
+        self.assertIn("organism", note)
+        self.assertIn("taxid", note)
+
+        sent = tool.session.get.call_args_list[0].kwargs["params"]
+        self.assertEqual(sent.get("taxid"), "9606")
+        self.assertNotIn("organism", sent)
+
+    def test_no_normalization_note_when_organism_is_a_name(self):
+        tool = _make_tool()
+        tool.session.get = MagicMock(return_value=_resp(200, [{"accession": "I7ACB1"}]))
+
+        result = tool.run({"query": "KPC-2", "organism": "Klebsiella pneumoniae"})
+
+        self.assertEqual(result["count"], 1)
+        self.assertNotIn("normalization_note", result)
+
+    def test_numeric_organism_disables_the_human_default_like_a_taxid(self):
+        """A caller-supplied numeric organism is scoping, not the tool's default."""
+        tool = _make_tool()
+        params = tool._build_params({"query": "blaKPC", "organism": "573"})
+        self.assertEqual(params.get("taxid"), "573")
+
+
+class TestPriorFixesStillHold(unittest.TestCase):
+    """Guards for Feature-69A-007, Feature-81B-007 and Fix-T3A-008."""
+
+    def test_human_default_still_applied_to_bare_name_search(self):
+        tool = _make_tool()
+        self.assertEqual(tool._build_params({"query": "TP53"}).get("taxid"), "9606")
+
+    def test_short_query_still_routes_to_gene(self):
+        tool = _make_tool()
+        self.assertEqual(tool._build_params({"query": "CYP2D6"}).get("gene"), "CYP2D6")
+
+    def test_accession_still_routes_to_accession(self):
+        tool = _make_tool()
+        params = tool._build_params({"query": "P05067"})
+        self.assertEqual(params.get("accession"), "P05067")
+        self.assertNotIn("taxid", params)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_pubmed_unmatched_phrase_disclosed.py
+++ b/tests/unit/test_pubmed_unmatched_phrase_disclosed.py
@@ -1,0 +1,157 @@
+"""Regression guard: PubMed_search_articles must disclose that NCBI did not
+run the query as submitted.
+
+NCBI esearch silently drops quoted phrases it cannot match and answers a
+broader query instead, reporting this in
+``esearchresult.warninglist.quotedphrasesnotfound``. The tool previously read
+only ``idlist`` and ``count``, so a query containing an unmatchable phrase
+returned the results of a *different* query with nothing in the response to
+say so. The warning data is now propagated into ``metadata``.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.pubmed_tool import PubMedRESTTool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return PubMedRESTTool(
+        {
+            "name": "PubMed_search_articles",
+            "fields": {
+                "endpoint": (
+                    "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi"
+                ),
+                "db": "pubmed",
+                "retmode": "json",
+            },
+        }
+    )
+
+
+def _esearch_response(esearch_result):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi"
+    resp.json.return_value = {"esearchresult": esearch_result}
+    return resp
+
+
+def _run(esearch_result, summaries):
+    """Run the tool against a mocked esearch payload (no network)."""
+    tool = _tool()
+    with patch.object(tool, "_enforce_rate_limit"), patch.object(
+        tool, "_fetch_summaries", return_value=summaries
+    ), patch(
+        "tooluniverse.pubmed_tool.request_with_retry",
+        return_value=_esearch_response(esearch_result),
+    ):
+        return tool.run({"query": '"JAK2 V617F thrombosis unicornwombatxyz"'})
+
+
+WARNING_LIST = {
+    "quotedphrasesnotfound": ['"JAK2 V617F thrombosis unicornwombatxyz"'],
+    "phrasesignored": ["and"],
+    "outputmessages": ["No items found."],
+}
+
+ARTICLE = {
+    "pmid": "42567343",
+    "title": "Something about JAK2",
+    "authors": [],
+    "journal": "J Test",
+    "url": "https://pubmed.ncbi.nlm.nih.gov/42567343/",
+}
+
+
+def test_unmatched_quoted_phrase_disclosed_in_metadata():
+    result = _run(
+        {
+            "idlist": ["42567343"],
+            "count": "540",
+            "querytranslation": "jak2[All Fields] AND v617f[All Fields]",
+            "warninglist": WARNING_LIST,
+        },
+        {"status": "success", "data": [ARTICLE]},
+    )
+
+    metadata = result["metadata"]
+    # Existing semantics are untouched.
+    assert result["status"] == "success"
+    assert metadata["count"] == 1
+    assert metadata["total"] == 540
+
+    # The mismatch is unmissable at the top level of metadata.
+    assert metadata["query_not_executed_as_submitted"] is True
+    assert "BROADER" in metadata["warning"]
+
+    assert metadata["quoted_phrases_not_found"] == [
+        '"JAK2 V617F thrombosis unicornwombatxyz"'
+    ]
+    assert metadata["phrases_ignored"] == ["and"]
+    assert metadata["executed_query"] == "jak2[All Fields] AND v617f[All Fields]"
+
+
+def test_unmatched_quoted_phrase_disclosed_on_empty_result():
+    result = _run(
+        {
+            "idlist": [],
+            "count": "0",
+            "querytranslation": "jak2[All Fields]",
+            "warninglist": {
+                "quotedphrasesnotfound": ['"unicornwombatxyz"'],
+                "phrasesignored": [],
+                "outputmessages": [],
+            },
+        },
+        {"status": "success", "data": []},
+    )
+
+    metadata = result["metadata"]
+    assert result["data"] == []
+    assert metadata["total"] == 0
+    assert metadata["query_not_executed_as_submitted"] is True
+    assert metadata["quoted_phrases_not_found"] == ['"unicornwombatxyz"']
+    assert metadata["executed_query"] == "jak2[All Fields]"
+    # Empty warning categories are not emitted as noise.
+    assert "phrases_ignored" not in metadata
+    assert "ncbi_messages" not in metadata
+
+
+@pytest.mark.parametrize(
+    "warninglist",
+    [
+        None,
+        {},
+        {"quotedphrasesnotfound": [], "phrasesignored": [], "outputmessages": []},
+    ],
+    ids=["absent", "empty-dict", "all-empty-lists"],
+)
+def test_no_warning_keys_when_ncbi_reports_none(warninglist):
+    esearch_result = {
+        "idlist": ["42567343"],
+        "count": "540",
+        "querytranslation": "jak2[All Fields] AND v617f[All Fields]",
+    }
+    if warninglist is not None:
+        esearch_result["warninglist"] = warninglist
+
+    metadata = _run(esearch_result, {"status": "success", "data": [ARTICLE]})[
+        "metadata"
+    ]
+
+    # Unaffected queries keep their original response shape exactly.
+    assert set(metadata) == {"count", "total", "query", "source"}
+
+
+def test_no_warning_keys_on_empty_result_without_warnings():
+    metadata = _run(
+        {"idlist": [], "count": "0"},
+        {"status": "success", "data": []},
+    )["metadata"]
+
+    assert set(metadata) == {"count", "total", "query", "source"}

--- a/tests/unit/test_pubmed_unmatched_phrase_disclosed.py
+++ b/tests/unit/test_pubmed_unmatched_phrase_disclosed.py
@@ -44,11 +44,13 @@ def _esearch_response(esearch_result):
 def _run(esearch_result, summaries):
     """Run the tool against a mocked esearch payload (no network)."""
     tool = _tool()
-    with patch.object(tool, "_enforce_rate_limit"), patch.object(
-        tool, "_fetch_summaries", return_value=summaries
-    ), patch(
-        "tooluniverse.pubmed_tool.request_with_retry",
-        return_value=_esearch_response(esearch_result),
+    with (
+        patch.object(tool, "_enforce_rate_limit"),
+        patch.object(tool, "_fetch_summaries", return_value=summaries),
+        patch(
+            "tooluniverse.pubmed_tool.request_with_retry",
+            return_value=_esearch_response(esearch_result),
+        ),
     ):
         return tool.run({"query": '"JAK2 V617F thrombosis unicornwombatxyz"'})
 


### PR DESCRIPTION
Four tools returned a well-formed, confident response to a question the caller did not ask, with nothing in the payload to reveal the substitution. All four were reproduced live via the CLI before any code was written, and each root cause was confirmed against the upstream API rather than inferred.

## 1. `PubMed_search_articles` — a phrase that matched nothing was silently dropped

```
tu run PubMed_search_articles '{"query":"\"JAK2 V617F thrombosis unicornwombatxyz\"","limit":3}'
tu run PubMed_search_articles '{"query":"JAK2 V617F thrombosis","limit":3}'
```
Both returned `total: 540` and the identical top three PMIDs. The token `unicornwombatxyz` appears in no indexed article and had zero effect.

NCBI esearch drops quoted phrases it cannot match, answers a broader query, and reports exactly that in `esearchresult.warninglist` (`quotedphrasesnotfound`, `phrasesignored`) plus `querytranslation`. The tool read only `idlist` and `count`, so the disclosure never reached the caller.

Now propagated into `metadata` at both search return points. Additive only — queries NCBI does not warn about keep their existing metadata shape byte for byte.

## 2. BV-BRC — a page of rows reported as the complete match set

`metadata.total_results` was `len(results)`, so it always equalled the requested `limit`:
```
tu run BVBRC_search_genome_features '{"gene":"blaOXA-48","limit":3}'   # total_results: 3
tu run BVBRC_search_genome_features '{"gene":"blaOXA-48","limit":10}'  # total_results: 10
```
A surveillance user counting how far a resistance gene has spread could not tell truncation from completeness. BV-BRC already sends the true total in the `Content-Range` header (`items 0-3/13` for the query the tool actually issues), and exposes it via CORS.

Now parsed and reported as `returned_results` (this page) vs `total_results` (upstream), with explicit `truncated` + `truncation_note`. Both limits now report 13. Routed through one shared helper rather than ten copies of the same metadata block; header parsing is fully defensive and degrades to the old page-count behaviour when the header is absent or malformed.

## 3. `gather_gene_disease_associations` — answered about a different gene

```
tu run gather_gene_disease_associations '{"gene":"THP"}'
```
THP is the clinical alias for uromodulin. The tool returned 25 associations headed by "holoprosencephaly 9" (0.80) — **GLI2's** diseases — shaped exactly like a correct answer.

The OpenTargets target lookup is a fuzzy free-text search, so an unrecognised symbol still returns a ranked hit list; the code fell back to `hits[0]`. The hits carry only `id`/`name`/`description` with no synonym fields, so the alias is genuinely unresolvable here. Rather than guess, the tool now reports the symbol unresolved and names the candidates returned (GLI2, UMOD, THPO, PROS1, ...) so the caller can re-query. No alias table was added — a growing alias list is the anti-pattern this avoids. `{"gene":"UMOD"}` still returns its 27 kidney associations unchanged.

## 4. `proteins_api_search` — two paths to a silent empty for data that exists

**Asymmetric retry.** The empty-result retry swapped the search field only in the gene→protein direction. The routing heuristic sends anything over 10 characters to `protein=`, so `blaCTX-M-15` (the most common ESBL gene worldwide, 11 chars) was never retried as `gene=`; with a caller-supplied `organism` the auto-widen branch was skipped too, leaving no retry at all. Confirmed upstream that `gene=blaCTX-M-15&organism=Klebsiella pneumoniae` returns A0A077JMT3 while `protein=` returns `[]`. The swap is now symmetric.

**Numeric organism.** `organism` takes a name and `taxid` takes a number; `{"gene":"JAK2","organism":"9606"}` matched nothing and returned an empty success. A purely numeric value is unambiguously a taxonomy id, so it is routed to `taxid=` and the correction is disclosed in `normalization_note` — silent input mutation is the same class of defect this PR is about.

## Verification

- Full `tests/unit` suite: passes (exit 0, skips only for absent optional deps).
- All 49 pre-existing tests covering the touched areas pass unchanged; no pre-existing assertion was modified.
- Four new focused unit tests, all fully mocked (no network): `test_pubmed_unmatched_phrase_disclosed.py`, `test_bvbrc_total_reflects_upstream_count.py`, `test_gene_disease_no_wrong_target_substitution.py`, `test_proteins_api_search_no_silent_empty.py`.
- Every fix and every regression guard re-run live through the CLI.
- No files touched that are owned by the open round-26 (#500) or round-27 (#501) branches; `base_tool.py` and `execute_function.py` untouched.
- Tracked wrapper tree (`src/tooluniverse/tools/`, `_lazy_registry_static.py`) verified clean; no generator was run.

Two known-genuine defects in #500's territory (`ClinicalTrials_search_by_intervention` ignoring `phase`/`max_results`, `FDA_search_drug_labels` dropping `query`) were recognised and deliberately left alone.