### PR TITLE
Fix Round 29: partial answers presented as complete ones

### DIFF
--- a/src/tooluniverse/base_rest_tool.py
+++ b/src/tooluniverse/base_rest_tool.py
@@ -237,6 +237,87 @@ class BaseRESTTool(BaseTool):
 
         return result
 
+    @staticmethod
+    def _resolve_path(data: Any, path) -> Any:
+        """
+        Walk a list of dict keys / list indices into a decoded JSON payload.
+
+        Returns None if any step is missing, so callers can treat "not found"
+        and "explicitly null" alike (neither is usable as a total/row list).
+        """
+        current = data
+        for step in path or []:
+            if isinstance(step, int) and not isinstance(step, bool):
+                if not isinstance(current, (list, tuple)) or not (
+                    -len(current) <= step < len(current)
+                ):
+                    return None
+                current = current[step]
+            else:
+                if not isinstance(current, dict) or step not in current:
+                    return None
+                current = current[step]
+        return current
+
+    def _apply_pagination_disclosure(self, result: Dict[str, Any]) -> None:
+        """
+        Surface upstream truncation at the top level of the response.
+
+        Opt-in via ``fields.pagination_disclosure``; tools without the key are
+        untouched. Many APIs return a server-side page of a larger result set
+        and report the real total somewhere inside the payload (World Bank puts
+        ``{"page","pages","per_page","total"}`` at ``data[0]``; OData services
+        return ``@odata.count``). Left buried there, a partial answer is
+        indistinguishable from a complete one -- a country panel can lose a
+        whole country and still report ``status: success``.
+
+        Config keys (all paths are lists of dict keys / list indices into
+        ``result["data"]``)::
+
+            {
+              "total_path": [0, "total"],   # int: rows matching upstream
+              "rows_path": [1],             # list: rows actually returned
+              "page_path": [0, "page"],     # optional int
+              "pages_path": [0, "pages"],   # optional int
+              "more_hint": "How to fetch the rest."
+            }
+
+        Sets ``count`` to the real row count (not the length of an envelope),
+        plus ``total_available`` and an explicit ``truncated`` boolean so
+        "complete" and "partial" are never conflated. When truncated, adds a
+        top-level ``truncation_note`` naming the true total.
+        """
+        config = self.tool_config.get("fields", {}).get("pagination_disclosure")
+        if not config:
+            return
+
+        data = result.get("data")
+        total = self._resolve_path(data, config.get("total_path"))
+        rows = self._resolve_path(data, config.get("rows_path"))
+        if not isinstance(total, int) or isinstance(total, bool):
+            return
+        if not isinstance(rows, list):
+            return
+
+        returned = len(rows)
+        result["count"] = returned
+        result["total_available"] = total
+        result["truncated"] = returned < total
+        if returned >= total:
+            return
+
+        page = self._resolve_path(data, config.get("page_path"))
+        pages = self._resolve_path(data, config.get("pages_path"))
+        page_part = ""
+        if isinstance(page, int) and isinstance(pages, int):
+            page_part = f" This is page {page} of {pages}."
+        hint = config.get("more_hint", "")
+        result["truncation_note"] = (
+            f"Partial result: {returned} of {total} matching records were "
+            f"returned; {total - returned} are missing.{page_part} "
+            f"{hint}"
+        ).strip()
+
     def _handle_special_endpoint(
         self, url: str, response: requests.Response, arguments: Dict[str, Any]
     ) -> Optional[Dict[str, Any]]:
@@ -339,6 +420,15 @@ class BaseRESTTool(BaseTool):
                 max_attempts=3,
             )
 
+            # The echoed `url` is the endpoint only -- query params live in
+            # `params` and never appear in it, so a caller cannot tell what was
+            # actually requested (which page? which filter? which $top?) and
+            # cannot reproduce the call. `fields.echo_request_url` opts a tool
+            # into echoing the fully-resolved request URI instead. Guarded with
+            # getattr so stubbed responses in tests stay valid.
+            if self.tool_config.get("fields", {}).get("echo_request_url"):
+                url = getattr(response, "url", None) or url
+
             # Check for errors (accept any 2xx success status)
             if not (200 <= response.status_code < 300):
                 return {
@@ -370,6 +460,10 @@ class BaseRESTTool(BaseTool):
                     result["total_before_limit"] = len(data)
                     result["data"] = data[: int(limit)]
                     result["count"] = int(limit)
+
+            # Disclose server-side pagination/truncation at the top level for
+            # tools that opt in via `fields.pagination_disclosure`.
+            self._apply_pagination_disclosure(result)
 
             # Fix-R32C-4/5: an exact-match backend (e.g. CPIC's PostgREST
             # name=eq.{name}) silently returns status:success with an empty

--- a/src/tooluniverse/cbioportal_tool.py
+++ b/src/tooluniverse/cbioportal_tool.py
@@ -1,6 +1,7 @@
+import re
 import requests
 from typing import Any, Callable, Dict, Optional
-from urllib.parse import quote
+from urllib.parse import quote, urlencode, urlsplit, urlunsplit, parse_qsl
 from .base_tool import BaseTool
 from .tool_registry import register_tool
 
@@ -25,6 +26,191 @@ class CBioPortalRESTTool(BaseTool):
         for k, v in args.items():
             url = url.replace(f"{{{k}}}", str(v))
         return url
+
+    # cBioPortal paginates with `pageSize`/`pageNumber` query params.
+    _PAGE_SIZE_RE = re.compile(r"[?&]pageSize=(\d+)", re.IGNORECASE)
+    _PAGE_NUMBER_RE = re.compile(r"[?&]pageNumber=(\d+)", re.IGNORECASE)
+
+    @staticmethod
+    def _as_int(value: Any, default: int) -> int:
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return default
+
+    def _fetch_total_count(self, url: str) -> Optional[int]:
+        """Ask cBioPortal how many records the query matches in total.
+
+        cBioPortal only reports the true total through `projection=META`,
+        which answers with an empty body plus a `Total-Count` header.
+        Verified live: `GET /api/studies?projection=META` -> `Total-Count:
+        539` while the tool's default `pageSize=20` body carries 20
+        records. The paging params are stripped from the probe because the
+        `/studies` endpoint clamps the META count to `pageSize`
+        (`/api/studies?pageSize=20&projection=META` -> `Total-Count: 20`),
+        which would defeat the whole point of asking.
+
+        Returns None when the total cannot be established, so callers can
+        say "unknown" rather than invent a number.
+        """
+        parts = urlsplit(url)
+        query = [
+            (key, value)
+            for key, value in parse_qsl(parts.query)
+            if key.lower() not in ("pagesize", "pagenumber", "projection")
+        ]
+        query.append(("projection", "META"))
+        probe_url = urlunsplit(
+            (parts.scheme, parts.netloc, parts.path, urlencode(query), parts.fragment)
+        )
+        try:
+            response = self.session.get(probe_url, timeout=self.timeout)
+        except requests.RequestException:
+            return None
+        if response.status_code != 200:
+            return None
+        raw = response.headers.get("Total-Count") or response.headers.get(
+            "X-Total-Count"
+        )
+        try:
+            return int(raw)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _truncation_fields(
+        *, returned: int, offset: int, total: Optional[int], how_to_get_more: str
+    ) -> Dict[str, Any]:
+        """Build the disclosure keys that tell a slice apart from a full set.
+
+        `count` stays the number of records actually returned;
+        `total_available` is always the upstream total for the same query,
+        so neither field's meaning depends on whether the page limit
+        happened to bind.
+        """
+        if total is None:
+            return {
+                "total_available": None,
+                "truncated": True,
+                "truncation_note": (
+                    f"Returned {returned} record(s) starting at offset {offset}. "
+                    "The page came back full, so more records may exist upstream, "
+                    "but cBioPortal did not report the total for this query. "
+                    f"{how_to_get_more}"
+                ),
+            }
+        if offset + returned >= total:
+            return {"total_available": total, "truncated": False}
+        return {
+            "total_available": total,
+            "truncated": True,
+            "truncation_note": (
+                f"Returned {returned} of {total} matching record(s), starting at "
+                f"offset {offset}. This is a page, not the complete set — records "
+                f"absent here may still exist upstream. {how_to_get_more}"
+            ),
+        }
+
+    def _disclose_generic_truncation(
+        self, result: Dict[str, Any], url: str
+    ) -> Dict[str, Any]:
+        """Attach total/truncation disclosure to a plain paginated GET result.
+
+        Endpoints whose URL carries no `pageSize` return their whole set and
+        are left untouched. When the returned page is short, the set is known
+        to be exhausted without spending a second request.
+        """
+        data = result.get("data")
+        if not isinstance(data, list):
+            return result
+        size_match = self._PAGE_SIZE_RE.search(url)
+        if not size_match:
+            return result
+
+        page_size = int(size_match.group(1))
+        number_match = self._PAGE_NUMBER_RE.search(url)
+        offset = page_size * int(number_match.group(1) if number_match else 0)
+        returned = len(data)
+
+        if returned < page_size:
+            total: Optional[int] = offset + returned
+        else:
+            total = self._fetch_total_count(url)
+
+        props = self.tool_config.get("parameter", {}).get("properties", {})
+        size_param = "limit" if "limit" in props else "page_size"
+        page_param = "page_number" if "page_number" in props else None
+        hint = f"Re-run with a larger `{size_param}`"
+        if total is not None:
+            hint += f" (`{size_param}={total}` returns everything)"
+        if page_param:
+            hint += f", or page through the rest with `{page_param}`"
+        result.update(
+            self._truncation_fields(
+                returned=returned,
+                offset=offset,
+                total=total,
+                how_to_get_more=hint + ".",
+            )
+        )
+        return result
+
+    def _fetch_cancer_studies(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        """Return a page of the cBioPortal study catalogue plus its true size.
+
+        The endpoint defaults to `pageSize=20` while the catalogue holds 539
+        studies (verified live: `GET /api/studies` returns 539 records and
+        `GET /api/studies?projection=META` reports `Total-Count: 539`), so a
+        bare call used to look like the complete list of everything
+        cBioPortal has — a study sitting at position 21 read as "not in
+        cBioPortal at all".
+
+        `offset` is applied client-side because the endpoint accepts
+        `pageNumber` and then ignores it (verified live:
+        `?pageSize=5&pageNumber=2` returns the same first five studies as
+        `pageNumber=0`), so the tool over-fetches by `offset` and slices.
+        """
+        limit = max(self._as_int(arguments.get("limit"), 20), 1)
+        offset = max(self._as_int(arguments.get("offset"), 0), 0)
+        window = limit + offset
+
+        url = self._build_url({**arguments, "limit": window})
+        response = self.session.get(url, timeout=self.timeout)
+        response.raise_for_status()
+        fetched = response.json()
+        if not isinstance(fetched, list):
+            fetched = []
+        page = fetched[offset : offset + limit]
+
+        if len(fetched) < window:
+            # A short window means the catalogue is exhausted; no probe needed.
+            total: Optional[int] = len(fetched)
+        else:
+            probed = self._fetch_total_count(url)
+            total = None if probed is None else max(probed, len(fetched))
+
+        result = {
+            "status": "success",
+            "data": page,
+            "url": url,
+            "count": len(page),
+            "limit": limit,
+            "offset": offset,
+        }
+        result.update(
+            self._truncation_fields(
+                returned=len(page),
+                offset=offset,
+                total=total,
+                how_to_get_more=(
+                    "Raise `limit` to retrieve the whole catalogue in one call, or "
+                    "page through it with `offset`"
+                    + (f" (next page: offset={offset + len(page)})" if page else "")
+                    + "."
+                ),
+            )
+        )
+        return result
 
     def _get_gene_entrez_ids(self, gene_symbols: str) -> list[int]:
         """Convert gene symbols to Entrez IDs"""
@@ -216,6 +402,11 @@ class CBioPortalRESTTool(BaseTool):
             ):
                 return self._fetch_discrete_cna(arguments)
 
+            # The study catalogue needs client-side offset handling and an
+            # explicit catalogue size; see _fetch_cancer_studies.
+            if "cBioPortal_get_cancer_studies" in self.tool_config.get("name", ""):
+                return self._fetch_cancer_studies(arguments)
+
             # Special handling for mutation queries with new API
             if "cBioPortal_get_mutations" in self.tool_config.get("name", ""):
                 study_id = arguments.get("study_id")
@@ -299,12 +490,16 @@ class CBioPortalRESTTool(BaseTool):
             response.raise_for_status()
             data = response.json()
 
-            return {
+            result = {
                 "status": "success",
                 "data": data,
                 "url": url,
                 "count": len(data) if isinstance(data, list) else 1,
             }
+            # Paginated endpoints (gene panels, clinical data, samples,
+            # patients) previously returned only `count` -- the size of the
+            # page -- which is indistinguishable from the size of the set.
+            return self._disclose_generic_truncation(result, url)
         except Exception as e:
             return {
                 "status": "error",

--- a/src/tooluniverse/data/cbioportal_tools.json
+++ b/src/tooluniverse/data/cbioportal_tools.json
@@ -2,11 +2,12 @@
   {
     "type": "CBioPortalRESTTool",
     "name": "cBioPortal_get_cancer_studies",
-    "description": "Get list of cancer studies from cBioPortal",
+    "description": "Get one page of the cBioPortal study catalogue. This returns a SLICE, not the whole catalogue: `limit` defaults to 20 while cBioPortal currently holds several hundred studies. The response always reports `total_available` (the full catalogue size) alongside `count` (studies actually returned), and sets `truncated: true` with a `truncation_note` whenever studies were left behind. Never conclude a study is missing from cBioPortal from a truncated page — raise `limit` to `total_available`, or page with `offset`, before drawing that conclusion.",
     "parameter": {
       "type": "object",
       "properties": {
-        "limit": {"type": "integer", "default": 20, "description": "Number of studies to return"}
+        "limit": {"type": "integer", "default": 20, "description": "Number of studies to return in this page. The default of 20 covers only a small fraction of the catalogue; set it to the `total_available` reported in the response to retrieve every study."},
+        "offset": {"type": "integer", "default": 0, "description": "0-based index of the first study to return, for paging through the catalogue. Applied client-side because the cBioPortal /studies endpoint ignores its own pageNumber parameter."}
       }
     },
     "fields": {
@@ -318,7 +319,7 @@
   {
     "type": "CBioPortalRESTTool",
     "name": "cBioPortal_get_gene_panels",
-    "description": "Get all gene panels used in cBioPortal studies. Gene panels define which genes were sequenced in a study. Use to understand coverage before querying mutation data.",
+    "description": "Get gene panels used in cBioPortal studies. Gene panels define which genes were sequenced in a study. Use to understand coverage before querying mutation data. Returns one page: `page_size` defaults to 50, and the response reports `total_available` (all panels matching) next to `count` (panels returned), plus `truncated`/`truncation_note` when panels were left behind.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -409,7 +410,7 @@
   {
     "type": "CBioPortalRESTTool",
     "name": "cBioPortal_get_clinical_data",
-    "description": "Get clinical data for all samples in a study. Returns patient-level data like tumor stage, histology, survival status. Filter by clinical attribute ID for specific data types.",
+    "description": "Get clinical data for samples in a study. Returns patient-level data like tumor stage, histology, survival status. Filter by clinical attribute ID for specific data types. Returns one page: `page_size` defaults to 100 while a single TCGA study can hold tens of thousands of clinical records, so the response reports `total_available` (all records matching) next to `count` (records returned), plus `truncated`/`truncation_note` when records were left behind.",
     "parameter": {
       "type": "object",
       "properties": {

--- a/src/tooluniverse/data/europe_pmc_tools.json
+++ b/src/tooluniverse/data/europe_pmc_tools.json
@@ -2,7 +2,7 @@
   {
     "type": "EuropePMCTool",
     "name": "EuropePMC_search_articles",
-    "description": "Search for articles on Europe PMC including abstracts and metadata. Europe PMC supports fielded queries for indexed full text (e.g., BODY:\"term\") but only for records where Europe PMC has full text indexed (HAS_FT:Y). Use require_has_ft/fulltext_terms to avoid confusing 'has a full-text link somewhere' with 'full text searchable in Europe PMC'.",
+    "description": "Search for articles on Europe PMC including abstracts and metadata. Returns the top `limit` results ranked by relevance, which is normally a SLICE of the matches: `metadata.total_results` carries Europe PMC's own hitCount (every article matching the query) while `metadata.count` is only how many were returned, and a top-level `truncated: true` plus `truncation_note` appear whenever matches were left behind. Do not read a small `count` as 'few articles exist' — check `total_results`. Europe PMC supports fielded queries for indexed full text (e.g., BODY:\"term\") but only for records where Europe PMC has full text indexed (HAS_FT:Y). Use require_has_ft/fulltext_terms to avoid confusing 'has a full-text link somewhere' with 'full text searchable in Europe PMC'.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -12,7 +12,7 @@
         },
         "limit": {
           "type": "integer",
-          "description": "Number of articles to return. This sets the maximum number of articles retrieved from Europe PMC.",
+          "description": "Number of articles to return. This sets the maximum number of articles retrieved from Europe PMC; anything beyond it is silently left behind, so compare it against `metadata.total_results` in the response (Europe PMC's hitCount) before treating the returned set as complete. Europe PMC accepts up to 1000 per request.",
           "default": 5
         },
         "require_has_ft": {

--- a/src/tooluniverse/data/gtdb_tools.json
+++ b/src/tooluniverse/data/gtdb_tools.json
@@ -294,7 +294,7 @@
   },
   {
     "name": "GTDB_search_genomes",
-    "description": "Search for prokaryotic genomes in GTDB by organism name. This matches against the whole taxonomic clade, not just the organism-name text, so results can include other members of the same family/genus alongside genomes whose own name matches the query (exact/prefix name matches are ranked first). Returns genome accessions with both NCBI and GTDB taxonomy classifications, allowing comparison between the two taxonomic systems. Each result shows the genome accession (GCA/GCF), NCBI organism name, NCBI taxonomy, GTDB taxonomy, and whether the genome is a GTDB species representative. Supports pagination. Useful for finding genome accessions, exploring taxonomic reclassifications, and linking genomes to the GTDB taxonomy.",
+    "description": "Search for prokaryotic genomes in GTDB by organism name. A multi-word query (e.g. a binomial like 'Mycobacterium tuberculosis') is first matched precisely, requiring EVERY term of the query to appear in the genome's name or taxonomy; 'match_type' is then 'exact'. If nothing matches the whole query, the tool falls back to GTDB's loose search, which matches ANY term of the query and therefore returns a broader taxon (often just the genus) or a different species; that case is reported as 'match_type': 'broad' with a top-level 'note', and 'total_results' then counts the broader match rather than the queried organism -- always read 'match_type' and 'total_results_scope' before quoting a count or trusting a result. Results also match against the whole taxonomic clade rather than organism-name text alone, so exact/prefix name matches are ranked first within a page. Returns genome accessions with both NCBI and GTDB taxonomy classifications, allowing comparison between the two taxonomic systems. Each result shows the genome accession (GCA/GCF), NCBI organism name, NCBI taxonomy, GTDB taxonomy, and whether the genome is a GTDB species representative. Supports pagination. Useful for finding genome accessions, exploring taxonomic reclassifications, and linking genomes to the GTDB taxonomy.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -346,9 +346,26 @@
               "type": "string",
               "description": "The search query"
             },
+            "match_type": {
+              "type": "string",
+              "enum": [
+                "exact",
+                "broad",
+                "none"
+              ],
+              "description": "How the results relate to the query. 'exact': every returned genome matches every term of the query. 'broad': nothing matched the whole query, so these results match only part of it (typically the genus) and are NOT the queried organism -- see 'note'. 'none': GTDB holds no matching genome."
+            },
             "total_results": {
               "type": "integer",
-              "description": "Total number of matching genomes"
+              "description": "Total number of genomes in the match described by 'match_type'. When match_type is 'broad' this is the count for the broader match, NOT for the queried organism -- see 'total_results_scope'."
+            },
+            "total_results_scope": {
+              "type": "string",
+              "description": "Plain-language statement of exactly what 'total_results' counts"
+            },
+            "note": {
+              "type": "string",
+              "description": "Present when match_type is 'broad' or 'none': explains that the results are not the queried organism and that total_results must not be reported as its genome count"
             },
             "page": {
               "type": "integer",

--- a/src/tooluniverse/data/iedb_prediction_tools.json
+++ b/src/tooluniverse/data/iedb_prediction_tools.json
@@ -1,27 +1,27 @@
 [
   {
     "name": "IEDB_predict_mhci_binding",
-    "description": "Predict MHC class I peptide binding using NetMHCpan via the IEDB Analysis Resource API. Given a protein sequence and HLA allele, predicts which peptides will bind and be presented on the cell surface. Returns peptides ranked by percentile rank (lower = stronger binding). Essential for vaccine design, neoantigen prediction, and epitope mapping. Supports human HLA-A/B/C and mouse H-2 alleles.",
+    "description": "Predict MHC class I peptide binding using NetMHCpan via the IEDB next-generation tools API (https://api-nextgen-tools.iedb.org). Given a protein sequence and HLA allele, predicts which peptides will bind and be presented on the cell surface. Returns one row per scored peptide with the method's own score/IC50 and percentile columns, plus a uniform 'percentile_rank' (lower = stronger binding), sorted strongest first. Essential for vaccine design, neoantigen prediction, and epitope mapping. Supports human HLA-A/B/C and mouse H2 alleles. The prediction runs asynchronously upstream and typically returns within about 15 seconds.",
     "parameter": {
       "type": "object",
       "properties": {
         "sequence": {
           "type": "string",
-          "description": "Protein sequence (amino acid letters, e.g., 'TYQRTRALVFQRTRALKMFAL'). Multiple peptides can be concatenated."
+          "description": "Protein sequence (amino acid letters, e.g., 'TYQRTRALVFQRTRALKMFAL'). Multiple peptides can be concatenated. A FASTA block (starting with '>') is also accepted."
         },
         "allele": {
           "type": "string",
-          "description": "MHC allele name. Human: 'HLA-A*02:01', 'HLA-B*07:02'. Mouse: 'H-2-Kd', 'H-2-Db'. Default: HLA-A*02:01",
+          "description": "MHC allele name, validated upstream against the MHC Restriction Ontology. Human: 'HLA-A*02:01', 'HLA-B*07:02'. Mouse: 'H2-Kd', 'H2-Db' (the legacy 'H-2-Kd' spelling is accepted and translated). Comma-separate for several alleles. Default: HLA-A*02:01",
           "default": "HLA-A*02:01"
         },
         "method": {
           "type": "string",
-          "description": "Prediction method. 'netmhcpan_el' (recommended, eluted ligand), 'netmhcpan_ba' (binding affinity), 'ann', 'smm'",
+          "description": "Prediction method: 'netmhcpan_el' (recommended, eluted ligand), 'netmhcpan_ba' (binding affinity), 'netmhcpan', 'ann', 'smm', 'smmpmbec', 'comblib_sidney2008', 'consensus', 'mhcflurry', 'mhcnp', 'pickpocket'",
           "default": "netmhcpan_el"
         },
         "length": {
           "type": "integer",
-          "description": "Peptide length (8-14 for MHC-I, typically 9)",
+          "description": "Peptide length (8-15 for MHC-I, typically 9)",
           "default": 9
         }
       },
@@ -66,27 +66,27 @@
   },
   {
     "name": "IEDB_predict_mhcii_binding",
-    "description": "Predict MHC class II peptide binding using NetMHCIIpan via the IEDB Analysis Resource API. Predicts CD4+ T helper cell epitopes. Given a protein sequence and HLA-DR/DP/DQ allele, returns predicted binding peptides ranked by percentile rank. Essential for vaccine design (helper epitopes) and autoimmunity research.",
+    "description": "Predict MHC class II peptide binding using NetMHCIIpan via the IEDB next-generation tools API (https://api-nextgen-tools.iedb.org). Predicts CD4+ T helper cell epitopes. Given a protein sequence and HLA-DR/DP/DQ allele, returns one row per scored sliding-window peptide with the method's own core/score/percentile columns plus a uniform 'percentile_rank' (lower = stronger binding), sorted strongest first. Essential for vaccine design (helper epitopes) and autoimmunity research. The prediction runs asynchronously upstream and typically returns within about 15 seconds.",
     "parameter": {
       "type": "object",
       "properties": {
         "sequence": {
           "type": "string",
-          "description": "Protein sequence (amino acid letters)"
+          "description": "Protein sequence (amino acid letters). A FASTA block (starting with '>') is also accepted."
         },
         "allele": {
           "type": "string",
-          "description": "MHC-II allele. Examples: 'HLA-DRB1*01:01', 'HLA-DRB1*15:01'. Default: HLA-DRB1*01:01",
+          "description": "MHC-II allele, validated upstream against the MHC Restriction Ontology. Examples: 'HLA-DRB1*01:01', 'HLA-DRB1*15:01'. Comma-separate for several alleles. Default: HLA-DRB1*01:01",
           "default": "HLA-DRB1*01:01"
         },
         "method": {
           "type": "string",
-          "description": "Prediction method: 'netmhciipan_el' (recommended), 'netmhciipan_ba', 'nn_align'",
+          "description": "Prediction method: 'netmhciipan_el' (recommended), 'netmhciipan_ba', 'nn_align', 'smm_align', 'comblib', 'tepitope', 'consensus'",
           "default": "netmhciipan_el"
         },
         "length": {
           "type": ["integer", "null"],
-          "description": "Sliding-window peptide length IEDB scores within 'sequence'. IEDB defaults this to 15 server-side and errors if 'sequence' is shorter than it; omit to auto-match the sequence's own length when it's under 15."
+          "description": "Sliding-window peptide length scored within 'sequence' (11-30, default 15). Cannot exceed the sequence length; omit to use 15, or the sequence's own length when that is shorter."
         }
       },
       "required": [
@@ -211,13 +211,13 @@
   },
   {
     "name": "IEDB_predict_antigen_processing",
-    "description": "Predict MHC class I antigen processing using the IEDB Analysis Resource processing tool. Unlike raw binding prediction, this chains proteasomal cleavage + TAP transport + MHC-I binding into a combined processing_score and total_score, predicting peptides that are naturally processed and presented to CD8+ T cells. Given a protein sequence and HLA allele, returns per-peptide proteasome_score, tap_score, mhc_score, processing_score, total_score and ic50_score (nM). Use for neoantigen and epitope prioritization beyond binding affinity. No authentication required.",
+    "description": "Predict MHC class I antigen processing using the IEDB next-generation tools API (https://api-nextgen-tools.iedb.org). Unlike raw binding prediction, this runs the NetCTLpan processing predictor alongside an MHC-I binding predictor, chaining proteasomal cleavage + TAP transport + MHC-I binding into a combined score that identifies peptides likely to be naturally processed and presented to CD8+ T cells. Returns one row per peptide with cleavage_prediction_score, tap_prediction_score, mhc_prediction and combined_prediction_score (sorted highest first), alongside the binding method's own IC50/score and percentile columns. Use for neoantigen and epitope prioritization beyond binding affinity. Sequences of 20 or more residues are recommended, since cleavage prediction needs flanking context. No authentication required.",
     "parameter": {
       "type": "object",
       "properties": {
         "sequence": {
           "type": "string",
-          "description": "Protein sequence (single-letter amino acids), e.g. 'SLYNTVATLYCVHQRIDV'. Aliases: sequence_text."
+          "description": "Protein sequence (single-letter amino acids), e.g. 'SLYNTVATLYCVHQRIDVKQNTLKLATGGKS'. 20+ residues recommended. Aliases: sequence_text."
         },
         "sequence_text": {
           "type": "string",
@@ -225,17 +225,17 @@
         },
         "allele": {
           "type": "string",
-          "description": "MHC class I allele. Human: 'HLA-A*02:01', 'HLA-B*07:02'. Mouse: 'H-2-Kd'. Default: HLA-A*02:01",
+          "description": "MHC class I allele, validated upstream against the MHC Restriction Ontology. Human: 'HLA-A*02:01', 'HLA-B*07:02'. Mouse: 'H2-Kd' (the legacy 'H-2-Kd' spelling is accepted and translated). Default: HLA-A*02:01",
           "default": "HLA-A*02:01"
         },
         "method": {
           "type": "string",
-          "description": "MHC-I binding method used in the chain: 'netmhcpan' (default), 'ann', 'smm', 'comblib_sidney2008'.",
+          "description": "MHC-I binding method used in the chain: 'netmhcpan' (default), 'netmhcpan_ba', 'netmhcpan_el', 'ann', 'smm', 'smmpmbec', 'comblib_sidney2008', 'consensus'.",
           "default": "netmhcpan"
         },
         "length": {
           "type": "integer",
-          "description": "Peptide length (8-14 for MHC-I, typically 9).",
+          "description": "Peptide length (8-15 for MHC-I, typically 9).",
           "default": 9
         }
       },
@@ -249,7 +249,7 @@
     "type": "IEDBPredictionTool",
     "test_examples": [
       {
-        "sequence": "SLYNTVATLYCVHQRIDV",
+        "sequence": "SLYNTVATLYCVHQRIDVKQNTLKLATGGKS",
         "allele": "HLA-A*02:01",
         "length": 9
       }
@@ -264,23 +264,29 @@
               "peptide": {
                 "type": "string"
               },
-              "proteasome_score": {
+              "start": {
                 "type": ["number", "string"]
               },
-              "tap_score": {
+              "end": {
                 "type": ["number", "string"]
               },
-              "mhc_score": {
-                "type": ["number", "string"]
+              "allele": {
+                "type": "string"
               },
-              "processing_score": {
-                "type": ["number", "string"]
+              "cleavage_prediction_score": {
+                "type": ["number", "string", "null"]
               },
-              "total_score": {
-                "type": ["number", "string"]
+              "tap_prediction_score": {
+                "type": ["number", "string", "null"]
               },
-              "ic50_score": {
-                "type": ["number", "string"]
+              "mhc_prediction": {
+                "type": ["number", "string", "null"]
+              },
+              "combined_prediction_score": {
+                "type": ["number", "string", "null"]
+              },
+              "median_percentile": {
+                "type": ["number", "string", "null"]
               }
             }
           }

--- a/src/tooluniverse/data/nextstrain_tools.json
+++ b/src/tooluniverse/data/nextstrain_tools.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "Nextstrain_list_datasets",
-    "description": "List available pathogen phylogenetic datasets from Nextstrain. Returns datasets grouped by pathogen (e.g., avian-flu, dengue, ebola, flu, measles, mpox, SARS-CoV-2, zika). Optionally filter by pathogen name. Nextstrain provides real-time molecular epidemiology for public health, tracking how pathogens evolve and spread worldwide.",
+    "description": "List available pathogen phylogenetic datasets from Nextstrain. Returns datasets grouped by pathogen (e.g., avian-flu, dengue, ebola, flu, measles, mpox, SARS-CoV-2, zika), each with its true 'dataset_count'. By default only the first 10 dataset paths per pathogen are listed; when that hides entries the response sets 'truncated': true with a 'truncation_note', and 'metadata.total_datasets' always reports the full catalogue size (not the number listed). Pass datasets_per_pathogen=0 to list every dataset. Optionally filter by pathogen name. Nextstrain provides real-time molecular epidemiology for public health, tracking how pathogens evolve and spread worldwide.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -11,6 +11,14 @@
             "null"
           ],
           "description": "Optional pathogen name filter. Examples: 'flu', 'ebola', 'zika', 'dengue', 'mpox'. Leave empty for all pathogens."
+        },
+        "datasets_per_pathogen": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0,
+          "description": "Maximum number of dataset paths listed per pathogen (default 10). Set to 0 to list every dataset with no cap, or to a larger number (e.g. 100) to cover the biggest pathogens such as ncov and avian-flu."
         }
       },
       "required": []
@@ -38,13 +46,23 @@
                 "type": "string"
               },
               "dataset_count": {
-                "type": "integer"
+                "type": "integer",
+                "description": "True number of datasets available for this pathogen, regardless of how many are listed below."
               },
               "datasets": {
                 "type": "array",
                 "items": {
                   "type": "string"
-                }
+                },
+                "description": "Dataset paths, capped by the datasets_per_pathogen argument (default 10)."
+              },
+              "datasets_listed": {
+                "type": "integer",
+                "description": "Number of entries actually present in 'datasets'."
+              },
+              "datasets_truncated": {
+                "type": "boolean",
+                "description": "Present and true when 'datasets' lists fewer paths than 'dataset_count'."
               }
             }
           }
@@ -139,6 +157,9 @@
               "items": {
                 "type": "string"
               }
+            },
+            "available_colorings_count": {
+              "type": "integer"
             }
           }
         },

--- a/src/tooluniverse/data/pdc_tools.json
+++ b/src/tooluniverse/data/pdc_tools.json
@@ -2,7 +2,7 @@
   {
     "name": "PDC_search_studies",
     "type": "PDCTool",
-    "description": "Search the NCI Proteomics Data Commons (PDC) for cancer proteomics studies by keyword. PDC houses annotated data from CPTAC, ICPC, APOLLO, and other cancer proteomics programs covering 19+ cancer types with 160+ datasets. Search by disease name (e.g., 'Breast', 'Lung', 'CCRCC'), program name (e.g., 'CPTAC', 'HTAN'), or analytical fraction (e.g., 'Proteome', 'Phosphoproteome'). Returns matching study IDs, names, and PDC accession numbers. Use PDC study IDs with PDC_get_study_summary for detailed metadata.",
+    "description": "Search the NCI Proteomics Data Commons (PDC) for cancer proteomics studies. PDC houses annotated data from CPTAC, ICPC, APOLLO, CBTN, and other cancer proteomics programs. The query is matched case-insensitively as a substring against each study's curated PDC metadata - disease_type (e.g. 'Lung Adenocarcinoma', 'Breast Invasive Carcinoma'), primary_site (e.g. 'Bronchus and lung'), analytical_fraction (e.g. 'Proteome', 'Phosphoproteome', 'Acetylome'), experiment_type (e.g. 'TMT11', 'iTRAQ4'), program_name, project_name - and against the study title (submitter_id_name). Program acronyms ('CPTAC', 'ICPC', 'APOLLO') are additionally resolved against PDC's controlled program vocabulary, so they match every study in the program rather than only studies whose title happens to contain the acronym. Each returned study reports matched_fields, naming which fields produced the hit, so a title-only match is distinguishable from a curated disease_type match. Returns study IDs, PDC accession numbers, titles and the full curated metadata for every match; use the PDC study IDs with PDC_get_study_summary or PDC_get_quant_data_matrix.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -16,7 +16,7 @@
         },
         "query": {
           "type": "string",
-          "description": "Search keyword for studies. Can be disease name (Breast, Lung, Renal), program name (CPTAC, HTAN), or fraction type (Proteome, Phosphoproteome, Acetylome)."
+          "description": "Search term, matched case-insensitively as a substring against each study's disease_type, primary_site, analytical_fraction, experiment_type, program_name, project_name and title. Examples: a disease name ('Lung Adenocarcinoma', 'Breast', 'Glioblastoma'), an anatomical site ('Bronchus and lung', 'Kidney'), a program acronym ('CPTAC', 'ICPC', 'APOLLO', 'CBTN'), an analytical fraction ('Proteome', 'Phosphoproteome', 'Acetylome', 'Ubiquitylome'), or a study-title fragment ('LUAD', 'CCRCC')."
         }
       },
       "required": [
@@ -30,6 +30,17 @@
           "type": "string",
           "description": "The search query used"
         },
+        "fields_searched": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Names of the study fields the query was matched against. Present on every response, including empty ones, so callers can tell an honest 'no PDC study is annotated with this term' from a search that never looked at the field they cared about."
+        },
+        "num_studies_searched": {
+          "type": "integer",
+          "description": "Number of PDC studies in the catalog that were examined"
+        },
         "studies": {
           "type": "array",
           "items": {
@@ -39,20 +50,76 @@
                 "type": "string",
                 "description": "PDC internal UUID for the study"
               },
-              "name": {
-                "type": "string",
-                "description": "Full study name"
-              },
               "pdc_study_id": {
                 "type": "string",
                 "description": "PDC accession number (e.g., PDC000127)"
+              },
+              "name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Study title (same value as submitter_id_name; retained for backward compatibility)"
               },
               "submitter_id_name": {
                 "type": [
                   "string",
                   "null"
                 ],
-                "description": "Submitter-provided study name"
+                "description": "Submitter-provided study name/title"
+              },
+              "disease_type": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Curated disease types (semicolon-separated if multiple)"
+              },
+              "primary_site": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Curated primary anatomical sites (semicolon-separated if multiple)"
+              },
+              "analytical_fraction": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Proteomics fraction analyzed (Proteome, Phosphoproteome, Acetylome, ...)"
+              },
+              "experiment_type": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Mass spec experiment type (TMT10, TMT11, iTRAQ, LFQ, ...)"
+              },
+              "program_name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Parent program name"
+              },
+              "project_name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Parent project name"
+              },
+              "matched_fields": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Which fields of this study the query matched. A study whose only entry is 'submitter_id_name' matched the free-text title, not curated metadata."
+              },
+              "matched_curated_metadata": {
+                "type": "boolean",
+                "description": "True when at least one curated metadata field (not just the study title) matched"
               }
             }
           }
@@ -60,6 +127,24 @@
         "num_results": {
           "type": "integer",
           "description": "Number of matching studies"
+        },
+        "num_results_by_field": {
+          "type": "object",
+          "description": "Per-field count of how many matching studies matched on that field. Counts overlap because one study can match on several fields.",
+          "additionalProperties": {
+            "type": "integer"
+          }
+        },
+        "note": {
+          "type": "string",
+          "description": "Present only when num_results is 0: explains that the request succeeded and lists the fields that were searched, so an empty result is not mistaken for a failure."
+        },
+        "warnings": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Present only when part of the search degraded (e.g. PDC's controlled program vocabulary could not be reached), describing what was reduced."
         }
       }
     },

--- a/src/tooluniverse/data/tcia_tools.json
+++ b/src/tooluniverse/data/tcia_tools.json
@@ -9,7 +9,7 @@
     "fields": {
       "endpoint": "https://services.cancerimagingarchive.net/nbia-api/services/v1/getCollectionValues"
     },
-    "type": "BaseRESTTool",
+    "type": "TCIATool",
     "test_examples": [
       {}
     ],
@@ -87,7 +87,7 @@
     "fields": {
       "endpoint": "https://services.cancerimagingarchive.net/nbia-api/services/v1/getSeries"
     },
-    "type": "BaseRESTTool",
+    "type": "TCIATool",
     "test_examples": [
       {
         "Collection": "LIDC-IDRI",
@@ -183,7 +183,7 @@
     "fields": {
       "endpoint": "https://services.cancerimagingarchive.net/nbia-api/services/v1/getPatientStudy"
     },
-    "type": "BaseRESTTool",
+    "type": "TCIATool",
     "test_examples": [
       {
         "Collection": "LIDC-IDRI",
@@ -257,7 +257,7 @@
     "fields": {
       "endpoint": "https://services.cancerimagingarchive.net/nbia-api/services/v1/getModalityValues"
     },
-    "type": "BaseRESTTool",
+    "type": "TCIATool",
     "test_examples": [
       {
         "Collection": "LIDC-IDRI"
@@ -315,7 +315,7 @@
     "fields": {
       "endpoint": "https://services.cancerimagingarchive.net/nbia-api/services/v1/getBodyPartValues"
     },
-    "type": "BaseRESTTool",
+    "type": "TCIATool",
     "test_examples": [
       {
         "Modality": "CT"
@@ -361,7 +361,7 @@
     "fields": {
       "endpoint": "https://services.cancerimagingarchive.net/nbia-api/services/v1/getSeriesMetaData"
     },
-    "type": "BaseRESTTool",
+    "type": "TCIATool",
     "test_examples": [
       {
         "SeriesInstanceUID": "1.3.6.1.4.1.14519.5.2.1.6834.5010.189721824525842725510380467695"
@@ -407,7 +407,7 @@
     "fields": {
       "endpoint": "https://services.cancerimagingarchive.net/nbia-api/services/v1/getSeriesSize"
     },
-    "type": "BaseRESTTool",
+    "type": "TCIATool",
     "test_examples": [
       {
         "SeriesInstanceUID": "1.3.6.1.4.1.14519.5.2.1.6279.6001.100225287222365663678666836860"
@@ -463,7 +463,7 @@
     "fields": {
       "endpoint": "https://services.cancerimagingarchive.net/nbia-api/services/v1/getPatient"
     },
-    "type": "BaseRESTTool",
+    "type": "TCIATool",
     "test_examples": [
       {
         "Collection": "LIDC-IDRI"
@@ -535,7 +535,7 @@
     "fields": {
       "endpoint": "https://services.cancerimagingarchive.net/nbia-api/services/v1/getSOPInstanceUIDs"
     },
-    "type": "BaseRESTTool",
+    "type": "TCIATool",
     "test_examples": [
       {
         "SeriesInstanceUID": "1.3.6.1.4.1.14519.5.2.1.6279.6001.179049373636438705059720603192"
@@ -601,7 +601,7 @@
     "fields": {
       "endpoint": "https://services.cancerimagingarchive.net/nbia-api/services/v1/getManufacturerValues"
     },
-    "type": "BaseRESTTool",
+    "type": "TCIATool",
     "test_examples": [
       {
         "Collection": "LIDC-IDRI",

--- a/src/tooluniverse/data/who_gho_tools.json
+++ b/src/tooluniverse/data/who_gho_tools.json
@@ -88,7 +88,7 @@
   },
   {
     "name": "WHOGHO_get_indicator_data",
-    "description": "Get actual health data values for a specific WHO Global Health Observatory indicator by its code. Returns country-level data with values, confidence intervals, year, and sex/age breakdowns. No authentication required. Common indicator codes: WHOSIS_000001 (life expectancy at birth), MALARIA002 (malaria cases), MDG_0000000026 (HIV prevalence), NCD_BMI_30C (obesity prevalence), SDGPM25 (PM2.5 air pollution), WHS4_100 (hospital beds per 10000).",
+    "description": "Get actual health data values for a specific WHO Global Health Observatory indicator by its code. Returns country-level data with values, confidence intervals, year, and sex/age breakdowns. No authentication required. Common indicator codes: WHOSIS_000001 (life expectancy at birth), MALARIA002 (malaria cases), MDG_0000000026 (HIV prevalence), NCD_BMI_30C (obesity prevalence), SDGPM25 (PM2.5 air pollution), WHS4_100 (hospital beds per 10000). Rows are ordered by country then year and capped at `top`: the response reports 'count' (rows returned), 'total_available' (rows matching upstream) and a 'truncated' flag, and when truncated a 'truncation_note' explaining how to retrieve the rest.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -108,7 +108,14 @@
             "integer",
             "null"
           ],
-          "description": "Maximum number of data rows to return. Default: 20"
+          "description": "Maximum number of data rows to return (default 100). One row is one country-year-dimension observation, so a full time series for one country needs top >= the number of years (and x3 if the indicator is broken down by sex). Raise this when the response reports truncated=true."
+        },
+        "orderby": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "OData $orderby clause controlling row order, which also determines which rows survive the `top` cut-off. Default: \"SpatialDim asc,TimeDim asc\" (grouped by country, then chronological), so a truncated result is a contiguous prefix rather than an arbitrary sample. Use \"TimeDim asc\" for a purely chronological cross-section, or \"TimeDim desc\" for the most recent years first."
         }
       },
       "required": [
@@ -118,11 +125,24 @@
     "fields": {
       "endpoint": "https://ghoapi.azureedge.net/api/{indicator_code}",
       "params": {
-        "$top": 20
+        "$top": 100,
+        "$orderby": "SpatialDim asc,TimeDim asc",
+        "$count": "true"
       },
       "param_mapping": {
         "filter": "$filter",
-        "top": "$top"
+        "top": "$top",
+        "orderby": "$orderby"
+      },
+      "echo_request_url": true,
+      "pagination_disclosure": {
+        "total_path": [
+          "@odata.count"
+        ],
+        "rows_path": [
+          "value"
+        ],
+        "more_hint": "The GHO OData API applied the `top` row cap server-side. Re-run with a larger `top` to retrieve the full series, or narrow `filter` (e.g. \"SpatialDim eq 'BGD'\", \"TimeDim ge 2015\") so the whole result fits. Rows are returned in `orderby` order, so a truncated result is a contiguous prefix of that ordering."
       }
     },
     "type": "BaseRESTTool",
@@ -148,6 +168,13 @@
           "type": "object",
           "description": "WHO GHO indicator data values",
           "properties": {
+            "@odata.count": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Total rows matching the query upstream, before the `top` cap. Compare with the length of 'value' (also echoed as the envelope's 'count'/'total_available'/'truncated' fields) to detect truncation."
+            },
             "value": {
               "type": "array",
               "description": "Data records",

--- a/src/tooluniverse/data/worldbank_tools.json
+++ b/src/tooluniverse/data/worldbank_tools.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "WorldBank_get_indicator",
-    "description": "Get World Bank development indicator data for one or more countries over time. Returns economic, health, education, and social development metrics from the World Development Indicators (WDI) database. Covers 200+ countries with annual data going back to 1960s. Example indicators: NY.GDP.MKTP.CD (GDP current USD), SP.POP.TOTL (total population), SH.DYN.MORT (child mortality), SE.ADT.LITR.ZS (adult literacy rate), SP.DYN.LE00.IN (life expectancy), SH.MED.PHYS.ZS (physicians per 1000), EN.ATM.CO2E.PC (CO2 per capita), SL.UEM.TOTL.ZS (unemployment rate).",
+    "description": "Get World Bank development indicator data for one or more countries over time. Returns economic, health, education, and social development metrics from the World Development Indicators (WDI) database. Covers 200+ countries with annual data going back to 1960s. Example indicators: NY.GDP.MKTP.CD (GDP current USD), SP.POP.TOTL (total population), SH.DYN.MORT (child mortality), SE.ADT.LITR.ZS (adult literacy rate), SP.DYN.LE00.IN (life expectancy), SH.MED.PHYS.ZS (physicians per 1000), EN.ATM.CO2E.PC (CO2 per capita), SL.UEM.TOTL.ZS (unemployment rate). Results are paginated server-side: the response reports 'count' (rows returned), 'total_available' (rows matching upstream) and a 'truncated' flag, and when truncated a 'truncation_note' explaining how to retrieve the rest via 'per_page'/'page'.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -26,6 +26,20 @@
             "null"
           ],
           "description": "Year or year range to filter data (e.g., '2020', '2015:2023' for a range)"
+        },
+        "per_page": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Rows returned per request (default 1000, maximum 32500). One row is one country-year observation, so a panel of N countries over Y years needs per_page >= N*Y. Raise this when the response reports truncated=true."
+        },
+        "page": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "1-based page number of the result set (default 1). Only needed when a result exceeds per_page: the response reports total_available and pages so you can fetch the remaining pages."
         }
       },
       "required": [
@@ -37,7 +51,26 @@
       "endpoint": "https://api.worldbank.org/v2/country/{country}/indicator/{indicator}",
       "params": {
         "format": "json",
-        "per_page": "50"
+        "per_page": "1000"
+      },
+      "echo_request_url": true,
+      "pagination_disclosure": {
+        "total_path": [
+          0,
+          "total"
+        ],
+        "rows_path": [
+          1
+        ],
+        "page_path": [
+          0,
+          "page"
+        ],
+        "pages_path": [
+          0,
+          "pages"
+        ],
+        "more_hint": "The World Bank API paginates server-side. Re-run with a larger `per_page` (maximum 32500) to get every row in one call, or step through the remaining pages with `page`. Narrowing `date` or `mrv` also reduces the result set."
       }
     },
     "type": "BaseRESTTool",

--- a/src/tooluniverse/europe_pmc_tool.py
+++ b/src/tooluniverse/europe_pmc_tool.py
@@ -369,21 +369,41 @@ class EuropePMCTool(BaseTool):
             query = f"({query}) AND ({clause})"
         if require_has_ft:
             query = f"({query}) AND HAS_FT:Y"
-        articles = self._search(
+        articles, hit_count = self._search(
             query,
             limit,
             enrich_missing_abstract=enrich_missing_abstract,
             extract_terms_from_fulltext=extract_terms_from_fulltext,
         )
-        return {
-            "status": "success",
-            "data": articles,
-            "metadata": {
-                "count": len(articles),
-                "query": query,
-                "source": "Europe PMC",
-            },
+        metadata = {
+            "count": len(articles),
+            "query": query,
+            "source": "Europe PMC",
         }
+        result = {"status": "success", "data": articles, "metadata": metadata}
+
+        # `count` is the number of records returned, which on its own is
+        # indistinguishable from the number of records that matched. Europe PMC
+        # reports the real figure as `hitCount` in every search response
+        # (verified live: .../search?query=NSCLC+radiogenomics+EGFR+CT+radiomics+
+        # TCIA&format=json&pageSize=1 -> "hitCount": 103); it used to be parsed
+        # and thrown away. Surface it, and say plainly when the returned set is
+        # only a slice of it.
+        metadata["total_results"] = hit_count
+        if hit_count is None:
+            return result
+        if len(articles) < hit_count:
+            result["truncated"] = True
+            result["truncation_note"] = (
+                f"Returned the top {len(articles)} of {hit_count} articles matching "
+                f"this query in Europe PMC. This is a ranked slice, not the full "
+                f"result set — an article absent here may still match. Raise `limit` "
+                f"(up to Europe PMC's 1000-per-request maximum) or narrow the query "
+                f"to see the rest."
+            )
+        else:
+            result["truncated"] = False
+        return result
 
     def _local_name(self, tag: str) -> str:
         return tag.rsplit("}", 1)[-1] if "}" in tag else tag
@@ -451,7 +471,15 @@ class EuropePMCTool(BaseTool):
         *,
         enrich_missing_abstract: bool = False,
         extract_terms_from_fulltext: list | None = None,
-    ):
+    ) -> tuple[list, int | None]:
+        """Run the Europe PMC search.
+
+        Returns ``(articles, hit_count)`` where ``hit_count`` is the total
+        number of records matching the query upstream (Europe PMC's
+        ``hitCount``), or ``None`` when the search failed and no total is
+        known. The caller needs the total to tell a truncated page apart from
+        a complete result set.
+        """
         # First try core mode to get abstracts
         core_params = {
             "query": query,
@@ -503,7 +531,7 @@ class EuropePMCTool(BaseTool):
                     "retryable": core_response.status_code
                     in (408, 429, 500, 502, 503, 504),
                 }
-            ]
+            ], None
 
         # Get core mode results
         try:
@@ -525,7 +553,13 @@ class EuropePMCTool(BaseTool):
                     "error": "Europe PMC returned invalid JSON",
                     "retryable": True,
                 }
-            ]
+            ], None
+
+        hit_count = core_payload.get("hitCount")
+        try:
+            hit_count = int(hit_count)
+        except (TypeError, ValueError):
+            hit_count = None
 
         core_results = core_payload.get("resultList", {}).get("result", [])
         lite_results = []
@@ -792,7 +826,7 @@ class EuropePMCTool(BaseTool):
                         # Silently skip articles that fail snippet extraction
                         continue
 
-        return articles
+        return articles, hit_count
 
 
 @register_tool("EuropePMCFullTextSnippetsTool")

--- a/src/tooluniverse/gtdb_tool.py
+++ b/src/tooluniverse/gtdb_tool.py
@@ -247,21 +247,108 @@ class GTDBTool(BaseTool):
         page = arguments.get("page", 1)
         items_per_page = arguments.get("items_per_page", 10)
 
+        # Fix-R29: GTDB's /search/gtdb endpoint ORs the terms of a multi-word
+        # query rather than requiring all of them, so a binomial silently
+        # degrades to a genus-wide match. Confirmed live against
+        # https://gtdb-api.ecogenomic.org/search/gtdb :
+        #   search=xyzzyplop                 -> totalRows 0
+        #   search=Mycobacterium             -> totalRows 13027
+        #   search=Mycobacterium xyzzyplop   -> totalRows 13027 (identical rows)
+        #   search=Mycobacterium tuberculosis-> totalRows 13381, first row
+        #                                       "Mycobacterium leprae Br4923"
+        # i.e. an unmatchable second term is discarded entirely, and the
+        # reported total is the union count for the broader taxon, not for the
+        # species the caller named.
+        #
+        # The endpoint's documented `filterText` parameter applies an
+        # additional case-insensitive literal-substring test that must hold for
+        # every returned row, which is the precise lookup we want (confirmed
+        # live: search+filterText="Mycobacterium tuberculosis" -> totalRows
+        # 7869, all M. tuberculosis; filterText="Mycobacterium xyzzyplop" -> 0).
+        # It is order- and whitespace-literal ("tuberculosis Mycobacterium" and
+        # a double space both return 0), so collapse internal whitespace first.
+        normalized_query = " ".join(query.split())
+        base_params = {
+            "search": normalized_query,
+            "page": page,
+            "itemsPerPage": min(items_per_page, 50),
+        }
+
+        # Precise lookup first: every row must contain the whole query.
         result = self._make_request(
             "search/gtdb",
-            params={
-                "search": query,
-                "page": page,
-                "itemsPerPage": min(items_per_page, 50),
-            },
+            params=dict(base_params, filterText=normalized_query),
         )
 
-        if not result["ok"]:
-            return {"status": "error", "error": result["error"]}
+        match_type = "exact"
+        note = None
+
+        precise_total = 0
+        if result["ok"]:
+            precise_rows = result["data"].get("rows", [])
+            precise_total = result["data"].get("totalRows", len(precise_rows))
+
+        if not result["ok"] or precise_total == 0:
+            # Either the precise filter is unavailable on this GTDB deployment,
+            # or nothing matches the full query. Fall back to GTDB's loose
+            # union search -- but say so, because those rows are a different
+            # (usually broader) entity than the one that was asked for.
+            precise_failed = not result["ok"]
+            precise_error = result.get("error") if precise_failed else None
+
+            fallback = self._make_request("search/gtdb", params=base_params)
+            if not fallback["ok"]:
+                return {"status": "error", "error": precise_error or fallback["error"]}
+
+            fb_rows = fallback["data"].get("rows", [])
+            fb_total = fallback["data"].get("totalRows", len(fb_rows))
+
+            if fb_total or fb_rows:
+                result = fallback
+                match_type = "broad"
+                if precise_failed:
+                    note = (
+                        "GTDB rejected the precise (all-terms) filter for "
+                        "'{q}' ({err}), so these results come from GTDB's "
+                        "loose search, which matches ANY term of the query. "
+                        "They may belong to a different species or a broader "
+                        "taxon than '{q}', and total_results ({n}) is the "
+                        "count for that looser match, not for '{q}'. Check "
+                        "each result's gtdbTaxonomy before relying on it."
+                    ).format(q=normalized_query, err=precise_error, n=fb_total)
+                else:
+                    note = (
+                        "No GTDB genome matches the full query '{q}'. GTDB's "
+                        "genome search unions the terms of a multi-word query, "
+                        "so these results match only PART of '{q}' (e.g. its "
+                        "genus) and are NOT '{q}'. total_results ({n}) is the "
+                        "count for that broader match, not for '{q}'. Check "
+                        "each result's gtdbTaxonomy before relying on it."
+                    ).format(q=normalized_query, n=fb_total)
+            elif not result["ok"]:
+                return {"status": "error", "error": precise_error}
+            else:
+                match_type = "none"
 
         data = result["data"]
         rows = data.get("rows", [])
         total = data.get("totalRows", len(rows))
+
+        if match_type == "exact":
+            scope = "Number of GTDB genomes matching every term of '{}'.".format(
+                normalized_query
+            )
+        elif match_type == "broad":
+            scope = (
+                "Number of GTDB genomes matching only SOME terms of '{}' -- a "
+                "broader set than '{}' itself, which matched no genome."
+            ).format(normalized_query, normalized_query)
+        else:
+            scope = "No GTDB genome matched '{}'.".format(normalized_query)
+            note = (
+                "GTDB holds no genome matching '{}', either as a whole or by "
+                "any of its terms.".format(normalized_query)
+            )
 
         # GTDB's search matches against the whole taxonomic clade, not just
         # organism-name substrings (confirmed live: querying "Akkermansia
@@ -269,7 +356,7 @@ class GTDBTool(BaseTool):
         # TMED18" ranked above the exact species) -- boost rows whose own
         # ncbiOrgName actually matches the query so the requested organism
         # isn't buried under broader clade results within this page.
-        query_lower = query.strip().lower()
+        query_lower = normalized_query.lower()
 
         def _relevance(row):
             name = (row.get("ncbiOrgName") or "").lower()
@@ -281,16 +368,19 @@ class GTDBTool(BaseTool):
 
         rows = sorted(rows, key=_relevance)
 
-        return {
-            "status": "success",
-            "data": {
-                "query": query,
-                "total_results": total,
-                "page": page,
-                "results": rows,
-                "count": len(rows),
-            },
+        payload = {
+            "query": query,
+            "match_type": match_type,
+            "total_results": total,
+            "total_results_scope": scope,
+            "page": page,
+            "results": rows,
+            "count": len(rows),
         }
+        if note:
+            payload["note"] = note
+
+        return {"status": "success", "data": payload}
 
     def _get_genome(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Get detailed genome metadata by accession."""

--- a/src/tooluniverse/iedb_prediction_tool.py
+++ b/src/tooluniverse/iedb_prediction_tool.py
@@ -1,24 +1,82 @@
 """
-IEDB Prediction Tool - MHC-I and MHC-II Binding Prediction
+IEDB Prediction Tool - MHC-I, MHC-II, processing and B-cell epitope prediction
 
-Provides access to the IEDB Analysis Resource tools API for predicting
-peptide binding to MHC class I and class II molecules.
+T-cell predictions (MHC-I binding, MHC-II binding and antigen processing) run
+against IEDB's next-generation tools API:
 
-API: https://tools-cluster-interface.iedb.org/tools_api/
-No authentication required.
+    https://api-nextgen-tools.iedb.org/api/v1
 
-Methods: NetMHCpan EL (recommended), NetMHCpan BA, SMM, ANN
+That API is asynchronous: a prediction is submitted as a *pipeline* stage
+(``POST /pipeline``) and the caller then polls ``GET /results/{result_id}``
+until the job reports ``status: "done"``. Results arrive as typed tables
+(``table_columns`` + ``table_data``) rather than TSV text.
+
+Fix-R29A-1: these three predictions previously used the legacy synchronous
+endpoint ``https://tools-cluster-interface.iedb.org/tools_api/{mhci,mhcii,
+processing}/``. That host still completes a TCP/TLS handshake and answers
+GET with 405, but it never sends a response body for a POST -- confirmed
+live, e.g.::
+
+    curl -X POST --max-time 90 \\
+      https://tools-cluster-interface.iedb.org/tools_api/mhci/ \\
+      -d "method=netmhcpan_el&sequence_text=GILGFVFTL&allele=HLA-A*02:01&length=9"
+    -> curl exit 28, http_code 000, time 90.00   (no bytes, ever)
+
+so every call -- including each tool's own documented example -- stalled for
+the full client timeout and then reported a misleading "timed out" error.
+The ``bcell/`` route on that same legacy host does still answer (verified
+live, HTTP 200 with real TSV in ~67 s) and is therefore left in place.
+
+No authentication required for either API.
 """
 
+import re
+import time
 import requests
 import csv
 import io
-from typing import Dict, Any, List
+from typing import Dict, Any, List, Optional, Tuple
 from .base_tool import BaseTool
 from .tool_registry import register_tool
 
 
 IEDB_TOOLS_BASE = "https://tools-cluster-interface.iedb.org/tools_api"
+IEDB_NEXTGEN_BASE = "https://api-nextgen-tools.iedb.org/api/v1"
+
+# Methods accepted by the next-gen pipeline, per predictor type. Verified
+# live against POST /pipeline (a name outside these sets is rejected with an
+# opaque HTML 500, so it is worth catching client-side).
+NEXTGEN_MHCI_METHODS = (
+    "netmhcpan_el",
+    "netmhcpan_ba",
+    "netmhcpan",
+    "ann",
+    "smm",
+    "smmpmbec",
+    "comblib_sidney2008",
+    "consensus",
+    "mhcflurry",
+    "mhcnp",
+    "pickpocket",
+)
+NEXTGEN_MHCII_METHODS = (
+    "netmhciipan_el",
+    "netmhciipan_ba",
+    "netmhciipan",
+    "nn_align",
+    "smm_align",
+    "comblib",
+    "tepitope",
+    "consensus",
+)
+
+# Legacy tools_api spellings that the next-gen API renamed.
+LEGACY_METHOD_ALIASES = {
+    "netmhciipan": "netmhciipan_el",
+    "nn_align_2.3": "nn_align",
+    "smm_align_1.1": "smm_align",
+    "sturniolo": "tepitope",
+}
 
 
 @register_tool("IEDBPredictionTool")
@@ -29,11 +87,25 @@ class IEDBPredictionTool(BaseTool):
     Supported operations:
     - predict_mhci: Predict MHC class I binding (CD8+ T cell epitopes)
     - predict_mhcii: Predict MHC class II binding (CD4+ T cell epitopes)
+    - predict_processing: MHC-I binding chained with proteasomal cleavage
+      and TAP transport (NetCTLpan)
+    - predict_bcell: Linear B-cell epitope prediction (legacy tools_api)
     """
+
+    #: Bound on how long the async next-gen pipeline is polled before the
+    #: call is abandoned with an explicit message. Short peptides finish in
+    #: roughly 10-20 s; nothing here should ever stall indefinitely.
+    max_wait = 90
+    #: Seconds between polls of GET /results/{id}.
+    poll_interval = 3
+    #: (connect, read) timeout for every individual HTTP request. A read
+    #: timeout this short is safe because no next-gen request blocks on the
+    #: prediction itself -- the work happens between polls.
+    request_timeout: Tuple[int, int] = (10, 30)
 
     def __init__(self, tool_config: Dict[str, Any]):
         super().__init__(tool_config)
-        self.timeout = 120  # predictions can be slow
+        self.timeout = 120  # legacy bcell/ route only; predictions are slow
         self.endpoint_type = tool_config.get("fields", {}).get(
             "endpoint_type", "predict_mhci"
         )
@@ -53,9 +125,234 @@ class IEDBPredictionTool(BaseTool):
                 "error": f"Unknown endpoint: {self.endpoint_type}",
             }
         except requests.exceptions.Timeout:
-            return {"status": "error", "error": "IEDB prediction timed out (max 120s)"}
+            return {
+                "status": "error",
+                "error": (
+                    "IEDB did not respond within the request timeout "
+                    f"{self.request_timeout}s (connect, read)."
+                ),
+            }
+        except requests.exceptions.RequestException as e:
+            return {"status": "error", "error": f"IEDB request failed: {e}"}
         except Exception as e:
             return {"status": "error", "error": f"IEDB prediction error: {str(e)}"}
+
+    # ------------------------------------------------------------------
+    # Next-generation tools API (async pipeline) helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _normalize_allele(allele: str) -> str:
+        """Translate legacy tools_api allele spellings to next-gen/MRO names.
+
+        The next-gen API validates alleles against the MHC Restriction
+        Ontology and rejects the legacy hyphenated mouse form: confirmed
+        live, ``H-2-Kd`` returns ``{"errors": ["The following are not valid
+        alleles: H-2-Kd"]}`` while ``H2-Kd`` predicts normally. This tool's
+        own registered example used ``H-2-Kd``.
+        """
+        parts = [p.strip() for p in str(allele).split(",") if p.strip()]
+        return ",".join(re.sub(r"^H-2-", "H2-", p) for p in parts)
+
+    @staticmethod
+    def _as_fasta(sequence: str) -> str:
+        sequence = sequence.strip()
+        if sequence.startswith(">"):
+            return sequence
+        return f">sequence_1\n{sequence}"
+
+    @staticmethod
+    def _table_rows(table: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """Zip a next-gen result table's column names onto its row values."""
+        names = [c.get("name") for c in table.get("table_columns", [])]
+        return [dict(zip(names, row)) for row in table.get("table_data", [])]
+
+    @staticmethod
+    def _find_table(results: List[Dict[str, Any]], table_type: str):
+        for table in results or []:
+            if table.get("type") == table_type:
+                return table
+        return None
+
+    def _submit_pipeline(
+        self,
+        tool_group: str,
+        sequence: str,
+        allele: str,
+        length_range: List[int],
+        predictors: List[Dict[str, str]],
+    ):
+        """POST a single-stage pipeline. Returns (result_id, warnings) or an
+        error dict when the API rejects the request outright."""
+        body = {
+            "pipeline_id": "",
+            "run_stage_range": [1, 1],
+            "stages": [
+                {
+                    "stage_number": 1,
+                    "tool_group": tool_group,
+                    "input_sequence_text": self._as_fasta(sequence),
+                    "input_parameters": {
+                        "alleles": allele,
+                        "peptide_length_range": length_range,
+                        "predictors": predictors,
+                    },
+                }
+            ],
+        }
+        resp = requests.post(
+            f"{IEDB_NEXTGEN_BASE}/pipeline",
+            json=body,
+            timeout=self.request_timeout,
+        )
+        if resp.status_code != 200:
+            return {
+                "status": "error",
+                "error": (
+                    f"IEDB next-generation tools API rejected the submission "
+                    f"(HTTP {resp.status_code}): {resp.text[:300]!r}"
+                ),
+            }
+        payload = resp.json()
+        # A validation failure (bad allele, incompatible length) still comes
+        # back as HTTP 200 -- but with `errors` and no `result_id`.
+        if "result_id" not in payload:
+            errors = payload.get("errors") or ["unspecified validation failure"]
+            return {
+                "status": "error",
+                "error": f"IEDB rejected the prediction request: {'; '.join(errors)}",
+            }
+        return payload["result_id"], payload.get("warnings") or []
+
+    def _poll_results(self, result_id: str):
+        """Poll GET /results/{id} until the job is terminal.
+
+        Returns the ``data`` block on success, or an error dict. Note that a
+        failed stage surfaces as a populated ``data.errors`` list which may
+        keep reporting ``status: "pending"`` indefinitely (confirmed live),
+        so errors -- not just the status field -- must terminate the loop.
+        """
+        deadline = time.monotonic() + self.max_wait
+        last_status = "unknown"
+        while True:
+            resp = requests.get(
+                f"{IEDB_NEXTGEN_BASE}/results/{result_id}",
+                timeout=self.request_timeout,
+            )
+            resp.raise_for_status()
+            payload = resp.json()
+            data = payload.get("data") or {}
+            errors = data.get("errors") or []
+            last_status = payload.get("status", "unknown")
+            if errors:
+                return {
+                    "status": "error",
+                    "error": (
+                        f"IEDB prediction failed (result_id={result_id}): "
+                        f"{'; '.join(str(e) for e in errors)[:600]}"
+                    ),
+                }
+            if last_status == "done":
+                return data
+            if last_status == "error":
+                return {
+                    "status": "error",
+                    "error": (
+                        f"IEDB reported an unspecified failure for "
+                        f"result_id={result_id}"
+                    ),
+                }
+            if time.monotonic() + self.poll_interval >= deadline:
+                return {
+                    "status": "error",
+                    "error": (
+                        f"IEDB prediction did not finish within {self.max_wait}s "
+                        f"(last status: {last_status!r}, result_id={result_id}). "
+                        f"Results may still appear at "
+                        f"{IEDB_NEXTGEN_BASE}/results/{result_id}"
+                    ),
+                }
+            time.sleep(self.poll_interval)
+
+    def _resolve_method(
+        self, method: str, allowed: Tuple[str, ...], label: str
+    ) -> Tuple[Optional[str], Optional[Dict[str, Any]]]:
+        method = LEGACY_METHOD_ALIASES.get(method, method)
+        if method not in allowed:
+            return None, {
+                "status": "error",
+                "error": (
+                    f"Unsupported {label} method {method!r}. The IEDB "
+                    f"next-generation tools API accepts: {', '.join(allowed)}"
+                ),
+            }
+        return method, None
+
+    @staticmethod
+    def _first_present(row: Dict[str, Any], keys):
+        for key in keys:
+            if row.get(key) is not None:
+                return row[key]
+        return None
+
+    def _peptide_rows(self, data: Dict[str, Any], method: str) -> List[Dict[str, Any]]:
+        """Extract the peptide table and attach a uniform percentile_rank.
+
+        Every next-gen peptide table carries ``median_percentile`` plus
+        method-specific score columns. Single-algorithm methods name those
+        ``<method>_percentile`` / ``<method>_score`` / ``<method>_ic50``
+        (verified live for netmhcpan_el, netmhcpan_ba, ann, smm,
+        netmhciipan_el, netmhciipan_ba, nn_align); the aggregate
+        ``netmhcpan`` method instead uses the dotted
+        ``binding.<method>.percentile`` form (also verified live), so both
+        spellings are consulted before falling back to the median.
+        """
+        table = self._find_table(data.get("results", []), "peptide_table")
+        rows = self._table_rows(table) if table else []
+        for row in rows:
+            rank = self._first_present(
+                row,
+                (
+                    f"{method}_percentile",
+                    f"binding.{method}.percentile",
+                    "median_percentile",
+                ),
+            )
+            if rank is not None:
+                row["percentile_rank"] = rank
+            score = self._first_present(
+                row,
+                (
+                    f"{method}_score",
+                    f"{method}_ic50",
+                    f"binding.{method}.score",
+                    f"binding.{method}.ic50",
+                ),
+            )
+            if score is not None:
+                row["score"] = score
+        rows.sort(
+            key=lambda r: (
+                r["percentile_rank"]
+                if isinstance(r.get("percentile_rank"), (int, float))
+                else float("inf")
+            )
+        )
+        return rows
+
+    @staticmethod
+    def _merge_warnings(*groups) -> List[str]:
+        """Union of submit-time and result-time warnings, order preserved.
+
+        The pipeline echoes its submission warnings back on the result, so
+        concatenating the two lists otherwise reports each one twice.
+        """
+        merged: List[str] = []
+        for group in groups:
+            for warning in group or []:
+                if warning not in merged:
+                    merged.append(warning)
+        return merged
 
     def _parse_tsv(self, text: str) -> List[Dict[str, str]]:
         text = text.strip()
@@ -180,63 +477,59 @@ class IEDBPredictionTool(BaseTool):
         }
 
     def _predict_processing(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
-        """Predict MHC class I antigen processing (proteasome + TAP + MHC-I).
+        """Predict MHC class I antigen processing (cleavage + TAP + MHC-I).
 
-        The IEDB processing tool chains proteasomal cleavage and TAP transport
-        predictions with MHC-I binding to score peptides for natural processing
-        and presentation, rather than raw binding alone. Returns per-peptide
-        proteasome_score, tap_score, mhc_score, processing_score, total_score
-        and ic50_score.
+        Runs the next-gen T-cell class I pipeline with both a binding
+        predictor and the NetCTLpan processing predictor, so each peptide is
+        scored for natural processing and presentation rather than raw
+        binding alone. Verified live: the peptide table gains the columns
+        ``cleavage_prediction_score``, ``tap_prediction_score``,
+        ``mhc_prediction`` and ``combined_prediction_score`` alongside the
+        binding columns.
         """
         sequence = arguments.get("sequence") or arguments.get("sequence_text", "")
         allele = arguments.get("allele", "HLA-A*02:01")
         method = arguments.get("method", "netmhcpan")
-        length = arguments.get("length", 9)
+        length = arguments.get("length") or 9
 
         if not sequence:
             return {"status": "error", "error": "sequence is required"}
 
-        data = {
-            "method": method,
-            "sequence_text": sequence,
-            "allele": allele,
-            "length": str(length),
-        }
-
-        resp = requests.post(
-            f"{IEDB_TOOLS_BASE}/processing/",
-            data=data,
-            timeout=self.timeout,
-        )
-        resp.raise_for_status()
-
-        err = self._iedb_error_response(resp.text)
+        method, err = self._resolve_method(method, NEXTGEN_MHCI_METHODS, "MHC-I")
         if err:
             return err
-        results = self._parse_tsv(resp.text)
+        allele = self._normalize_allele(allele)
+        length = int(length)
 
-        # Cast numeric columns; sort by total_score descending (higher = more
-        # likely to be naturally processed and presented).
-        numeric_cols = (
-            "proteasome_score",
-            "tap_score",
-            "mhc_score",
-            "processing_score",
-            "total_score",
-            "ic50_score",
+        submitted = self._submit_pipeline(
+            "mhci",
+            sequence,
+            allele,
+            [length, length],
+            [
+                {"type": "binding", "method": method},
+                {"type": "processing", "method": "netctlpan"},
+            ],
         )
-        for r in results:
-            for col in numeric_cols:
-                if col in r:
-                    try:
-                        r[col] = float(r[col])
-                    except (ValueError, TypeError):
-                        pass
+        if isinstance(submitted, dict):
+            return submitted
+        result_id, warnings = submitted
 
+        data = self._poll_results(result_id)
+        if data.get("status") == "error":
+            return data
+
+        table = self._find_table(data.get("results", []), "peptide_table")
+        results = self._table_rows(table) if table else []
+
+        # Higher combined_prediction_score = more likely to be cleaved,
+        # transported and presented.
         results.sort(
-            key=lambda x: x.get("total_score")
-            if isinstance(x.get("total_score"), (int, float))
-            else float("-inf"),
+            key=lambda x: (
+                x.get("combined_prediction_score")
+                if isinstance(x.get("combined_prediction_score"), (int, float))
+                else float("-inf")
+            ),
             reverse=True,
         )
 
@@ -245,16 +538,22 @@ class IEDBPredictionTool(BaseTool):
             "data": results,
             "metadata": {
                 "method": method,
+                "processing_method": "netctlpan",
                 "allele": allele,
                 "length": length,
                 "n_peptides": len(results),
-                "source": "IEDB Analysis Resource (processing)",
+                "source": "IEDB next-generation tools API (T cell class I)",
+                "result_id": result_id,
+                "warnings": self._merge_warnings(warnings, data.get("warnings")),
                 "interpretation": (
-                    "processing_score = proteasome + TAP component; "
-                    "total_score = processing_score + mhc_score (binding). "
-                    "Higher total_score = more likely naturally processed and "
-                    "presented to CD8+ T cells. ic50_score is predicted MHC-I "
-                    "binding affinity (nM, lower = stronger binder)."
+                    "cleavage_prediction_score = proteasomal C-terminal "
+                    "cleavage; tap_prediction_score = TAP transport "
+                    "efficiency; mhc_prediction = MHC-I binding component; "
+                    "combined_prediction_score merges all three (higher = "
+                    "more likely naturally processed and presented to CD8+ "
+                    "T cells). The binding columns "
+                    "(<method>_ic50 / <method>_score, <method>_percentile) "
+                    "carry the raw affinity prediction."
                 ),
             },
         }
@@ -263,39 +562,33 @@ class IEDBPredictionTool(BaseTool):
         sequence = arguments.get("sequence", "")
         allele = arguments.get("allele", "HLA-A*02:01")
         method = arguments.get("method", "netmhcpan_el")
-        length = arguments.get("length", 9)
+        length = arguments.get("length") or 9
 
         if not sequence:
             return {"status": "error", "error": "sequence is required"}
 
-        data = {
-            "method": method,
-            "sequence_text": sequence,
-            "allele": allele,
-            "length": str(length),
-        }
-
-        resp = requests.post(
-            f"{IEDB_TOOLS_BASE}/mhci/",
-            data=data,
-            timeout=self.timeout,
-        )
-        resp.raise_for_status()
-
-        err = self._iedb_error_response(resp.text)
+        method, err = self._resolve_method(method, NEXTGEN_MHCI_METHODS, "MHC-I")
         if err:
             return err
-        results = self._parse_tsv(resp.text)
+        allele = self._normalize_allele(allele)
+        length = int(length)
 
-        # Sort by score (descending for EL, ascending for BA)
-        for r in results:
-            try:
-                r["score"] = float(r.get("score", 0))
-                r["percentile_rank"] = float(r.get("percentile_rank", 100))
-            except (ValueError, TypeError):
-                pass
+        submitted = self._submit_pipeline(
+            "mhci",
+            sequence,
+            allele,
+            [length, length],
+            [{"type": "binding", "method": method}],
+        )
+        if isinstance(submitted, dict):
+            return submitted
+        result_id, warnings = submitted
 
-        results.sort(key=lambda x: x.get("percentile_rank", 100))
+        data = self._poll_results(result_id)
+        if data.get("status") == "error":
+            return data
+
+        results = self._peptide_rows(data, method)
 
         return {
             "status": "success",
@@ -305,7 +598,9 @@ class IEDBPredictionTool(BaseTool):
                 "allele": allele,
                 "length": length,
                 "n_peptides": len(results),
-                "source": "IEDB Analysis Resource",
+                "source": "IEDB next-generation tools API (T cell class I)",
+                "result_id": result_id,
+                "warnings": self._merge_warnings(warnings, data.get("warnings")),
                 "interpretation": (
                     "percentile_rank < 0.5% = strong binder, "
                     "0.5-2% = moderate binder, >2% = weak/non-binder"
@@ -321,54 +616,35 @@ class IEDBPredictionTool(BaseTool):
         if not sequence:
             return {"status": "error", "error": "sequence is required"}
 
-        data = {
-            "method": method,
-            "sequence_text": sequence,
-            "allele": allele,
-        }
-        # Fix-R34A-1: IEDB's mhcii endpoint defaults its sliding-window
-        # length to 15 server-side and hard-errors on any shorter sequence
-        # ("length of input sequence is less than the input/default length
-        # 15") -- confirmed live, including against this tool's own <15-
-        # residue test example. Unlike the MHC-I methods in this file,
-        # this endpoint never exposed a length override. Auto-shrink the
-        # window to the sequence's own length when it's under 15, mirroring
-        # the MHC-I `length` param.
-        length = arguments.get("length")
-        if length is None and len(sequence) < 15:
-            length = len(sequence)
-        if length is not None:
-            data["length"] = str(length)
-
-        resp = requests.post(
-            f"{IEDB_TOOLS_BASE}/mhcii/",
-            data=data,
-            timeout=self.timeout,
-        )
-        resp.raise_for_status()
-
-        err = self._iedb_error_response(resp.text)
+        method, err = self._resolve_method(method, NEXTGEN_MHCII_METHODS, "MHC-II")
         if err:
             return err
-        results = self._parse_tsv(resp.text)
-        # The mhcii/ endpoint's TSV column is "rank", not "percentile_rank"
-        # (confirmed live) -- reading the wrong key silently defaulted every
-        # result to 100.0, masking real binder rankings.
-        for r in results:
-            # Fix-R18D-2: the mhcii endpoint's real TSV column is named
-            # "rank", not "percentile_rank" (unlike the mhci endpoint,
-            # confirmed live to genuinely have a "percentile_rank" column)
-            # -- so this always hit the `100` default, making the field
-            # silently and completely wrong for every successful call
-            # regardless of the actual binding rank.
-            try:
-                r["percentile_rank"] = float(
-                    r.get("rank", r.get("percentile_rank", 100))
-                )
-            except (ValueError, TypeError):
-                pass
+        allele = self._normalize_allele(allele)
 
-        results.sort(key=lambda x: x.get("percentile_rank", 100))
+        # The class II sliding window defaults to 15 residues and cannot
+        # exceed the input sequence, so shrink it for short peptides (this
+        # tool's own registered example is a 13-mer).
+        length = arguments.get("length")
+        if length is None:
+            length = min(15, len(sequence.strip()))
+        length = int(length)
+
+        submitted = self._submit_pipeline(
+            "mhcii",
+            sequence,
+            allele,
+            [length, length],
+            [{"type": "binding", "method": method}],
+        )
+        if isinstance(submitted, dict):
+            return submitted
+        result_id, warnings = submitted
+
+        data = self._poll_results(result_id)
+        if data.get("status") == "error":
+            return data
+
+        results = self._peptide_rows(data, method)
 
         return {
             "status": "success",
@@ -376,8 +652,11 @@ class IEDBPredictionTool(BaseTool):
             "metadata": {
                 "method": method,
                 "allele": allele,
+                "length": length,
                 "n_peptides": len(results),
-                "source": "IEDB Analysis Resource",
+                "source": "IEDB next-generation tools API (T cell class II)",
+                "result_id": result_id,
+                "warnings": self._merge_warnings(warnings, data.get("warnings")),
                 "interpretation": (
                     "percentile_rank < 2% = strong binder, "
                     "2-10% = weak binder, >10% = non-binder (NetMHCIIpan convention)"

--- a/src/tooluniverse/nextstrain_tool.py
+++ b/src/tooluniverse/nextstrain_tool.py
@@ -17,6 +17,10 @@ from .tool_registry import register_tool
 
 NEXTSTRAIN_BASE_URL = "https://nextstrain.org/charon"
 
+# Default number of dataset paths listed per pathogen. Callers can raise this
+# (or pass 0 for "no cap") via the ``datasets_per_pathogen`` argument.
+DEFAULT_DATASETS_PER_PATHOGEN = 10
+
 
 @register_tool("NextstrainTool")
 class NextstrainTool(BaseTool):
@@ -76,7 +80,30 @@ class NextstrainTool(BaseTool):
 
     def _list_datasets(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """List available Nextstrain pathogen datasets."""
-        pathogen_filter = arguments.get("pathogen", "").lower()
+        pathogen_filter = (arguments.get("pathogen") or "").lower()
+
+        raw_limit = arguments.get("datasets_per_pathogen")
+        if raw_limit is None or raw_limit == "":
+            per_pathogen_limit = DEFAULT_DATASETS_PER_PATHOGEN
+        else:
+            try:
+                per_pathogen_limit = int(raw_limit)
+            except (TypeError, ValueError):
+                return {
+                    "status": "error",
+                    "error": (
+                        "datasets_per_pathogen must be a non-negative integer "
+                        "(0 means return every dataset)."
+                    ),
+                }
+            if per_pathogen_limit < 0:
+                return {
+                    "status": "error",
+                    "error": (
+                        "datasets_per_pathogen must be a non-negative integer "
+                        "(0 means return every dataset)."
+                    ),
+                }
 
         url = f"{NEXTSTRAIN_BASE_URL}/getAvailable"
         response = requests.get(url, timeout=self.timeout)
@@ -105,25 +132,54 @@ class NextstrainTool(BaseTool):
         # Build response
         results = []
         for pathogen, paths in sorted(pathogen_groups.items()):
-            results.append(
-                {
-                    "pathogen": pathogen,
-                    "dataset_count": len(paths),
-                    "datasets": sorted(paths)[:10],
-                }
-            )
+            ordered = sorted(paths)
+            listed = ordered if per_pathogen_limit == 0 else ordered[:per_pathogen_limit]
+            entry = {
+                "pathogen": pathogen,
+                "dataset_count": len(ordered),
+                "datasets": listed,
+                "datasets_listed": len(listed),
+            }
+            if len(listed) < len(ordered):
+                entry["datasets_truncated"] = True
+            results.append(entry)
 
-        return {
+        # 'total_datasets' is the true catalogue size (sum of every pathogen's
+        # dataset_count), never the size of the possibly-truncated listings.
+        total_datasets = sum(r["dataset_count"] for r in results)
+        listed_datasets = sum(r["datasets_listed"] for r in results)
+        truncated = listed_datasets < total_datasets
+
+        response = {
             "status": "success",
             "data": results,
+            "truncated": truncated,
             "metadata": {
                 "source": "Nextstrain",
                 "total_pathogens": len(results),
-                "total_datasets": sum(len(r["datasets"]) for r in results),
+                "total_datasets": total_datasets,
+                "listed_datasets": listed_datasets,
+                "datasets_per_pathogen": per_pathogen_limit,
+                "truncated": truncated,
                 "filter": pathogen_filter or "(none)",
                 "endpoint": "list_datasets",
             },
         }
+
+        if truncated:
+            largest = max(r["dataset_count"] for r in results)
+            note = (
+                f"Listed {listed_datasets} of {total_datasets} datasets: each pathogen's "
+                f"'datasets' array is capped at {per_pathogen_limit} entries, while its "
+                f"'dataset_count' reports the true number available. To retrieve the rest, "
+                f"re-run with datasets_per_pathogen=0 (no cap) or a higher cap "
+                f"(datasets_per_pathogen={largest} covers the largest pathogen), and/or "
+                f"narrow the query with the 'pathogen' filter."
+            )
+            response["truncation_note"] = note
+            response["metadata"]["truncation_note"] = note
+
+        return response
 
     def _get_dataset(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Get metadata and tree summary for a Nextstrain dataset."""
@@ -187,12 +243,15 @@ class NextstrainTool(BaseTool):
             "root_attributes": root_info,
         }
 
-        # Color-by options
+        # Color-by options (complete list — these are short keys, so nothing is
+        # dropped; the count is reported alongside so callers can verify.)
         colorings = meta.get("colorings", [])
         if colorings:
-            result["available_colorings"] = [
+            coloring_keys = [
                 c.get("key", "") for c in colorings if isinstance(c, dict)
-            ][:15]
+            ]
+            result["available_colorings"] = coloring_keys
+            result["available_colorings_count"] = len(coloring_keys)
 
         return {
             "status": "success",

--- a/src/tooluniverse/pdc_tool.py
+++ b/src/tooluniverse/pdc_tool.py
@@ -8,12 +8,52 @@ API: https://pdc.cancer.gov/graphql
 Authentication: None required (free public API).
 """
 
+import json
+
 import requests
 from typing import Dict, Any, Optional
 from .base_tool import BaseTool
 from .tool_registry import register_tool
 
 PDC_GRAPHQL_URL = "https://pdc.cancer.gov/graphql"
+
+# Structured study-catalog fields that PDC_search_studies matches a query
+# against, in the order they are reported back to the caller. Every entry is a
+# curated PDC metadata field except ``submitter_id_name``, which is the free
+# text study title. Keeping the title last means curated matches are listed
+# first in each study's ``matched_fields``.
+STUDY_SEARCH_FIELDS = (
+    "disease_type",
+    "primary_site",
+    "analytical_fraction",
+    "experiment_type",
+    "program_name",
+    "project_name",
+    "submitter_id_name",
+)
+
+# Curated metadata fields the query is matched against. A hit on one of these
+# is a controlled-vocabulary hit, as opposed to a coincidental study-title hit.
+STUDY_SEARCH_CURATED_FIELDS = tuple(
+    f for f in STUDY_SEARCH_FIELDS if f != "submitter_id_name"
+)
+
+# Page size used when pulling the PDC study catalog. PDC currently publishes a
+# few hundred studies, so this normally takes a single request.
+STUDY_CATALOG_PAGE_SIZE = 500
+
+# Safety valve so a malformed ``total`` from the API cannot cause a runaway
+# pagination loop.
+STUDY_CATALOG_MAX_PAGES = 20
+
+
+def _gql_string(value: str) -> str:
+    """Render a Python string as a quoted GraphQL string literal.
+
+    GraphQL string syntax is a subset of JSON string syntax, so ``json.dumps``
+    escapes quotes, backslashes and control characters correctly.
+    """
+    return json.dumps(str(value))
 
 
 def _execute_graphql(
@@ -102,44 +142,205 @@ class PDCTool(BaseTool):
         except Exception as e:
             return {"status": "error", "error": "Operation failed: %s" % str(e)}
 
+    def _fetch_study_catalog(self) -> Dict[str, Any]:
+        """Fetch the full PDC study catalog with its structured metadata.
+
+        Uses ``getPaginatedUIStudy``, which returns the curated study
+        annotations (disease type, primary site, analytical fraction,
+        experiment type, program and project) alongside the study title.
+        The legacy ``studySearch(name:)`` endpoint only matches the title and
+        silently truncates at 100 results, so it cannot back a search that
+        claims to cover disease/program/fraction.
+        """
+        gql = """
+        {
+            getPaginatedUIStudy(offset: %d, limit: %d) {
+                total
+                uiStudies {
+                    study_id
+                    pdc_study_id
+                    submitter_id_name
+                    disease_type
+                    primary_site
+                    analytical_fraction
+                    experiment_type
+                    program_name
+                    project_name
+                }
+            }
+        }
+        """
+
+        studies: list = []
+        total = 0
+        for page in range(STUDY_CATALOG_MAX_PAGES):
+            offset = page * STUDY_CATALOG_PAGE_SIZE
+            result = _execute_graphql(
+                gql % (offset, STUDY_CATALOG_PAGE_SIZE), timeout=60
+            )
+            if not result["ok"]:
+                return {"ok": False, "error": result["error"]}
+
+            paginated = result["data"].get("getPaginatedUIStudy") or {}
+            page_studies = paginated.get("uiStudies") or []
+            total = paginated.get("total") or total
+            studies.extend(page_studies)
+
+            if not page_studies or len(studies) >= total:
+                break
+
+        return {"ok": True, "studies": studies, "total": total or len(studies)}
+
+    def _fetch_program_vocabulary_matches(self, query_text: str) -> Dict[str, Any]:
+        """Resolve a query against PDC's controlled program vocabulary.
+
+        PDC's ``program_name`` filter matches the program *short name* (e.g.
+        "CPTAC", "APOLLO", "ICPC"), which does not appear in the long program
+        name carried on each study ("Clinical Proteomic Tumor Analysis
+        Consortium"). Substring matching over the catalog therefore cannot
+        find every study belonging to a program, so the program acronym is
+        resolved server-side and unioned into the results.
+
+        Only ``program_name`` needs this: the values of disease_type,
+        primary_site, analytical_fraction, experiment_type and project_name
+        are carried verbatim on each catalog record, so substring matching
+        over the catalog is already a superset of the server-side filter for
+        those fields.
+
+        Note: each filter must be sent as its own request. Combining several
+        filtered ``getPaginatedUIStudy`` selections into one document via
+        GraphQL aliases makes the API return results for the wrong filter.
+        """
+        gql = (
+            '{ getPaginatedUIStudy(offset: 0, limit: %d, program_name: %s) '
+            "{ uiStudies { pdc_study_id } } }"
+            % (STUDY_CATALOG_PAGE_SIZE, _gql_string(query_text))
+        )
+        result = _execute_graphql(gql, timeout=60)
+        if not result["ok"]:
+            return {"ok": False, "error": result["error"]}
+
+        paginated = result["data"].get("getPaginatedUIStudy") or {}
+        return {
+            "ok": True,
+            "pdc_study_ids": {
+                s.get("pdc_study_id")
+                for s in (paginated.get("uiStudies") or [])
+                if s.get("pdc_study_id")
+            },
+        }
+
     def _search_studies(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
-        """Search PDC studies by name/keyword."""
+        """Search PDC studies across their curated metadata fields.
+
+        The query is matched case-insensitively as a substring against each
+        field in ``STUDY_SEARCH_FIELDS`` - the curated disease type, primary
+        site, analytical fraction, experiment type, program and project, plus
+        the study title - and additionally resolved against PDC's controlled
+        program vocabulary so program acronyms work. Every returned study
+        reports which fields matched, so a title-only hit is never mistaken
+        for a curated disease-type hit.
+        """
         query_text = arguments.get("query")
-        if not query_text:
+        if not query_text or not str(query_text).strip():
             return {
                 "status": "error",
                 "error": "query parameter is required for study search",
             }
 
-        gql = """
-        {
-            studySearch(name: "%s") {
-                studies {
-                    study_id
-                    name
-                    pdc_study_id
-                    submitter_id_name
+        query_text = str(query_text).strip()
+        needle = query_text.casefold()
+
+        catalog = self._fetch_study_catalog()
+        if not catalog["ok"]:
+            return {"status": "error", "error": catalog["error"]}
+
+        all_studies = catalog["studies"]
+
+        warnings = []
+        program_matches = self._fetch_program_vocabulary_matches(query_text)
+        if program_matches["ok"]:
+            program_study_ids = program_matches["pdc_study_ids"]
+        else:
+            program_study_ids = set()
+            warnings.append(
+                "Could not resolve '%s' against PDC's controlled program "
+                "vocabulary (%s); program matching fell back to text "
+                "matching on the program and project names carried by each "
+                "study, so studies in a program whose acronym does not "
+                "appear in their metadata may be missing."
+                % (query_text, program_matches["error"])
+            )
+
+        matches = []
+        num_results_by_field = {field: 0 for field in STUDY_SEARCH_FIELDS}
+
+        for study in all_studies:
+            matched_fields = [
+                field
+                for field in STUDY_SEARCH_FIELDS
+                if needle in str(study.get(field) or "").casefold()
+            ]
+            if (
+                study.get("pdc_study_id") in program_study_ids
+                and "program_name" not in matched_fields
+            ):
+                matched_fields.append("program_name")
+                matched_fields.sort(key=STUDY_SEARCH_FIELDS.index)
+            if not matched_fields:
+                continue
+
+            for field in matched_fields:
+                num_results_by_field[field] += 1
+
+            name = study.get("submitter_id_name")
+            matches.append(
+                {
+                    "study_id": study.get("study_id"),
+                    "pdc_study_id": study.get("pdc_study_id"),
+                    # ``name`` is kept for backward compatibility; PDC's study
+                    # catalog exposes the title as submitter_id_name only.
+                    "name": name,
+                    "submitter_id_name": name,
+                    "disease_type": study.get("disease_type"),
+                    "primary_site": study.get("primary_site"),
+                    "analytical_fraction": study.get("analytical_fraction"),
+                    "experiment_type": study.get("experiment_type"),
+                    "program_name": study.get("program_name"),
+                    "project_name": study.get("project_name"),
+                    "matched_fields": matched_fields,
+                    "matched_curated_metadata": any(
+                        field in STUDY_SEARCH_CURATED_FIELDS
+                        for field in matched_fields
+                    ),
                 }
-                total
-            }
+            )
+
+        fields_searched = list(STUDY_SEARCH_FIELDS)
+        data = {
+            "query": query_text,
+            "fields_searched": fields_searched,
+            "num_studies_searched": len(all_studies),
+            "studies": matches,
+            "num_results": len(matches),
+            "num_results_by_field": num_results_by_field,
         }
-        """ % query_text.replace('"', '\\"')
+        if warnings:
+            data["warnings"] = warnings
 
-        result = _execute_graphql(gql, timeout=30)
-        if not result["ok"]:
-            return {"status": "error", "error": result["error"]}
+        if not matches:
+            data["note"] = (
+                "No PDC study matched '%s'. The query was compared "
+                "case-insensitively as a substring against %d PDC studies on "
+                "these fields: %s. This is an empty result, not a failed "
+                "request - PDC has no study annotated with this term. Try a "
+                "broader term (e.g. 'Lung' instead of a specific subtype), a "
+                "program name such as 'CPTAC' or 'APOLLO', or an analytical "
+                "fraction such as 'Proteome' or 'Phosphoproteome'."
+                % (query_text, len(all_studies), ", ".join(fields_searched))
+            )
 
-        search_data = result["data"].get("studySearch", {})
-        studies = search_data.get("studies", [])
-
-        return {
-            "status": "success",
-            "data": {
-                "query": query_text,
-                "studies": studies,
-                "num_results": len(studies),
-            },
-        }
+        return {"status": "success", "data": data}
 
     def _get_gene_protein(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Get protein information and study coverage for a gene symbol."""

--- a/src/tooluniverse/tcia_tool.py
+++ b/src/tooluniverse/tcia_tool.py
@@ -1,0 +1,246 @@
+"""
+TCIA (The Cancer Imaging Archive) NBIA REST API tool.
+
+The NBIA v1 REST services answer *every* zero-result query the same way: HTTP
+200 with a completely empty body and no ``Content-Type`` header.  Verified live
+against ``services.cancerimagingarchive.net``::
+
+    getModalityValues?Collection=NSCLC-Radiogenomics  -> 200, body ''
+    getModalityValues?Collection=NSCLC Radiogenomics  -> 200, [{"Modality":"CT"},...]
+    getSeries?Collection=NSCLC Radiogenomics&Modality=MR -> 200, body ''
+    getSeries?Collection=NSCLC Radiogenomics&Modality=CT -> 200, [ ...series... ]
+
+``BaseRESTTool._process_response`` cannot decode an empty body as JSON, so it
+falls through to its plain-text branch and reports ``{"status": "success",
+"data": ""}`` -- an empty *string* where every non-empty response is a *list*,
+with no ``count`` key at all.  Three failures compound in that one payload:
+
+1. A misspelled / nonexistent collection is reported as a success.  Collection
+   names are exact-match and are not consistently punctuated (the real
+   ``NSCLC Radiogenomics`` sits next to ``NSCLC-Radiomics`` and
+   ``NSCLC-Radiomics-Genomics``), so hyphenating it is a natural mistake that
+   the API silently swallows.
+2. ``data`` changes type between the hit and the miss, so ``len(data)`` is 0
+   either way and iteration yields nothing without raising.
+3. A genuine filter miss on a *valid* collection is byte-identical to (1), so a
+   caller cannot tell "this collection has no MR series" from "you typed the
+   collection name wrong".
+
+This subclass fixes all three at the point where the archive goes quiet:
+
+* An empty body always becomes ``data: []`` with ``count: 0`` -- a list, like
+  every non-empty response, never ``""``.
+* If a ``Collection`` argument was supplied and it is not one of the names the
+  archive publishes, the result is ``status: "error"`` naming the closest real
+  collection names instead of a silent success.
+* Otherwise the empty list carries a ``note`` stating that the collection is
+  real and that the remaining filters are what matched nothing.
+
+Cost: validation needs the collection list (~155 names).  It is fetched **only
+on the empty-result path** -- the request is paid for exactly when the tool is
+about to return nothing, never on the overwhelmingly common success path -- and
+then memoized for the life of the process, so a session that mistypes several
+collection names still makes at most one extra request.
+"""
+
+import threading
+from difflib import get_close_matches
+from typing import Any
+
+from .base_rest_tool import BaseRESTTool
+from .http_utils import request_with_retry
+from .tool_registry import register_tool
+
+COLLECTION_VALUES_URL = (
+    "https://services.cancerimagingarchive.net/nbia-api/services/v1/getCollectionValues"
+)
+
+# Process-wide memo of the published collection names. The archive's collection
+# list changes on the order of months, so caching for the process lifetime is
+# safe and keeps the validation cost at one request per session.
+_COLLECTIONS_LOCK = threading.Lock()
+_COLLECTIONS_CACHE: dict[str, Any] = {"names": None, "error": None}
+
+
+def _reset_collection_cache() -> None:
+    """Clear the memoized collection list (used by tests)."""
+    with _COLLECTIONS_LOCK:
+        _COLLECTIONS_CACHE["names"] = None
+        _COLLECTIONS_CACHE["error"] = None
+
+
+def _normalize(name: str) -> str:
+    """Fold case and separator punctuation so 'NSCLC-Radiogenomics' == 'NSCLC Radiogenomics'."""
+    return "".join(ch for ch in name.lower() if ch.isalnum())
+
+
+@register_tool("TCIATool")
+class TCIATool(BaseRESTTool):
+    """BaseRESTTool for the NBIA v1 API that never reports an empty body as bare success."""
+
+    def _fetch_collection_names(self) -> list[str] | None:
+        """
+        Return the archive's collection names, memoized per process.
+
+        Returns None (and records the reason) when the list cannot be fetched,
+        so a validation outage degrades to "cannot verify" rather than to a
+        false "this collection does not exist".  Only successes are memoized: a
+        transient outage must not disable validation for the whole process.
+        """
+        with _COLLECTIONS_LOCK:
+            if _COLLECTIONS_CACHE["names"] is not None:
+                return _COLLECTIONS_CACHE["names"]
+
+        names: list[str] | None = None
+        error: str | None = None
+        try:
+            response = request_with_retry(
+                self.session,
+                "GET",
+                COLLECTION_VALUES_URL,
+                timeout=self.timeout,
+                max_attempts=2,
+            )
+            if 200 <= response.status_code < 300:
+                payload = response.json()
+                if isinstance(payload, list):
+                    names = [
+                        row["Collection"]
+                        for row in payload
+                        if isinstance(row, dict)
+                        and isinstance(row.get("Collection"), str)
+                    ]
+            if not names:
+                names = None
+                error = f"getCollectionValues returned no usable collection list (HTTP {response.status_code})"
+        except Exception as exc:  # network / decode failure
+            names = None
+            error = str(exc)
+
+        with _COLLECTIONS_LOCK:
+            _COLLECTIONS_CACHE["names"] = names
+            _COLLECTIONS_CACHE["error"] = error
+        return names
+
+    @staticmethod
+    def _suggest(collection: str, known: list[str]) -> list[str]:
+        """Closest real collection names to a name that does not exist."""
+        target = _normalize(collection)
+        # An exact match once case and separators are folded is almost always
+        # the intended collection (the reported 'NSCLC-Radiogenomics' case), so
+        # rank those first.
+        suggestions = [name for name in known if _normalize(name) == target]
+        for name in get_close_matches(collection, known, n=5, cutoff=0.6):
+            if name not in suggestions:
+                suggestions.append(name)
+        if not suggestions:
+            suggestions = [
+                name
+                for name in known
+                if target and (target in _normalize(name) or _normalize(name) in target)
+            ]
+        return suggestions[:3]
+
+    def _filter_summary(self, arguments: dict[str, Any], skip: str = "") -> str:
+        """Render the non-empty filters that were actually sent, for the note text."""
+        parts = [
+            f"{key}={value!r}"
+            for key, value in (arguments or {}).items()
+            if key != skip and value is not None and value != ""
+        ]
+        return ", ".join(parts)
+
+    @staticmethod
+    def _requested_url(response: Any, url: str) -> str:
+        """
+        Echo the fully-resolved request URI rather than the bare endpoint.
+
+        BaseRESTTool keeps the query string in ``params``, so the echoed ``url``
+        was just the endpoint -- two very different queries against
+        ``/getSeries`` were reported identically and neither could be
+        reproduced from the response. ``response.url`` carries the filters that
+        were actually sent. Falls back to the endpoint when the attribute is
+        absent or is not a real string (stubbed responses in tests).
+        """
+        resolved = getattr(response, "url", None)
+        return resolved if isinstance(resolved, str) and resolved else url
+
+    def _process_response(self, response, url):
+        """Attach the resolved request URI to the normal (non-empty) success path."""
+        return super()._process_response(response, self._requested_url(response, url))
+
+    def _handle_special_endpoint(self, url, response, arguments):
+        """
+        Intercept NBIA's empty-body "no results" response.
+
+        Returns None for any response with a body so normal processing (and any
+        real error handling) is untouched.
+        """
+        if (getattr(response, "text", "") or "").strip():
+            return None
+
+        url = self._requested_url(response, url)
+        endpoint = self.tool_config.get("fields", {}).get("endpoint", "")
+        collection = (arguments or {}).get("Collection")
+        collection = collection.strip() if isinstance(collection, str) else None
+
+        # getCollectionValues is the validation source itself; never recurse.
+        if collection and "getCollectionValues" not in endpoint:
+            known = self._fetch_collection_names()
+            if known is not None and collection not in known:
+                suggestions = self._suggest(collection, known)
+                hint = (
+                    " Closest existing collection name(s): "
+                    + ", ".join(f"'{name}'" for name in suggestions)
+                    + "."
+                    if suggestions
+                    else ""
+                )
+                return {
+                    "status": "error",
+                    "error": (
+                        f"TCIA: collection '{collection}' does not exist in The Cancer "
+                        f"Imaging Archive (checked against the {len(known)} collections "
+                        f"published by getCollectionValues).{hint} Collection names are "
+                        f"matched exactly, including case, spaces and hyphens; call "
+                        f"TCIA_list_collections for the full list."
+                    ),
+                    "suggestions": suggestions,
+                    "invalid_collection": collection,
+                    "url": url,
+                }
+
+            if known is not None:
+                other = self._filter_summary(arguments, skip="Collection")
+                narrowed = (
+                    f" the other filters ({other}) matched nothing in it"
+                    if other
+                    else " it currently exposes no records for this endpoint"
+                )
+                note = (
+                    f"No matching records. The collection '{collection}' exists in TCIA, so"
+                    f"{narrowed}."
+                )
+            else:
+                note = (
+                    f"No matching records. The collection name '{collection}' could not be "
+                    f"verified against TCIA_list_collections "
+                    f"({_COLLECTIONS_CACHE.get('error')}), so a misspelled collection name "
+                    f"cannot be ruled out as the cause."
+                )
+        else:
+            filters = self._filter_summary(arguments)
+            note = (
+                "No matching records"
+                + (f" for {filters}" if filters else "")
+                + ". TCIA matches identifiers exactly, so a value that does not exist "
+                "returns the same empty result as a filter that genuinely has no data."
+            )
+
+        return {
+            "status": "success",
+            "data": [],
+            "count": 0,
+            "url": url,
+            "note": note,
+        }

--- a/src/tooluniverse/tools/Nextstrain_list_datasets.py
+++ b/src/tooluniverse/tools/Nextstrain_list_datasets.py
@@ -10,6 +10,7 @@ from ._shared_client import get_shared_client
 
 def Nextstrain_list_datasets(
     pathogen: Optional[str | Any] = None,
+    datasets_per_pathogen: Optional[int | Any] = None,
     *,
     stream_callback: Optional[Callable[[str], None]] = None,
     use_cache: bool = False,
@@ -22,6 +23,8 @@ def Nextstrain_list_datasets(
     ----------
     pathogen : str | Any
         Optional pathogen name filter. Examples: 'flu', 'ebola', 'zika', 'dengue', 'm...
+    datasets_per_pathogen : int | Any
+        Maximum dataset paths listed per pathogen (default 10; 0 lists every da...
     stream_callback : Callable, optional
         Callback for streaming output
     use_cache : bool, default False
@@ -36,7 +39,14 @@ def Nextstrain_list_datasets(
     # Handle mutable defaults to avoid B006 linting error
 
     # Strip None values so optional parameters don't trigger schema validation errors
-    _args = {k: v for k, v in {"pathogen": pathogen}.items() if v is not None}
+    _args = {
+        k: v
+        for k, v in {
+            "pathogen": pathogen,
+            "datasets_per_pathogen": datasets_per_pathogen,
+        }.items()
+        if v is not None
+    }
     return get_shared_client().run_one_function(
         {
             "name": "Nextstrain_list_datasets",

--- a/src/tooluniverse/tools/WHOGHO_get_indicator_data.py
+++ b/src/tooluniverse/tools/WHOGHO_get_indicator_data.py
@@ -12,6 +12,7 @@ def WHOGHO_get_indicator_data(
     indicator_code: str,
     filter: Optional[str | Any] = None,
     top: Optional[int | Any] = None,
+    orderby: Optional[str | Any] = None,
     *,
     stream_callback: Optional[Callable[[str], None]] = None,
     use_cache: bool = False,
@@ -27,7 +28,9 @@ def WHOGHO_get_indicator_data(
     filter : str | Any
         OData filter for data rows. Examples: "SpatialDim eq 'USA'", "TimeDim eq 2022...
     top : int | Any
-        Maximum number of data rows to return. Default: 20
+        Maximum number of data rows to return (default 100). One row is one country-...
+    orderby : str | Any
+        OData $orderby clause controlling row order, which also determines which rows...
     stream_callback : Callable, optional
         Callback for streaming output
     use_cache : bool, default False
@@ -48,6 +51,7 @@ def WHOGHO_get_indicator_data(
             "indicator_code": indicator_code,
             "filter": filter,
             "top": top,
+            "orderby": orderby,
         }.items()
         if v is not None
     }

--- a/src/tooluniverse/tools/WorldBank_get_indicator.py
+++ b/src/tooluniverse/tools/WorldBank_get_indicator.py
@@ -13,6 +13,8 @@ def WorldBank_get_indicator(
     indicator: str,
     mrv: Optional[int | Any] = None,
     date: Optional[str | Any] = None,
+    per_page: Optional[int | Any] = None,
+    page: Optional[int | Any] = None,
     *,
     stream_callback: Optional[Callable[[str], None]] = None,
     use_cache: bool = False,
@@ -31,6 +33,10 @@ def WorldBank_get_indicator(
         Most recent values - number of most recent years to return (e.g., 5 for last ...
     date : str | Any
         Year or year range to filter data (e.g., '2020', '2015:2023' for a range)
+    per_page : int | Any
+        Rows returned per request (default 1000, maximum 32500). One row is one coun...
+    page : int | Any
+        1-based page number of the result set (default 1). Only needed when a result...
     stream_callback : Callable, optional
         Callback for streaming output
     use_cache : bool, default False
@@ -52,6 +58,8 @@ def WorldBank_get_indicator(
             "indicator": indicator,
             "mrv": mrv,
             "date": date,
+            "per_page": per_page,
+            "page": page,
         }.items()
         if v is not None
     }

--- a/src/tooluniverse/tools/cBioPortal_get_cancer_studies.py
+++ b/src/tooluniverse/tools/cBioPortal_get_cancer_studies.py
@@ -1,7 +1,7 @@
 """
 cBioPortal_get_cancer_studies
 
-Get list of cancer studies from cBioPortal
+Get one page of the cBioPortal study catalogue
 """
 
 from typing import Any, Optional, Callable
@@ -10,18 +10,23 @@ from ._shared_client import get_shared_client
 
 def cBioPortal_get_cancer_studies(
     limit: Optional[int] = 20,
+    offset: Optional[int] = 0,
     *,
     stream_callback: Optional[Callable[[str], None]] = None,
     use_cache: bool = False,
     validate: bool = True,
 ) -> list[Any]:
     """
-    Get list of cancer studies from cBioPortal
+    Get one page of the cBioPortal study catalogue. The response reports
+    `total_available` (full catalogue size) alongside `count` (studies
+    returned) and sets `truncated` when studies were left behind.
 
     Parameters
     ----------
     limit : int
-        Number of studies to return
+        Number of studies to return in this page
+    offset : int
+        0-based index of the first study to return
     stream_callback : Callable, optional
         Callback for streaming output
     use_cache : bool, default False
@@ -36,7 +41,9 @@ def cBioPortal_get_cancer_studies(
     # Handle mutable defaults to avoid B006 linting error
 
     # Strip None values so optional parameters don't trigger schema validation errors
-    _args = {k: v for k, v in {"limit": limit}.items() if v is not None}
+    _args = {
+        k: v for k, v in {"limit": limit, "offset": offset}.items() if v is not None
+    }
     return get_shared_client().run_one_function(
         {
             "name": "cBioPortal_get_cancer_studies",

--- a/tests/unit/test_cbioportal_studies_total_disclosed.py
+++ b/tests/unit/test_cbioportal_studies_total_disclosed.py
@@ -1,0 +1,183 @@
+"""Regression guard: cBioPortal paginated results must disclose the real total.
+
+`cBioPortal_get_cancer_studies` defaults to `pageSize=20` while cBioPortal
+holds 539 studies (verified live: `GET /api/studies` returns 539 records and
+`GET /api/studies?projection=META` reports `Total-Count: 539`). The tool used
+to answer with `count: 20` and nothing else, so a page read exactly like the
+complete catalogue and a study at position 21 read as "not in cBioPortal".
+
+The tool now reports `total_available` next to `count`, sets a top-level
+`truncated` flag plus a `truncation_note`, and supports `offset` for paging.
+`count` keeps its old meaning -- the number of records actually returned -- so
+its meaning never flips depending on whether the page limit binds.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from tooluniverse.cbioportal_tool import CBioPortalRESTTool
+
+pytestmark = pytest.mark.unit
+
+
+def _studies_tool():
+    return CBioPortalRESTTool(
+        {
+            "name": "cBioPortal_get_cancer_studies",
+            "parameter": {
+                "type": "object",
+                "properties": {
+                    "limit": {"type": "integer", "default": 20},
+                    "offset": {"type": "integer", "default": 0},
+                },
+            },
+            "fields": {
+                "endpoint": "https://www.cbioportal.org/api/studies?pageSize={limit}"
+            },
+        }
+    )
+
+
+def _panels_tool():
+    return CBioPortalRESTTool(
+        {
+            "name": "cBioPortal_get_gene_panels",
+            "parameter": {
+                "type": "object",
+                "properties": {"page_size": {"type": "integer", "default": 50}},
+            },
+            "fields": {
+                "endpoint": "https://www.cbioportal.org/api/gene-panels?pageSize={page_size}"
+            },
+        }
+    )
+
+
+def _fake_session(tool, *, page, total):
+    """Route the data request and the projection=META total probe separately."""
+    calls = []
+
+    def _get(url, **kwargs):
+        calls.append(url)
+        response = MagicMock()
+        response.raise_for_status.return_value = None
+        response.status_code = 200
+        if "projection=META" in url:
+            response.json.return_value = []
+            response.headers = {"Total-Count": str(total)}
+        else:
+            response.json.return_value = page
+            response.headers = {}
+        return response
+
+    tool.session.get = _get
+    return calls
+
+
+def test_truncated_study_page_reports_catalogue_total():
+    tool = _studies_tool()
+    page = [{"studyId": f"study_{i}"} for i in range(20)]
+    calls = _fake_session(tool, page=page, total=539)
+
+    result = tool.run({})
+
+    assert result["status"] == "success"
+    assert result["count"] == 20, "count must stay the number of records returned"
+    assert result["total_available"] == 539
+    assert result["truncated"] is True
+    assert "539" in result["truncation_note"]
+    assert "offset" in result["truncation_note"]
+    # The total came from a dedicated META probe with the paging params
+    # stripped -- /api/studies clamps the META count to pageSize otherwise.
+    probe = [u for u in calls if "projection=META" in u]
+    assert len(probe) == 1
+    assert "pageSize" not in probe[0]
+
+
+def test_complete_study_list_is_not_flagged_truncated():
+    tool = _studies_tool()
+    page = [{"studyId": f"study_{i}"} for i in range(539)]
+    calls = _fake_session(tool, page=page, total=539)
+
+    result = tool.run({"limit": 1000})
+
+    assert result["count"] == 539
+    assert result["total_available"] == 539
+    assert result["truncated"] is False
+    assert "truncation_note" not in result
+    # A short page proves the set is exhausted, so no probe is spent.
+    assert not [u for u in calls if "projection=META" in u]
+
+
+def test_offset_pages_past_the_first_slice():
+    tool = _studies_tool()
+    page = [{"studyId": f"study_{i}"} for i in range(25)]
+    _fake_session(tool, page=page, total=539)
+
+    result = tool.run({"limit": 5, "offset": 20})
+
+    assert [s["studyId"] for s in result["data"]] == [
+        f"study_{i}" for i in range(20, 25)
+    ]
+    assert result["offset"] == 20
+    assert result["count"] == 5
+    assert result["total_available"] == 539
+    assert result["truncated"] is True
+
+
+def test_unknown_total_is_reported_as_unknown_not_invented():
+    tool = _studies_tool()
+    page = [{"studyId": f"study_{i}"} for i in range(20)]
+
+    def _get(url, **kwargs):
+        response = MagicMock()
+        response.raise_for_status.return_value = None
+        if "projection=META" in url:
+            response.status_code = 503
+            response.headers = {}
+        else:
+            response.status_code = 200
+            response.json.return_value = page
+            response.headers = {}
+        return response
+
+    tool.session.get = _get
+    result = tool.run({})
+
+    assert result["total_available"] is None
+    assert result["truncated"] is True
+    assert "did not report the total" in result["truncation_note"]
+
+
+def test_sibling_paginated_tool_also_discloses_total():
+    """The same silent-slice shape existed on the other paged endpoints."""
+    tool = _panels_tool()
+    page = [{"genePanelId": f"panel_{i}"} for i in range(50)]
+    _fake_session(tool, page=page, total=69)
+
+    result = tool.run({})
+
+    assert result["count"] == 50
+    assert result["total_available"] == 69
+    assert result["truncated"] is True
+    assert "page_size" in result["truncation_note"]
+
+
+def test_unpaginated_endpoint_is_left_alone():
+    """Endpoints with no pageSize return their whole set; no probe, no flags."""
+    tool = CBioPortalRESTTool(
+        {
+            "name": "cBioPortal_get_cancer_types",
+            "parameter": {"type": "object", "properties": {}},
+            "fields": {"endpoint": "https://www.cbioportal.org/api/cancer-types"},
+        }
+    )
+    calls = _fake_session(tool, page=[{"cancerTypeId": "acc"}], total=897)
+
+    result = tool.run({})
+
+    assert result["count"] == 1
+    assert "total_available" not in result
+    assert "truncated" not in result
+    assert not [u for u in calls if "projection=META" in u]

--- a/tests/unit/test_clinical_imaging_archives_depth.py
+++ b/tests/unit/test_clinical_imaging_archives_depth.py
@@ -8,9 +8,9 @@ in the mocked payload) and an error-path test. No live network access is used;
 all HTTP calls are patched.
 
 Tools under test:
-- TCIA_get_patients                 (BaseRESTTool, getPatient)
-- TCIA_get_sop_instance_uids        (BaseRESTTool, getSOPInstanceUIDs)
-- TCIA_get_manufacturer_values      (BaseRESTTool, getManufacturerValues)
+- TCIA_get_patients                 (TCIATool, getPatient)
+- TCIA_get_sop_instance_uids        (TCIATool, getSOPInstanceUIDs)
+- TCIA_get_manufacturer_values      (TCIATool, getManufacturerValues)
 - OpenNeuro_get_snapshot_files      (OpenNeuroTool, snapshot.files)
 - OpenNeuro_get_snapshot_validation (OpenNeuroTool, snapshot.validation)
 - OpenNeuro_advanced_search         (OpenNeuroTool, participantCount + advancedSearch)
@@ -51,13 +51,13 @@ def _mock_response(json_payload=None, status_code=200, text=None):
 
 
 # --------------------------------------------------------------------------- #
-# TCIA_get_patients  (BaseRESTTool via request_with_retry)
+# TCIA_get_patients  (TCIATool via request_with_retry)
 # --------------------------------------------------------------------------- #
 class TestTCIAGetPatients:
     def _tool(self):
-        from tooluniverse.base_rest_tool import BaseRESTTool
+        from tooluniverse.tcia_tool import TCIATool
 
-        return BaseRESTTool(_load_config("tcia_tools.json", "TCIA_get_patients"))
+        return TCIATool(_load_config("tcia_tools.json", "TCIA_get_patients"))
 
     def test_parse_success(self):
         """Success path: getPatient payload parses with patient-level fields."""
@@ -113,17 +113,15 @@ class TestTCIAGetPatients:
 
 
 # --------------------------------------------------------------------------- #
-# TCIA_get_sop_instance_uids  (BaseRESTTool via request_with_retry)
+# TCIA_get_sop_instance_uids  (TCIATool via request_with_retry)
 # --------------------------------------------------------------------------- #
 class TestTCIAGetSopInstanceUids:
     SERIES = "1.3.6.1.4.1.14519.5.2.1.6279.6001.179049373636438705059720603192"
 
     def _tool(self):
-        from tooluniverse.base_rest_tool import BaseRESTTool
+        from tooluniverse.tcia_tool import TCIATool
 
-        return BaseRESTTool(
-            _load_config("tcia_tools.json", "TCIA_get_sop_instance_uids")
-        )
+        return TCIATool(_load_config("tcia_tools.json", "TCIA_get_sop_instance_uids"))
 
     def test_parse_success(self):
         """Success path: getSOPInstanceUIDs returns per-image SOP UID objects."""
@@ -167,15 +165,13 @@ class TestTCIAGetSopInstanceUids:
 
 
 # --------------------------------------------------------------------------- #
-# TCIA_get_manufacturer_values  (BaseRESTTool via request_with_retry)
+# TCIA_get_manufacturer_values  (TCIATool via request_with_retry)
 # --------------------------------------------------------------------------- #
 class TestTCIAGetManufacturerValues:
     def _tool(self):
-        from tooluniverse.base_rest_tool import BaseRESTTool
+        from tooluniverse.tcia_tool import TCIATool
 
-        return BaseRESTTool(
-            _load_config("tcia_tools.json", "TCIA_get_manufacturer_values")
-        )
+        return TCIATool(_load_config("tcia_tools.json", "TCIA_get_manufacturer_values"))
 
     def test_parse_success(self):
         """Success path: getManufacturerValues returns distinct manufacturers."""

--- a/tests/unit/test_europepmc_hitcount_surfaced.py
+++ b/tests/unit/test_europepmc_hitcount_surfaced.py
@@ -1,0 +1,114 @@
+"""Regression guard: EuropePMC_search_articles must surface upstream hitCount.
+
+Europe PMC returns the true number of matching records as `hitCount` in every
+search response (verified live: `.../search?query=NSCLC%20radiogenomics%20EGFR
+%20CT%20radiomics%20TCIA&format=json&pageSize=1` -> `"hitCount": 103`). The
+tool parsed that payload and discarded the figure, reporting only
+`metadata.count` -- the number of records returned -- which is
+indistinguishable from the number that matched.
+
+`metadata.total_results` now always carries the upstream total, `count` keeps
+its old meaning, and a truncated answer is flagged at the top level.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.europe_pmc_tool import EuropePMCTool
+
+pytestmark = pytest.mark.unit
+
+
+def _record(idx):
+    return {
+        "id": f"MED{idx}",
+        "source": "MED",
+        "title": f"Article {idx}",
+        "abstractText": "abstract",
+        "pubYear": "2026",
+    }
+
+
+def _payload(hit_count, n_records):
+    return {
+        "hitCount": hit_count,
+        "resultList": {"result": [_record(i) for i in range(n_records)]},
+    }
+
+
+def _response(payload, status_code=200):
+    response = MagicMock()
+    response.status_code = status_code
+    response.json.return_value = payload
+    return response
+
+
+def _run(hit_count, n_records, arguments):
+    tool = EuropePMCTool({"name": "EuropePMC_search_articles"})
+    response = _response(_payload(hit_count, n_records))
+    with patch(
+        "tooluniverse.europe_pmc_tool.request_with_retry", return_value=response
+    ):
+        return tool.run(arguments)
+
+
+def test_hit_count_is_reported_and_truncation_disclosed():
+    result = _run(103, 6, {"query": "NSCLC radiogenomics EGFR", "limit": 6})
+
+    assert result["status"] == "success"
+    assert len(result["data"]) == 6
+    assert result["metadata"]["count"] == 6, "count stays the number returned"
+    assert result["metadata"]["total_results"] == 103
+    assert result["truncated"] is True
+    assert "103" in result["truncation_note"]
+    assert "limit" in result["truncation_note"]
+
+
+def test_complete_result_set_is_not_flagged_truncated():
+    result = _run(2, 2, {"query": "a very specific query", "limit": 10})
+
+    assert result["metadata"]["count"] == 2
+    assert result["metadata"]["total_results"] == 2
+    assert result["truncated"] is False
+    assert "truncation_note" not in result
+
+
+def test_zero_hits_reports_zero_total():
+    result = _run(0, 0, {"query": "nonexistent gibberish", "limit": 5})
+
+    assert result["data"] == []
+    assert result["metadata"]["count"] == 0
+    assert result["metadata"]["total_results"] == 0
+    assert result["truncated"] is False
+
+
+def test_missing_hit_count_reports_unknown_rather_than_returned_count():
+    """A total the upstream did not give must not be faked from `count`."""
+    tool = EuropePMCTool({"name": "EuropePMC_search_articles"})
+    payload = {"resultList": {"result": [_record(0)]}}
+    with patch(
+        "tooluniverse.europe_pmc_tool.request_with_retry",
+        return_value=_response(payload),
+    ):
+        result = tool.run({"query": "q", "limit": 5})
+
+    assert result["metadata"]["count"] == 1
+    assert result["metadata"]["total_results"] is None
+    assert "truncated" not in result
+
+
+def test_upstream_error_still_returns_the_documented_error_shape():
+    tool = EuropePMCTool({"name": "EuropePMC_search_articles"})
+    response = MagicMock()
+    response.status_code = 503
+    response.reason = "Service Unavailable"
+    with patch(
+        "tooluniverse.europe_pmc_tool.request_with_retry", return_value=response
+    ):
+        result = tool.run({"query": "q", "limit": 5})
+
+    assert result["status"] == "success"
+    assert result["data"][0]["error"].startswith("Europe PMC API error 503")
+    assert result["data"][0]["retryable"] is True
+    assert result["metadata"]["total_results"] is None

--- a/tests/unit/test_gtdb_species_query_not_genus_match.py
+++ b/tests/unit/test_gtdb_species_query_not_genus_match.py
@@ -1,0 +1,210 @@
+"""Regression guard for Fix-R29: a binomial query to GTDB_search_genomes must
+not silently degrade into a genus-wide match.
+
+GTDB's /search/gtdb endpoint ORs the terms of a multi-word query instead of
+requiring all of them. Confirmed live against https://gtdb-api.ecogenomic.org :
+
+    search=xyzzyplop                  -> totalRows 0
+    search=Mycobacterium              -> totalRows 13027
+    search=Mycobacterium xyzzyplop    -> totalRows 13027 (identical rows)
+    search=Mycobacterium tuberculosis -> totalRows 13381, first row
+                                         "Mycobacterium leprae Br4923"
+
+So an unmatchable term is discarded entirely and the reported total is the
+union count for the broader taxon. The endpoint's documented `filterText`
+parameter adds a case-insensitive literal-substring test that every returned
+row must satisfy (live: search+filterText="Mycobacterium tuberculosis" ->
+totalRows 7869, all M. tuberculosis; filterText="Mycobacterium xyzzyplop" -> 0),
+so the tool now issues the precise lookup first and only falls back to the
+loose union search with an explicit top-level disclosure.
+
+No live network here -- the HTTP layer is mocked.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from tooluniverse.gtdb_tool import GTDBTool
+
+pytestmark = pytest.mark.unit
+
+
+def _row(name, species):
+    return {
+        "gid": "GCA_TEST",
+        "accession": "GCA_TEST",
+        "ncbiOrgName": name,
+        "ncbiTaxonomy": "d__Bacteria; g__Mycobacterium; s__" + species,
+        "gtdbTaxonomy": "d__Bacteria; g__Mycobacterium; s__" + species,
+        "isGtdbSpeciesRep": False,
+        "isNcbiTypeMaterial": False,
+    }
+
+
+TB_ROWS = [
+    _row("Mycobacterium tuberculosis SUMu001", "Mycobacterium tuberculosis"),
+    _row("Mycobacterium tuberculosis C", "Mycobacterium tuberculosis"),
+]
+GENUS_ROWS = [
+    _row("Mycobacterium leprae Br4923", "Mycobacterium leprae"),
+] + TB_ROWS
+
+
+def _tool():
+    return GTDBTool({"name": "GTDB_search_genomes", "parameter": {}})
+
+
+def _resp(json_body, status_code=200):
+    r = MagicMock()
+    r.status_code = status_code
+    r.json.return_value = json_body
+    return r
+
+
+def _fake_gtdb(filtered_body, unfiltered_body):
+    """Mimic /search/gtdb: `filterText` narrows, its absence unions the terms."""
+    calls = []
+
+    def _get(url, params=None, timeout=None):
+        params = params or {}
+        calls.append(params)
+        if params.get("filterText"):
+            return _resp(filtered_body)
+        return _resp(unfiltered_body)
+
+    return _get, calls
+
+
+class TestBinomialQueryDoesNotDegradeToGenus:
+    def test_precise_filter_is_applied_and_wrong_species_excluded(self):
+        tool = _tool()
+        get, calls = _fake_gtdb(
+            {"rows": TB_ROWS, "totalRows": 7869},
+            {"rows": GENUS_ROWS, "totalRows": 13381},
+        )
+        tool.session.get = get
+
+        result = tool.run(
+            {
+                "operation": "search_genomes",
+                "query": "Mycobacterium tuberculosis",
+                "items_per_page": 5,
+            }
+        )
+
+        assert result["status"] == "success"
+        data = result["data"]
+
+        # The precise lookup must actually be sent upstream.
+        assert calls[0]["filterText"] == "Mycobacterium tuberculosis"
+
+        # No result may be a species other than the one that was asked for.
+        for row in data["results"]:
+            assert "s__Mycobacterium tuberculosis" in row["gtdbTaxonomy"]
+            assert "leprae" not in row["ncbiOrgName"]
+
+        # The count must be the species count, not the genus/union count.
+        assert data["match_type"] == "exact"
+        assert data["total_results"] == 7869
+        assert data["total_results"] != 13381
+        assert "note" not in data
+
+    def test_unmatched_binomial_falls_back_but_discloses_it(self):
+        """GTDB drops the unmatchable term and returns the whole genus; the
+        tool must fall back only with an explicit top-level disclosure."""
+        tool = _tool()
+        get, _calls = _fake_gtdb(
+            {"rows": [], "totalRows": 0},
+            {"rows": GENUS_ROWS, "totalRows": 13027},
+        )
+        tool.session.get = get
+
+        result = tool.run(
+            {"operation": "search_genomes", "query": "Mycobacterium xyzzyplop"}
+        )
+
+        data = result["data"]
+        assert data["match_type"] == "broad"
+        # The disclosure must be at the top level, not buried in the rows.
+        assert "note" in data
+        assert "NOT 'Mycobacterium xyzzyplop'" in data["note"]
+        # total_results must not be passed off as the count for the query.
+        assert "not for 'Mycobacterium xyzzyplop'" in data["note"]
+        assert "broader" in data["total_results_scope"]
+        # Results are still returned so the caller can inspect them.
+        assert data["count"] == len(GENUS_ROWS)
+
+    def test_no_match_at_all_reported_as_none(self):
+        tool = _tool()
+        get, _calls = _fake_gtdb(
+            {"rows": [], "totalRows": 0}, {"rows": [], "totalRows": 0}
+        )
+        tool.session.get = get
+
+        result = tool.run(
+            {"operation": "search_genomes", "query": "Xyzzyplop notaspecies"}
+        )
+
+        data = result["data"]
+        assert data["match_type"] == "none"
+        assert data["total_results"] == 0
+        assert data["results"] == []
+        assert "no genome" in data["note"]
+
+    def test_genus_query_still_matches_the_genus(self):
+        """Control: a genus query is legitimately a genus-level match."""
+        tool = _tool()
+        get, calls = _fake_gtdb(
+            {"rows": GENUS_ROWS, "totalRows": 13027},
+            {"rows": GENUS_ROWS, "totalRows": 13027},
+        )
+        tool.session.get = get
+
+        result = tool.run({"operation": "search_genomes", "query": "Mycobacterium"})
+
+        data = result["data"]
+        assert data["match_type"] == "exact"
+        assert data["total_results"] == 13027
+        assert "note" not in data
+        assert len(calls) == 1
+
+    def test_internal_whitespace_collapsed_for_literal_filter(self):
+        """filterText is whitespace-literal upstream (a double space matches
+        nothing), so the query must be normalized before it is sent."""
+        tool = _tool()
+        get, calls = _fake_gtdb(
+            {"rows": TB_ROWS, "totalRows": 7869},
+            {"rows": GENUS_ROWS, "totalRows": 13381},
+        )
+        tool.session.get = get
+
+        result = tool.run(
+            {"operation": "search_genomes", "query": "  Mycobacterium   tuberculosis "}
+        )
+
+        assert calls[0]["filterText"] == "Mycobacterium tuberculosis"
+        assert calls[0]["search"] == "Mycobacterium tuberculosis"
+        assert result["data"]["match_type"] == "exact"
+
+    def test_page_beyond_last_does_not_trigger_broad_fallback(self):
+        """An empty page of a non-empty exact match is still an exact match."""
+        tool = _tool()
+        get, calls = _fake_gtdb(
+            {"rows": [], "totalRows": 7869},
+            {"rows": GENUS_ROWS, "totalRows": 13381},
+        )
+        tool.session.get = get
+
+        result = tool.run(
+            {
+                "operation": "search_genomes",
+                "query": "Mycobacterium tuberculosis",
+                "page": 99999,
+            }
+        )
+
+        data = result["data"]
+        assert data["match_type"] == "exact"
+        assert data["results"] == []
+        assert len(calls) == 1

--- a/tests/unit/test_iedb_mhcii_fixes.py
+++ b/tests/unit/test_iedb_mhcii_fixes.py
@@ -1,17 +1,23 @@
-"""Regression guard for Fix-R18D-1/R18D-2: IEDB's MHC-II prediction endpoint
-had two bugs, both confirmed live --
+"""Regression guard for the IEDB MHC-II prediction defects.
 
-1. A too-short input sequence gets a plain-text validation error back with
-   HTTP 200 (not real TSV data). csv.DictReader silently misparsed the
-   error's first line as a single-column header, producing a fabricated
-   "successful" result with `percentile_rank: 100.0`. _iedb_error_response
-   now detects a non-tabular response (no tab in the first line) before
-   parsing and returns a real error instead.
-2. Even on a genuine successful response, the real TSV column is named
-   "rank" (unlike the sibling MHC-I endpoint, which really does use
-   "percentile_rank"), so `r.get("percentile_rank", 100)` always hit the
-   default -- every result silently reported rank 100 regardless of the
-   real value.
+Fix-R18D-1/R18D-2 and Fix-R34A-1 were all found against the legacy
+synchronous ``tools_api`` endpoint:
+
+1. An input the endpoint could not handle came back as prose with HTTP 200,
+   which was misparsed as TSV into a fabricated "successful" result.
+2. The real rank column was named differently from the one being read, so
+   every result silently reported rank 100.
+3. The class II sliding window defaults to 15 residues and errors on any
+   shorter sequence, including this tool's own 13-mer registered example, so
+   the window has to shrink to fit.
+
+Fix-R29A-1 then moved MHC-II off that endpoint entirely -- it accepts a POST
+and never answers, so every call stalled for the full client timeout. These
+guards are therefore expressed against IEDB's next-generation async pipeline
+API, where the equivalents are: an upstream failure surfaces in
+``data.errors`` (and must not be reported as success), the percentile comes
+from the peptide table's real columns, and the window is the submitted
+``peptide_length_range``.
 """
 
 import sys
@@ -28,47 +34,117 @@ pytestmark = pytest.mark.unit
 
 
 def _tool(endpoint_type):
-    return IEDBPredictionTool(
+    tool = IEDBPredictionTool(
         {"name": "IEDB_predict", "fields": {"endpoint_type": endpoint_type}}
     )
+    tool.poll_interval = 0
+    return tool
 
 
-def _resp(text):
+def _resp(payload, status_code=200):
     r = MagicMock()
-    r.text = text
+    r.status_code = status_code
+    r.json.return_value = payload
+    r.text = str(payload)
     r.raise_for_status = MagicMock()
     return r
 
 
-def test_short_sequence_error_text_is_reported_as_error_not_success():
-    tool = _tool("predict_mhcii")
-    error_text = (
-        "The length of input sequence is less than the input/default length 15.\n"
-        "* Please go to the link below for usage info:\n"
-        "http://tools.iedb.org/main/html/tools_api.html"
+def _done(columns, rows, warnings=None):
+    return {
+        "status": "done",
+        "data": {
+            "errors": [],
+            "warnings": warnings or [],
+            "results": [
+                {
+                    "type": "peptide_table",
+                    "table_columns": [{"name": c} for c in columns],
+                    "table_data": rows,
+                }
+            ],
+        },
+    }
+
+
+_SUBMIT_OK = {"result_id": "rid-1", "warnings": []}
+
+_MHCII_COLUMNS = [
+    "allele",
+    "start",
+    "end",
+    "length",
+    "netmhciipan_el_core",
+    "peptide",
+    "netmhciipan_el_score",
+    "median_percentile",
+    "netmhciipan_el_percentile",
+]
+
+
+def _submit_and_get(submit_payload, result_payload):
+    return patch(
+        "tooluniverse.iedb_prediction_tool.requests.post",
+        return_value=_resp(submit_payload),
+    ), patch(
+        "tooluniverse.iedb_prediction_tool.requests.get",
+        return_value=_resp(result_payload),
     )
 
-    with patch(
-        "tooluniverse.iedb_prediction_tool.requests.post",
-        return_value=_resp(error_text),
-    ):
+
+def test_upstream_stage_failure_is_reported_as_error_not_success():
+    """A stage that dies upstream must never surface as a prediction."""
+    tool = _tool("predict_mhcii")
+    failed = {
+        "status": "error",
+        "data": {
+            "errors": [
+                (
+                    "The following errors occurred during processing. "
+                    "stage reference number db5761a5"
+                )
+            ]
+        },
+    }
+    post, get = _submit_and_get(_SUBMIT_OK, failed)
+    with post, get:
         result = tool.run({"sequence": "PKYVKQNTLKLAT", "allele": "HLA-DRB1*01:01"})
 
     assert result["status"] == "error"
-    assert "length of input sequence" in result["error"]
+    assert "errors occurred during processing" in result["error"]
 
 
-def test_percentile_rank_reads_from_real_rank_column():
+def test_percentile_rank_reads_the_real_percentile_column():
     tool = _tool("predict_mhcii")
-    tsv = (
-        "allele\tseq_num\tstart\tend\tlength\tcore_peptide\tpeptide\tscore\trank\n"
-        "HLA-DRB1*01:01\t1\t15\t29\t15\tYAGSYPYDV\tVPDYAGSYPYDVPDY\t0.2922\t6.4\n"
-        "HLA-DRB1*01:01\t1\t14\t28\t15\tYAGSYPYDV\tDVPDYAGSYPYDVPD\t0.2454\t7.4\n"
+    payload = _done(
+        _MHCII_COLUMNS,
+        [
+            [
+                "HLA-DRB1*01:01",
+                15,
+                29,
+                15,
+                "YAGSYPYDV",
+                "VPDYAGSYPYDVPDY",
+                0.2922,
+                6.4,
+                6.4,
+            ],
+            [
+                "HLA-DRB1*01:01",
+                14,
+                28,
+                15,
+                "YAGSYPYDV",
+                "DVPDYAGSYPYDVPD",
+                0.2454,
+                7.4,
+                7.4,
+            ],
+        ],
     )
-
-    with patch(
-        "tooluniverse.iedb_prediction_tool.requests.post", return_value=_resp(tsv)
-    ):
+    post, get = _submit_and_get(_SUBMIT_OK, payload)
+    with post, get:
         result = tool.run(
             {
                 "sequence": "YPYDVPDYAGYPYDVPDYAGSYPYDVPDYA",
@@ -83,14 +159,21 @@ def test_percentile_rank_reads_from_real_rank_column():
 
 def test_mhci_percentile_rank_column_unaffected():
     tool = _tool("predict_mhci")
-    tsv = (
-        "allele\tseq_num\tstart\tend\tlength\tpeptide\tcore\ticore\tscore\tpercentile_rank\n"
-        "HLA-A*02:01\t1\t18\t26\t9\tYAGSYPYDV\tYAGSYPYDV\tYAGSYPYDV\t0.0512\t2.1\n"
+    payload = _done(
+        [
+            "allele",
+            "start",
+            "end",
+            "length",
+            "peptide",
+            "netmhcpan_el_score",
+            "median_percentile",
+            "netmhcpan_el_percentile",
+        ],
+        [["HLA-A*02:01", 18, 26, 9, "YAGSYPYDV", 0.0512, 2.1, 2.1]],
     )
-
-    with patch(
-        "tooluniverse.iedb_prediction_tool.requests.post", return_value=_resp(tsv)
-    ):
+    post, get = _submit_and_get(_SUBMIT_OK, payload)
+    with post, get:
         result = tool.run(
             {
                 "sequence": "YPYDVPDYAGYPYDVPDYAGSYPYDVPDYA",
@@ -103,56 +186,74 @@ def test_mhci_percentile_rank_column_unaffected():
     assert result["data"][0]["percentile_rank"] == 2.1
 
 
-def test_empty_response_is_reported_as_error():
+def test_empty_peptide_table_is_not_a_fabricated_hit():
     tool = _tool("predict_mhcii")
-
-    with patch(
-        "tooluniverse.iedb_prediction_tool.requests.post", return_value=_resp("")
-    ):
+    post, get = _submit_and_get(_SUBMIT_OK, _done(_MHCII_COLUMNS, []))
+    with post, get:
         result = tool.run({"sequence": "A" * 20, "allele": "HLA-DRB1*01:01"})
 
-    assert result["status"] == "error"
+    assert result["status"] == "success"
+    assert result["data"] == []
+    assert result["metadata"]["n_peptides"] == 0
 
 
-# Fix-R34A-1: IEDB's mhcii endpoint defaults its sliding-window length to 15
-# server-side and hard-errors on any shorter sequence -- confirmed live,
-# including against this tool's own registered <15-residue test example
-# ("PKYVKQNTLKLAT", 13 residues). Unlike the MHC-I methods in this file,
-# this endpoint never passed a length override even though IEDB's API
-# accepts one (confirmed live: length=13 makes the same short peptide
-# succeed). Auto-shrink the window to the sequence's own length when it's
-# under 15.
-_TSV = "allele\tseq_num\tstart\tend\tlength\tcore_peptide\tpeptide\tscore\trank\nHLA-DRB1*01:01\t1\t1\t13\t13\tYVKQNTLKL\tPKYVKQNTLKLAT\t0.8871\t0.23\n"
+# Fix-R34A-1: the class II sliding window defaults to 15 residues and cannot
+# exceed the input sequence, so a shorter sequence -- such as this tool's own
+# registered 13-residue example "PKYVKQNTLKLAT" -- needs the window shrunk to
+# its own length. On the next-gen API the window is the submitted
+# peptide_length_range.
+def _submitted_length_range(mock_post):
+    stage = mock_post.call_args.kwargs["json"]["stages"][0]
+    return stage["input_parameters"]["peptide_length_range"]
 
 
-def test_short_sequence_auto_shrinks_length_param():
+def test_short_sequence_auto_shrinks_the_window():
     tool = _tool("predict_mhcii")
-    with patch(
-        "tooluniverse.iedb_prediction_tool.requests.post", return_value=_resp(_TSV)
-    ) as mock_post:
+    with (
+        patch(
+            "tooluniverse.iedb_prediction_tool.requests.post",
+            return_value=_resp(_SUBMIT_OK),
+        ) as mock_post,
+        patch(
+            "tooluniverse.iedb_prediction_tool.requests.get",
+            return_value=_resp(_done(_MHCII_COLUMNS, [])),
+        ),
+    ):
         result = tool.run({"sequence": "PKYVKQNTLKLAT", "allele": "HLA-DRB1*01:01"})
 
     assert result["status"] == "success"
-    assert mock_post.call_args.kwargs["data"]["length"] == "13"
+    assert _submitted_length_range(mock_post) == [13, 13]
 
 
-def test_long_sequence_omits_length_param_by_default():
+def test_long_sequence_uses_the_default_window_of_15():
     tool = _tool("predict_mhcii")
-    with patch(
-        "tooluniverse.iedb_prediction_tool.requests.post", return_value=_resp(_TSV)
-    ) as mock_post:
+    with (
+        patch(
+            "tooluniverse.iedb_prediction_tool.requests.post",
+            return_value=_resp(_SUBMIT_OK),
+        ) as mock_post,
+        patch(
+            "tooluniverse.iedb_prediction_tool.requests.get",
+            return_value=_resp(_done(_MHCII_COLUMNS, [])),
+        ),
+    ):
         tool.run({"sequence": "A" * 20, "allele": "HLA-DRB1*01:01"})
 
-    assert "length" not in mock_post.call_args.kwargs["data"]
+    assert _submitted_length_range(mock_post) == [15, 15]
 
 
 def test_explicit_length_argument_takes_precedence():
     tool = _tool("predict_mhcii")
-    with patch(
-        "tooluniverse.iedb_prediction_tool.requests.post", return_value=_resp(_TSV)
-    ) as mock_post:
-        tool.run(
-            {"sequence": "A" * 20, "allele": "HLA-DRB1*01:01", "length": 11}
-        )
+    with (
+        patch(
+            "tooluniverse.iedb_prediction_tool.requests.post",
+            return_value=_resp(_SUBMIT_OK),
+        ) as mock_post,
+        patch(
+            "tooluniverse.iedb_prediction_tool.requests.get",
+            return_value=_resp(_done(_MHCII_COLUMNS, [])),
+        ),
+    ):
+        tool.run({"sequence": "A" * 20, "allele": "HLA-DRB1*01:01", "length": 11})
 
-    assert mock_post.call_args.kwargs["data"]["length"] == "11"
+    assert _submitted_length_range(mock_post) == [11, 11]

--- a/tests/unit/test_iedb_prediction_fails_fast_not_hangs.py
+++ b/tests/unit/test_iedb_prediction_fails_fast_not_hangs.py
@@ -1,0 +1,358 @@
+"""Regression guard for Fix-R29A-1: the IEDB T-cell predictors must not hang.
+
+``IEDB_predict_mhci_binding``, ``IEDB_predict_mhcii_binding`` and
+``IEDB_predict_antigen_processing`` all POSTed to the legacy synchronous
+endpoint ``https://tools-cluster-interface.iedb.org/tools_api/{mhci,mhcii,
+processing}/``. That host still answers a GET with 405, but it never sends
+any response body for a POST -- confirmed live::
+
+    curl -X POST --max-time 90 \\
+      https://tools-cluster-interface.iedb.org/tools_api/mhci/ \\
+      -d "method=netmhcpan_el&sequence_text=GILGFVFTL&allele=HLA-A*02:01&length=9"
+    -> curl exit 28, http_code 000, time 90.00
+
+so every call, including each tool's own registered example, stalled for the
+full 120 s client timeout and then reported "IEDB prediction timed out".
+
+These three predictions now run on IEDB's next-generation tools API
+(``POST /api/v1/pipeline`` then poll ``GET /api/v1/results/{id}``). The
+``bcell/`` route on the legacy host does still respond and stays there.
+
+The guards below are all mocked -- no live calls.
+"""
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.iedb_prediction_tool import (
+    IEDB_NEXTGEN_BASE,
+    IEDBPredictionTool,
+)
+
+pytestmark = pytest.mark.unit
+
+RETIRED_HOST = "tools-cluster-interface.iedb.org"
+
+
+def _tool(endpoint_type, **overrides):
+    tool = IEDBPredictionTool(
+        {"name": "iedb_test", "fields": {"endpoint_type": endpoint_type}}
+    )
+    for key, value in overrides.items():
+        setattr(tool, key, value)
+    return tool
+
+
+def _json_response(payload, status_code=200):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = payload
+    resp.text = str(payload)
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+_SUBMIT_OK = {"result_id": "rid-123", "warnings": []}
+
+# Shape copied verbatim from a live GET /api/v1/results/{id} for
+# {"sequence": "GILGFVFTL", "allele": "HLA-A*02:01", "length": 9}.
+_MHCI_DONE = {
+    "id": "rid-123",
+    "status": "done",
+    "data": {
+        "errors": [],
+        "warnings": [],
+        "results": [
+            {
+                "type": "peptide_table",
+                "table_columns": [
+                    {"name": "sequence_number"},
+                    {"name": "peptide"},
+                    {"name": "allele"},
+                    {"name": "median_percentile"},
+                    {"name": "netmhcpan_el_score"},
+                    {"name": "netmhcpan_el_percentile"},
+                ],
+                "table_data": [
+                    [1, "GILGFVFTL", "HLA-A*02:01", 0.09, 0.789948, 0.09],
+                    [1, "AAAAAAAAA", "HLA-A*02:01", 42.0, 0.0011, 42.0],
+                ],
+            }
+        ],
+    },
+}
+
+
+class TestNoLegacyHost:
+    """The retired synchronous endpoint must not be contacted any more."""
+
+    @pytest.mark.parametrize(
+        "endpoint_type,arguments",
+        [
+            (
+                "predict_mhci",
+                {"sequence": "GILGFVFTL", "allele": "HLA-A*02:01", "length": 9},
+            ),
+            (
+                "predict_mhcii",
+                {"sequence": "PKYVKQNTLKLAT", "allele": "HLA-DRB1*01:01"},
+            ),
+            (
+                "predict_processing",
+                {"sequence": "SLYNTVATLYCVHQRIDVKQNTLKLATGGKS", "length": 9},
+            ),
+        ],
+    )
+    def test_tcell_predictions_use_nextgen_api(self, endpoint_type, arguments):
+        tool = _tool(endpoint_type, poll_interval=0)
+        post = MagicMock(return_value=_json_response(_SUBMIT_OK))
+        get = MagicMock(return_value=_json_response(_MHCI_DONE))
+
+        with (
+            patch("tooluniverse.iedb_prediction_tool.requests.post", post),
+            patch("tooluniverse.iedb_prediction_tool.requests.get", get),
+        ):
+            result = tool.run(arguments)
+
+        assert result["status"] == "success"
+        called = [c.args[0] for c in post.call_args_list] + [
+            c.args[0] for c in get.call_args_list
+        ]
+        assert called, "expected at least one upstream request"
+        assert all(RETIRED_HOST not in url for url in called), called
+        assert any(url.startswith(IEDB_NEXTGEN_BASE) for url in called), called
+
+
+class TestBoundedWait:
+    """An unresponsive upstream must fail quickly and say why."""
+
+    def test_submit_timeout_reports_the_request_timeout_not_a_120s_hang(self):
+        import requests as _requests
+
+        tool = _tool("predict_mhci")
+        with patch(
+            "tooluniverse.iedb_prediction_tool.requests.post",
+            side_effect=_requests.exceptions.Timeout(),
+        ):
+            started = time.monotonic()
+            result = tool.run({"sequence": "GILGFVFTL"})
+            elapsed = time.monotonic() - started
+
+        assert result["status"] == "error"
+        assert "120" not in result["error"]
+        assert str(tool.request_timeout) in result["error"]
+        assert elapsed < 5
+        # The per-request budget must stay far below the old 120 s stall.
+        assert max(tool.request_timeout) <= 30
+
+    def test_perpetually_pending_job_stops_at_max_wait(self):
+        """A job that never finishes is abandoned with an actionable message."""
+        tool = _tool("predict_mhci", poll_interval=0, max_wait=0.05)
+        pending = {"status": "pending", "data": {"errors": [], "results": []}}
+
+        with (
+            patch(
+                "tooluniverse.iedb_prediction_tool.requests.post",
+                return_value=_json_response(_SUBMIT_OK),
+            ),
+            patch(
+                "tooluniverse.iedb_prediction_tool.requests.get",
+                return_value=_json_response(pending),
+            ) as get,
+        ):
+            started = time.monotonic()
+            result = tool.run({"sequence": "GILGFVFTL"})
+            elapsed = time.monotonic() - started
+
+        assert result["status"] == "error"
+        assert "did not finish" in result["error"]
+        assert "rid-123" in result["error"]
+        assert elapsed < 5
+        assert get.call_count >= 1
+
+    def test_stage_failure_reported_even_while_status_stays_pending(self):
+        """Live behaviour: a crashed stage populates data.errors but can keep
+        reporting status 'pending' forever, so errors must end the poll."""
+        tool = _tool("predict_mhci", poll_interval=0, max_wait=60)
+        broken = {
+            "status": "pending",
+            "data": {"errors": ["Command 'tcell_mhci.py' returned non-zero"]},
+        }
+
+        with (
+            patch(
+                "tooluniverse.iedb_prediction_tool.requests.post",
+                return_value=_json_response(_SUBMIT_OK),
+            ),
+            patch(
+                "tooluniverse.iedb_prediction_tool.requests.get",
+                return_value=_json_response(broken),
+            ) as get,
+        ):
+            result = tool.run({"sequence": "GILGFVFTL"})
+
+        assert result["status"] == "error"
+        assert "non-zero" in result["error"]
+        assert get.call_count == 1, "must not keep polling a failed stage"
+
+
+class TestRequestContract:
+    """The submitted pipeline body matches the documented next-gen contract."""
+
+    def test_mhci_submits_a_single_binding_stage(self):
+        tool = _tool("predict_mhci", poll_interval=0)
+        post = MagicMock(return_value=_json_response(_SUBMIT_OK))
+
+        with (
+            patch("tooluniverse.iedb_prediction_tool.requests.post", post),
+            patch(
+                "tooluniverse.iedb_prediction_tool.requests.get",
+                return_value=_json_response(_MHCI_DONE),
+            ),
+        ):
+            tool.run({"sequence": "GILGFVFTL", "allele": "HLA-A*02:01", "length": 9})
+
+        assert post.call_args.args[0] == f"{IEDB_NEXTGEN_BASE}/pipeline"
+        stage = post.call_args.kwargs["json"]["stages"][0]
+        assert stage["tool_group"] == "mhci"
+        assert stage["input_sequence_text"].endswith("GILGFVFTL")
+        assert stage["input_sequence_text"].startswith(">")
+        params = stage["input_parameters"]
+        assert params["alleles"] == "HLA-A*02:01"
+        assert params["peptide_length_range"] == [9, 9]
+        assert params["predictors"] == [{"type": "binding", "method": "netmhcpan_el"}]
+
+    def test_mhcii_window_shrinks_to_a_short_sequence(self):
+        """The class II window defaults to 15 and cannot exceed the input;
+        the tool's own registered example is a 13-mer."""
+        tool = _tool("predict_mhcii", poll_interval=0)
+        post = MagicMock(return_value=_json_response(_SUBMIT_OK))
+
+        with (
+            patch("tooluniverse.iedb_prediction_tool.requests.post", post),
+            patch(
+                "tooluniverse.iedb_prediction_tool.requests.get",
+                return_value=_json_response(_MHCI_DONE),
+            ),
+        ):
+            tool.run({"sequence": "PKYVKQNTLKLAT", "allele": "HLA-DRB1*01:01"})
+
+        stage = post.call_args.kwargs["json"]["stages"][0]
+        assert stage["tool_group"] == "mhcii"
+        assert stage["input_parameters"]["peptide_length_range"] == [13, 13]
+
+    def test_processing_chains_netctlpan_onto_the_binding_predictor(self):
+        tool = _tool("predict_processing", poll_interval=0)
+        post = MagicMock(return_value=_json_response(_SUBMIT_OK))
+
+        with (
+            patch("tooluniverse.iedb_prediction_tool.requests.post", post),
+            patch(
+                "tooluniverse.iedb_prediction_tool.requests.get",
+                return_value=_json_response(_MHCI_DONE),
+            ),
+        ):
+            tool.run({"sequence": "SLYNTVATLYCVHQRIDVKQNTLKLATGGKS", "length": 9})
+
+        predictors = post.call_args.kwargs["json"]["stages"][0]["input_parameters"][
+            "predictors"
+        ]
+        assert {"type": "processing", "method": "netctlpan"} in predictors
+        assert any(p["type"] == "binding" for p in predictors)
+
+    def test_legacy_mouse_allele_spelling_is_translated(self):
+        """Live: the next-gen API rejects 'H-2-Kd' as an invalid allele but
+        accepts 'H2-Kd'. The registered example uses the legacy spelling."""
+        tool = _tool("predict_mhci", poll_interval=0)
+        post = MagicMock(return_value=_json_response(_SUBMIT_OK))
+
+        with (
+            patch("tooluniverse.iedb_prediction_tool.requests.post", post),
+            patch(
+                "tooluniverse.iedb_prediction_tool.requests.get",
+                return_value=_json_response(_MHCI_DONE),
+            ),
+        ):
+            result = tool.run(
+                {"sequence": "TYQRTRALV", "allele": "H-2-Kd", "length": 9}
+            )
+
+        stage = post.call_args.kwargs["json"]["stages"][0]
+        assert stage["input_parameters"]["alleles"] == "H2-Kd"
+        assert result["metadata"]["allele"] == "H2-Kd"
+
+
+class TestResponseParsing:
+    def test_peptide_table_becomes_rows_sorted_by_percentile_rank(self):
+        tool = _tool("predict_mhci", poll_interval=0)
+
+        with (
+            patch(
+                "tooluniverse.iedb_prediction_tool.requests.post",
+                return_value=_json_response(_SUBMIT_OK),
+            ),
+            patch(
+                "tooluniverse.iedb_prediction_tool.requests.get",
+                return_value=_json_response(_MHCI_DONE),
+            ),
+        ):
+            result = tool.run({"sequence": "GILGFVFTLAAAAAAAAA", "length": 9})
+
+        rows = result["data"]
+        assert [r["peptide"] for r in rows] == ["GILGFVFTL", "AAAAAAAAA"]
+        assert rows[0]["percentile_rank"] == 0.09
+        assert rows[0]["score"] == 0.789948
+        assert result["metadata"]["n_peptides"] == 2
+        assert result["metadata"]["result_id"] == "rid-123"
+
+    def test_invalid_allele_rejection_is_surfaced(self):
+        """A validation failure comes back HTTP 200 with `errors` and no
+        `result_id` -- confirmed live for an unknown allele name."""
+        tool = _tool("predict_mhci", poll_interval=0)
+        rejection = {"errors": ["The following are not valid alleles: HLA-NOPE*99:99"]}
+
+        with (
+            patch(
+                "tooluniverse.iedb_prediction_tool.requests.post",
+                return_value=_json_response(rejection),
+            ),
+            patch("tooluniverse.iedb_prediction_tool.requests.get") as get,
+        ):
+            result = tool.run({"sequence": "GILGFVFTL", "allele": "HLA-NOPE*99:99"})
+
+        assert result["status"] == "error"
+        assert "not valid alleles" in result["error"]
+        get.assert_not_called()
+
+    def test_unknown_method_is_rejected_before_any_request(self):
+        """An unsupported method name draws an opaque HTML 500 upstream, so
+        it is caught locally with the list of accepted methods instead."""
+        tool = _tool("predict_mhci")
+
+        with patch("tooluniverse.iedb_prediction_tool.requests.post") as post:
+            result = tool.run({"sequence": "GILGFVFTL", "method": "not_a_method"})
+
+        assert result["status"] == "error"
+        assert "not_a_method" in result["error"]
+        assert "netmhcpan_el" in result["error"]
+        post.assert_not_called()
+
+
+class TestBcellStillUsesWorkingLegacyRoute:
+    def test_bcell_keeps_the_legacy_tools_api(self):
+        """bcell/ on the legacy host does still answer (verified live), so it
+        is deliberately left unmigrated."""
+        tool = _tool("predict_bcell")
+        resp = MagicMock()
+        resp.text = "Position\tResidue\tScore\tAssignment\n1\tS\t0.5\tE\n"
+        resp.raise_for_status = MagicMock()
+
+        with patch(
+            "tooluniverse.iedb_prediction_tool.requests.post", return_value=resp
+        ) as post:
+            result = tool.run({"sequence": "SLYNTVATL"})
+
+        assert result["status"] == "success"
+        assert RETIRED_HOST in post.call_args.args[0]

--- a/tests/unit/test_iedb_prediction_tool.py
+++ b/tests/unit/test_iedb_prediction_tool.py
@@ -1,18 +1,20 @@
-"""Regression guard for two Fix-R23B bugs in IEDBPredictionTool.
+"""Regression guard for two Fix-R23B defects in IEDBPredictionTool.
 
-Fix-R23B-1 (percentile_rank): the mhcii/ endpoint's real TSV column is
-"rank", not "percentile_rank" (confirmed live) -- _predict_mhcii read the
-wrong key, so every result silently defaulted to percentile_rank=100.0
-regardless of true binding strength, hiding real strong binders from any
-caller filtering on the documented convention.
+Fix-R23B-1 (percentile_rank): every result silently reported
+percentile_rank=100.0 regardless of true binding strength, hiding real
+strong binders from any caller filtering on the documented convention.
 
-Fix-R23B-2 (invalid-allele silent success): IEDB's tools_api endpoints
-return HTTP 200 with a plain-text error message (not a TSV table) for
-invalid input like an unrecognized HLA allele name -- confirmed live for
-mhci/. Naively parsing that as TSV produced bogus single-column "rows"
-keyed on the error prose itself, with status:"success" and fabricated
-score/percentile_rank of 0.0/100.0. Fixed by detecting non-tabular
-responses before parsing and returning a clear error instead.
+Fix-R23B-2 (invalid-allele silent success): an unrecognized HLA allele name
+produced a bogus `status: "success"` payload with fabricated scores instead
+of an error.
+
+Both concerns still apply after Fix-R29A-1 moved the MHC-I and MHC-II
+predictions off the retired synchronous ``tools-cluster-interface.iedb.org``
+endpoint (which accepts a POST and then never answers) onto IEDB's
+next-generation async pipeline API, so the guards are expressed against that
+contract: a peptide table of ``table_columns``/``table_data``, and a
+validation rejection that returns HTTP 200 carrying ``errors`` and no
+``result_id`` (both shapes confirmed live).
 """
 
 from unittest.mock import MagicMock, patch
@@ -23,44 +25,115 @@ from tooluniverse.iedb_prediction_tool import IEDBPredictionTool
 
 pytestmark = pytest.mark.unit
 
-_MHCII_TSV = (
-    "allele\tseq_num\tstart\tend\tlength\tcore_peptide\tpeptide\tscore\trank\n"
-    "HLA-DRB1*01:01\t1\t194\t208\t15\tFELLHAPAT\tVLSFELLHAPATVCG\t0.8447\t0.67\n"
-    "HLA-DRB1*01:01\t1\t192\t206\t15\tFELLHAPAT\tVVVLSFELLHAPATV\t0.8119\t0.86\n"
-)
-
-_MHCI_INVALID_ALLELE_TEXT = (
-    "Invalid allele name HLA-A*99:99 found.\n\n"
-    "* Please go to the link below for more usage info:\n"
-    "http://tools.iedb.org/main/html/tools_api.html"
-)
-
-_MHCI_VALID_TSV = (
-    "allele\tseq_num\tstart\tend\tlength\tpeptide\tcore\ticore\tscore\tpercentile_rank\n"
-    "HLA-A*02:01\t1\t1\t9\t9\tKIADYNYKL\tKIADYNYKL\tKIADYNYKL\t0.865\t0.05\n"
-)
-
 
 def _tool(endpoint_type):
-    return IEDBPredictionTool(
+    tool = IEDBPredictionTool(
         {"name": "iedb_test", "fields": {"endpoint_type": endpoint_type}}
     )
+    tool.poll_interval = 0
+    return tool
 
 
-def _resp(text):
+def _resp(payload, status_code=200):
     r = MagicMock()
-    r.text = text
+    r.status_code = status_code
+    r.json.return_value = payload
+    r.text = str(payload)
     r.raise_for_status = MagicMock()
     return r
 
 
-class TestMhciiPercentileRank:
-    def test_reads_rank_column_not_hardcoded_100(self):
-        tool = _tool("predict_mhcii")
-        resp = _resp(_MHCII_TSV)
+def _done(columns, rows):
+    return {
+        "status": "done",
+        "data": {
+            "errors": [],
+            "warnings": [],
+            "results": [
+                {
+                    "type": "peptide_table",
+                    "table_columns": [{"name": c} for c in columns],
+                    "table_data": rows,
+                }
+            ],
+        },
+    }
 
-        with patch(
-            "tooluniverse.iedb_prediction_tool.requests.post", return_value=resp
+
+_SUBMIT_OK = {"result_id": "rid-1", "warnings": []}
+
+_MHCII_DONE = _done(
+    [
+        "allele",
+        "start",
+        "end",
+        "length",
+        "netmhciipan_el_core",
+        "peptide",
+        "netmhciipan_el_score",
+        "median_percentile",
+        "netmhciipan_el_percentile",
+    ],
+    [
+        [
+            "HLA-DRB1*01:01",
+            194,
+            208,
+            15,
+            "FELLHAPAT",
+            "VLSFELLHAPATVCG",
+            0.8447,
+            0.67,
+            0.67,
+        ],
+        [
+            "HLA-DRB1*01:01",
+            192,
+            206,
+            15,
+            "FELLHAPAT",
+            "VVVLSFELLHAPATV",
+            0.8119,
+            0.86,
+            0.86,
+        ],
+    ],
+)
+
+_MHCI_DONE = _done(
+    [
+        "allele",
+        "start",
+        "end",
+        "length",
+        "peptide",
+        "netmhcpan_el_score",
+        "median_percentile",
+        "netmhcpan_el_percentile",
+    ],
+    [["HLA-A*02:01", 1, 9, 9, "KIADYNYKL", 0.865, 0.05, 0.05]],
+)
+
+# Live shape for an unknown allele: HTTP 200, `errors`, no `result_id`.
+_INVALID_ALLELE_REJECTION = {
+    "errors": ["The following are not valid alleles: HLA-A*99:99"],
+    "warnings": [],
+}
+
+
+class TestMhciiPercentileRank:
+    def test_reads_real_percentile_not_hardcoded_100(self):
+        tool = _tool("predict_mhcii")
+
+        with (
+            patch(
+                "tooluniverse.iedb_prediction_tool.requests.post",
+                return_value=_resp(_SUBMIT_OK),
+            ),
+            patch(
+                "tooluniverse.iedb_prediction_tool.requests.get",
+                return_value=_resp(_MHCII_DONE),
+            ),
         ):
             result = tool.run({"sequence": "X" * 20, "allele": "HLA-DRB1*01:01"})
 
@@ -71,25 +144,31 @@ class TestMhciiPercentileRank:
 
 
 class TestInvalidAlleleErrorDetection:
-    def test_mhci_plain_text_error_returns_status_error(self):
+    def test_mhci_invalid_allele_returns_status_error(self):
         tool = _tool("predict_mhci")
-        resp = _resp(_MHCI_INVALID_ALLELE_TEXT)
 
         with patch(
-            "tooluniverse.iedb_prediction_tool.requests.post", return_value=resp
+            "tooluniverse.iedb_prediction_tool.requests.post",
+            return_value=_resp(_INVALID_ALLELE_REJECTION),
         ):
             result = tool.run({"sequence": "KIADYNYKLPDDFTGC", "allele": "HLA-A*99:99"})
 
         assert result["status"] == "error"
-        assert "Invalid allele name HLA-A*99:99" in result["error"]
+        assert "HLA-A*99:99" in result["error"]
         assert "data" not in result
 
-    def test_mhci_valid_tsv_still_succeeds(self):
+    def test_mhci_valid_response_still_succeeds(self):
         tool = _tool("predict_mhci")
-        resp = _resp(_MHCI_VALID_TSV)
 
-        with patch(
-            "tooluniverse.iedb_prediction_tool.requests.post", return_value=resp
+        with (
+            patch(
+                "tooluniverse.iedb_prediction_tool.requests.post",
+                return_value=_resp(_SUBMIT_OK),
+            ),
+            patch(
+                "tooluniverse.iedb_prediction_tool.requests.get",
+                return_value=_resp(_MHCI_DONE),
+            ),
         ):
             result = tool.run({"sequence": "KIADYNYKLPDDFTGC", "allele": "HLA-A*02:01"})
 

--- a/tests/unit/test_immunology_depth.py
+++ b/tests/unit/test_immunology_depth.py
@@ -16,8 +16,10 @@ capability gaps. All four reuse an existing registered tool class (no new
   ``get_germline_fasta``) — IMGT/GENE-DB germline IG/TR FASTA, following the
   GENElect redirect chain and extracting the FASTA <pre> block.
 * ``IEDB_predict_antigen_processing`` (IEDBPredictionTool, endpoint
-  ``predict_processing``) — combined proteasome + TAP + MHC-I processing
-  scores from the IEDB processing tool TSV.
+  ``predict_processing``) — combined cleavage + TAP + MHC-I processing scores
+  from IEDB's next-generation tools pipeline (Fix-R29A-1 moved this off the
+  retired synchronous ``tools_api/processing/`` endpoint, which accepts a
+  POST and then never answers, stalling every call for the full timeout).
 
 All network calls are mocked; these tests never touch the live APIs.
 """
@@ -276,41 +278,109 @@ class TestIMGTGermlineFasta(unittest.TestCase):
 # IEDB_predict_antigen_processing
 # ---------------------------------------------------------------------------
 
-_IEDB_PROCESSING_TSV = (
-    "allele\tseq_num\tstart\tend\tlength\tpeptide\tproteasome_score\ttap_score\t"
-    "mhc_score\tprocessing_score\ttotal_score\tic50_score\n"
-    "HLA-A*02:01\t1\t1\t9\t9\tSLYNTVATL\t1.5479\t0.5087\t-2.2849\t2.0566\t"
-    "-0.2283\t192.7\n"
-    "HLA-A*02:01\t1\t2\t10\t9\tLYNTVATLY\t1.2896\t1.3692\t-4.4622\t2.6588\t"
-    "-1.8034\t28984.2\n"
-)
+_IEDB_SUBMIT_OK = {"result_id": "rid-proc", "warnings": []}
+
+# Column set confirmed live for a netmhcpan binding predictor chained with
+# the netctlpan processing predictor.
+_IEDB_PROCESSING_DONE = {
+    "status": "done",
+    "data": {
+        "errors": [],
+        "warnings": [],
+        "results": [
+            {
+                "type": "peptide_table",
+                "table_columns": [
+                    {"name": n}
+                    for n in (
+                        "sequence_number",
+                        "peptide",
+                        "start",
+                        "end",
+                        "length",
+                        "allele",
+                        "netmhcpan_ba_ic50",
+                        "mhc_prediction",
+                        "tap_prediction_score",
+                        "cleavage_prediction_score",
+                        "combined_prediction_score",
+                    )
+                ],
+                "table_data": [
+                    [
+                        1,
+                        "LYNTVATLY",
+                        2,
+                        10,
+                        9,
+                        "HLA-A*02:01",
+                        30582.45,
+                        0.035,
+                        3.153,
+                        0.97688,
+                        0.33362,
+                    ],
+                    [
+                        1,
+                        "SLYNTVATL",
+                        1,
+                        9,
+                        9,
+                        "HLA-A*02:01",
+                        46.5,
+                        0.438,
+                        1.394,
+                        0.97756,
+                        0.6928,
+                    ],
+                ],
+            }
+        ],
+    },
+}
 
 
 def _iedb_tool():
     from tooluniverse.iedb_prediction_tool import IEDBPredictionTool
 
-    return IEDBPredictionTool(
+    tool = IEDBPredictionTool(
         {
             "name": "IEDB_predict_antigen_processing",
             "fields": {"endpoint_type": "predict_processing"},
         }
     )
+    tool.poll_interval = 0
+    return tool
+
+
+def _iedb_resp(payload):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = payload
+    resp.text = str(payload)
+    resp.raise_for_status.return_value = None
+    return resp
 
 
 class TestIEDBAntigenProcessing(unittest.TestCase):
     def test_parses_processing_scores_and_sorts(self):
-        """Processing scores are typed and rows sorted by total_score."""
+        """Rows carry the cleavage/TAP/MHC components and sort by the
+        combined score, highest first."""
         tool = _iedb_tool()
-        resp = MagicMock()
-        resp.text = _IEDB_PROCESSING_TSV
-        resp.raise_for_status.return_value = None
 
-        with patch(
-            "tooluniverse.iedb_prediction_tool.requests.post", return_value=resp
+        with (
+            patch(
+                "tooluniverse.iedb_prediction_tool.requests.post",
+                return_value=_iedb_resp(_IEDB_SUBMIT_OK),
+            ),
+            patch(
+                "tooluniverse.iedb_prediction_tool.requests.get",
+                return_value=_iedb_resp(_IEDB_PROCESSING_DONE),
+            ),
         ):
             result = tool.run(
                 {
-                    "sequence": "SLYNTVATLYCVHQRIDV",
+                    "sequence": "SLYNTVATLYCVHQRIDVKQNTLKLATGGKS",
                     "allele": "HLA-A*02:01",
                     "length": 9,
                 }
@@ -319,17 +389,21 @@ class TestIEDBAntigenProcessing(unittest.TestCase):
         self.assertEqual(result["status"], "success")
         rows = result["data"]
         self.assertEqual(len(rows), 2)
-        # Sorted by total_score descending: SLYNTVATL (-0.2283) before LYNTVATLY
+        # Sorted by combined_prediction_score descending, so the row that
+        # arrived second comes first.
         first = rows[0]
         self.assertEqual(first["peptide"], "SLYNTVATL")
-        self.assertEqual(first["proteasome_score"], 1.5479)
-        self.assertEqual(first["tap_score"], 0.5087)
-        self.assertEqual(first["mhc_score"], -2.2849)
-        self.assertEqual(first["processing_score"], 2.0566)
-        self.assertEqual(first["total_score"], -0.2283)
-        self.assertEqual(first["ic50_score"], 192.7)
-        self.assertGreater(first["total_score"], rows[1]["total_score"])
+        self.assertEqual(first["cleavage_prediction_score"], 0.97756)
+        self.assertEqual(first["tap_prediction_score"], 1.394)
+        self.assertEqual(first["mhc_prediction"], 0.438)
+        self.assertEqual(first["combined_prediction_score"], 0.6928)
+        self.assertEqual(first["netmhcpan_ba_ic50"], 46.5)
+        self.assertGreater(
+            first["combined_prediction_score"],
+            rows[1]["combined_prediction_score"],
+        )
         self.assertEqual(result["metadata"]["allele"], "HLA-A*02:01")
+        self.assertEqual(result["metadata"]["processing_method"], "netctlpan")
 
     def test_missing_sequence_errors(self):
         """Missing sequence returns an error envelope."""
@@ -349,7 +423,7 @@ class TestIEDBAntigenProcessing(unittest.TestCase):
         ):
             result = tool.run({"sequence": "SLYNTVATL"})
         self.assertEqual(result["status"], "error")
-        self.assertIn("time", result["error"].lower())
+        self.assertIn("timeout", result["error"].lower())
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_nextstrain_dataset_total_not_understated.py
+++ b/tests/unit/test_nextstrain_dataset_total_not_understated.py
@@ -1,0 +1,164 @@
+"""Regression tests for Nextstrain_list_datasets truncation reporting.
+
+The listing endpoint caps each pathogen's ``datasets`` array. Previously the
+grand total in ``metadata.total_datasets`` was computed from those capped
+arrays, so the response confidently reported a catalogue far smaller than the
+real one (113 vs. 295 against the live API) with no way to page past the cap.
+
+These tests pin the corrected behaviour: the reported total always equals the
+sum of the per-pathogen ``dataset_count`` values, truncation is disclosed at
+the top level, and the cap is caller-controllable.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from tooluniverse.nextstrain_tool import NextstrainTool
+
+
+LIST_CONFIG = {
+    "name": "Nextstrain_list_datasets",
+    "type": "NextstrainTool",
+    "fields": {"endpoint_type": "list_datasets"},
+}
+
+GET_CONFIG = {
+    "name": "Nextstrain_get_dataset",
+    "type": "NextstrainTool",
+    "fields": {"endpoint_type": "get_dataset"},
+}
+
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+def _available_payload():
+    """25 avian-flu datasets, 12 ncov, 3 zika -> 40 across 3 pathogens."""
+    requests_list = []
+    requests_list += [f"avian-flu/build-{i:02d}" for i in range(25)]
+    requests_list += [f"ncov/build-{i:02d}" for i in range(12)]
+    requests_list += [f"zika/build-{i:02d}" for i in range(3)]
+    return {"datasets": [{"request": r} for r in requests_list]}
+
+
+@pytest.fixture
+def list_tool():
+    return NextstrainTool(LIST_CONFIG)
+
+
+def _run_list(tool, arguments):
+    with patch(
+        "tooluniverse.nextstrain_tool.requests.get",
+        return_value=_FakeResponse(_available_payload()),
+    ):
+        return tool.run(arguments)
+
+
+def test_total_datasets_matches_sum_of_per_pathogen_counts(list_tool):
+    result = _run_list(list_tool, {})
+
+    assert result["status"] == "success"
+    expected_total = sum(entry["dataset_count"] for entry in result["data"])
+    assert expected_total == 40
+    assert result["metadata"]["total_datasets"] == expected_total
+
+    # The total must NOT be the sum of the truncated listings.
+    listed = sum(len(entry["datasets"]) for entry in result["data"])
+    assert listed == 10 + 10 + 3  # capped at the 10-per-pathogen default
+    assert listed < expected_total
+    assert result["metadata"]["total_datasets"] != listed
+
+
+def test_truncation_is_disclosed_at_top_level(list_tool):
+    result = _run_list(list_tool, {})
+
+    assert result["truncated"] is True
+    note = result["truncation_note"]
+    assert "295" not in note  # note is derived from the payload, not hardcoded
+    assert "40" in note  # true total is named
+    assert "datasets_per_pathogen" in note  # tells the caller how to get the rest
+    assert result["metadata"]["truncated"] is True
+    assert result["metadata"]["listed_datasets"] == 23
+
+
+def test_truncated_pathogen_entries_are_flagged(list_tool):
+    result = _run_list(list_tool, {})
+    by_pathogen = {entry["pathogen"]: entry for entry in result["data"]}
+
+    assert by_pathogen["avian-flu"]["datasets_truncated"] is True
+    assert by_pathogen["avian-flu"]["datasets_listed"] == 10
+    assert by_pathogen["avian-flu"]["dataset_count"] == 25
+
+    # A pathogen that fits under the cap is not flagged.
+    assert "datasets_truncated" not in by_pathogen["zika"]
+    assert by_pathogen["zika"]["datasets_listed"] == 3
+
+
+def test_datasets_per_pathogen_zero_returns_everything(list_tool):
+    result = _run_list(list_tool, {"datasets_per_pathogen": 0})
+
+    listed = sum(len(entry["datasets"]) for entry in result["data"])
+    assert listed == 40
+    assert result["metadata"]["total_datasets"] == 40
+    assert result["metadata"]["listed_datasets"] == 40
+    assert result["truncated"] is False
+    assert "truncation_note" not in result
+    assert all("datasets_truncated" not in e for e in result["data"])
+
+
+def test_datasets_per_pathogen_raises_the_cap(list_tool):
+    result = _run_list(list_tool, {"datasets_per_pathogen": 12})
+
+    by_pathogen = {entry["pathogen"]: entry for entry in result["data"]}
+    assert by_pathogen["avian-flu"]["datasets_listed"] == 12
+    assert by_pathogen["ncov"]["datasets_listed"] == 12
+    assert "datasets_truncated" not in by_pathogen["ncov"]
+    # avian-flu (25) is still cut, so truncation stays disclosed.
+    assert result["truncated"] is True
+    assert result["metadata"]["total_datasets"] == 40
+
+
+def test_pathogen_filter_totals_reflect_only_the_filtered_pathogen(list_tool):
+    result = _run_list(list_tool, {"pathogen": "ncov", "datasets_per_pathogen": 0})
+
+    assert result["metadata"]["total_pathogens"] == 1
+    assert result["metadata"]["total_datasets"] == 12
+    assert result["truncated"] is False
+
+
+def test_negative_datasets_per_pathogen_is_rejected(list_tool):
+    result = _run_list(list_tool, {"datasets_per_pathogen": -5})
+    assert result["status"] == "error"
+    assert "datasets_per_pathogen" in result["error"]
+
+
+def test_get_dataset_returns_all_colorings():
+    payload = {
+        "meta": {
+            "title": "Test build",
+            "colorings": [{"key": f"color_{i}"} for i in range(20)],
+        },
+        "tree": {"children": [{"name": "a"}, {"name": "b"}]},
+    }
+    tool = NextstrainTool(GET_CONFIG)
+    with patch(
+        "tooluniverse.nextstrain_tool.requests.get",
+        return_value=_FakeResponse(payload),
+    ):
+        result = tool.run({"dataset": "zika"})
+
+    assert result["status"] == "success"
+    data = result["data"]
+    # Previously capped at 15, silently dropping the remaining keys.
+    assert len(data["available_colorings"]) == 20
+    assert data["available_colorings_count"] == 20
+    assert data["num_sequences"] == 2

--- a/tests/unit/test_pdc_search_matches_disease_type.py
+++ b/tests/unit/test_pdc_search_matches_disease_type.py
@@ -1,0 +1,342 @@
+"""Regression tests for PDC_search_studies field-scoped matching.
+
+PDC_search_studies used to call ``studySearch(name:)``, which only compares the
+query against the study title. Searching PDC's own curated disease name
+("Lung Adenocarcinoma") returned zero studies even though PDC annotates
+PDC000153 with exactly that ``disease_type`` - the documented "search by
+disease name" capability only appeared to work when a study title happened to
+contain the word.
+
+The search now pulls PDC's study catalog (``getPaginatedUIStudy``) and matches
+the query against the curated structured fields as well as the title, and
+reports which field produced each hit.
+
+Fully mocked - no network.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+import tooluniverse.pdc_tool as pdc_mod
+from tooluniverse.pdc_tool import PDCTool
+
+
+# Three studies modelled on real PDC records:
+#  - PDC000153 is annotated Lung Adenocarcinoma AND titled "... LUAD ..."
+#  - PDC000231 is annotated Lung Adenocarcinoma but has no "LUAD" in its title
+#  - PDC000154 is titled "... LUAD ..." but curated as disease_type "Other"
+#  - PDC000315 belongs to the CPTAC program but no field spells out "CPTAC"
+CATALOG = [
+    {
+        "study_id": "uuid-153",
+        "pdc_study_id": "PDC000153",
+        "submitter_id_name": "CPTAC LUAD Discovery Study - Proteome",
+        "disease_type": "Lung Adenocarcinoma;Other",
+        "primary_site": "Bronchus and lung;Not Reported",
+        "analytical_fraction": "Proteome",
+        "experiment_type": "TMT10",
+        "program_name": "Clinical Proteomic Tumor Analysis Consortium",
+        "project_name": "CPTAC3 Discovery and Confirmatory",
+    },
+    {
+        "study_id": "uuid-231",
+        "pdc_study_id": "PDC000231",
+        "submitter_id_name": "Georgetown Lung Cancer Proteomics Study",
+        "disease_type": "Lung Adenocarcinoma;Other",
+        "primary_site": "Bronchus and lung;Lung",
+        "analytical_fraction": "Proteome",
+        "experiment_type": "iTRAQ8",
+        "program_name": "Georgetown Proteomics Research Program",
+        "project_name": "Georgetown Lung Cancer Proteomics Study",
+    },
+    {
+        "study_id": "uuid-154",
+        "pdc_study_id": "PDC000154",
+        "submitter_id_name": "CPTAC LUAD Discovery Study - CompRef Proteome",
+        "disease_type": "Other",
+        "primary_site": "Not Reported",
+        "analytical_fraction": "Proteome",
+        "experiment_type": "TMT10",
+        "program_name": "Clinical Proteomic Tumor Analysis Consortium",
+        "project_name": "CPTAC3 Discovery and Confirmatory",
+    },
+    {
+        "study_id": "uuid-315",
+        "pdc_study_id": "PDC000315",
+        "submitter_id_name": "AML Gilteritinib Resistance - Proteome",
+        "disease_type": "Other",
+        "primary_site": "Not Reported",
+        "analytical_fraction": "Proteome",
+        "experiment_type": "TMT11",
+        "program_name": "Clinical Proteomic Tumor Analysis Consortium",
+        "project_name": "Proteogenomic Translational Research Centers (PTRC)",
+    },
+]
+
+# Which studies PDC's controlled program vocabulary returns for "CPTAC".
+PROGRAM_VOCABULARY = {"CPTAC": ["PDC000153", "PDC000154", "PDC000315"]}
+
+
+def _tool():
+    return PDCTool(
+        {
+            "name": "PDC_search_studies",
+            "type": "PDCTool",
+            "parameter": {"required": ["query"]},
+        }
+    )
+
+
+def _fake_post_factory(calls=None):
+    """Fake requests.post that serves the study catalog and program filter.
+
+    Distinguishes the two GraphQL documents the search issues: an unfiltered
+    catalog page and a ``program_name``-filtered lookup.
+    """
+
+    def _fake_post(url, json=None, headers=None, timeout=None):
+        document = (json or {}).get("query", "")
+        if calls is not None:
+            calls.append(document)
+
+        if "program_name:" in document:
+            matched = []
+            for term, ids in PROGRAM_VOCABULARY.items():
+                if '"%s"' % term in document:
+                    matched = ids
+                    break
+            studies = [{"pdc_study_id": i} for i in matched]
+        else:
+            studies = CATALOG
+
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {
+            "data": {
+                "getPaginatedUIStudy": {
+                    "total": len(CATALOG),
+                    "uiStudies": studies,
+                }
+            }
+        }
+        return resp
+
+    return _fake_post
+
+
+def _search(monkeypatch, query, calls=None):
+    monkeypatch.setattr(pdc_mod.requests, "post", _fake_post_factory(calls))
+    return _tool().run({"operation": "search_studies", "query": query})
+
+
+def test_search_matches_curated_disease_type(monkeypatch):
+    """A curated PDC disease name finds studies whose title never mentions it.
+
+    This is the regression: 'Lung Adenocarcinoma' previously returned zero
+    results because only the study title was searched.
+    """
+    out = _search(monkeypatch, "Lung Adenocarcinoma")
+
+    assert out["status"] == "success"
+    data = out["data"]
+    found = {s["pdc_study_id"] for s in data["studies"]}
+    assert found == {"PDC000153", "PDC000231"}
+    assert data["num_results"] == 2
+    # PDC000231's title says "Lung Cancer", not "Lung Adenocarcinoma" - it can
+    # only be found via the structured field.
+    assert data["num_results_by_field"]["disease_type"] == 2
+    assert data["num_results_by_field"]["submitter_id_name"] == 0
+    for study in data["studies"]:
+        assert study["matched_fields"] == ["disease_type"]
+        assert study["matched_curated_metadata"] is True
+        assert study["disease_type"] == "Lung Adenocarcinoma;Other"
+
+
+def test_search_still_matches_study_title(monkeypatch):
+    """Title matching is preserved, and reported as a title-only match."""
+    out = _search(monkeypatch, "LUAD")
+
+    data = out["data"]
+    assert {s["pdc_study_id"] for s in data["studies"]} == {
+        "PDC000153",
+        "PDC000154",
+    }
+    assert data["num_results_by_field"]["submitter_id_name"] == 2
+
+    by_id = {s["pdc_study_id"]: s for s in data["studies"]}
+    # PDC000154 is curated as disease_type "Other"; a caller must be able to
+    # tell this apart from a curated disease-type hit.
+    assert by_id["PDC000154"]["matched_fields"] == ["submitter_id_name"]
+    assert by_id["PDC000154"]["matched_curated_metadata"] is False
+
+
+def test_search_matches_case_insensitively(monkeypatch):
+    """Matching does not depend on the caller's capitalisation."""
+    lower = _search(monkeypatch, "lung adenocarcinoma")["data"]
+    upper = _search(monkeypatch, "LUNG ADENOCARCINOMA")["data"]
+    assert lower["num_results"] == upper["num_results"] == 2
+
+
+def test_search_matches_analytical_fraction(monkeypatch):
+    """The documented analytical-fraction search hits the structured field."""
+    data = _search(monkeypatch, "Proteome")["data"]
+    assert data["num_results"] == len(CATALOG)
+    assert data["num_results_by_field"]["analytical_fraction"] == len(CATALOG)
+
+
+def test_search_resolves_program_acronym(monkeypatch):
+    """Program acronyms resolve via PDC's controlled program vocabulary.
+
+    PDC000315's program is spelled "Clinical Proteomic Tumor Analysis
+    Consortium" and none of its fields contain the string "CPTAC", so text
+    matching alone would drop it from a CPTAC search.
+    """
+    calls = []
+    data = _search(monkeypatch, "CPTAC", calls=calls)["data"]
+
+    assert "PDC000315" in {s["pdc_study_id"] for s in data["studies"]}
+    by_id = {s["pdc_study_id"]: s for s in data["studies"]}
+    assert by_id["PDC000315"]["matched_fields"] == ["program_name"]
+    assert by_id["PDC000315"]["matched_curated_metadata"] is True
+
+    # The program filter must be its own request: PDC returns results for the
+    # wrong filter when several filtered selections share one document.
+    filtered = [c for c in calls if "program_name:" in c]
+    assert len(filtered) == 1
+
+
+def test_empty_result_explains_which_fields_were_searched(monkeypatch):
+    """A genuine miss is an honest empty success, not a crash or a bare zero."""
+    out = _search(monkeypatch, "Amyotrophic Lateral Sclerosis")
+
+    assert out["status"] == "success"
+    data = out["data"]
+    assert data["studies"] == []
+    assert data["num_results"] == 0
+    assert data["num_studies_searched"] == len(CATALOG)
+    # The caller can see exactly what was compared.
+    for field in (
+        "disease_type",
+        "primary_site",
+        "analytical_fraction",
+        "experiment_type",
+        "program_name",
+        "project_name",
+        "submitter_id_name",
+    ):
+        assert field in data["fields_searched"]
+    assert "disease_type" in data["note"]
+    assert "Amyotrophic Lateral Sclerosis" in data["note"]
+
+
+def test_fields_searched_present_on_non_empty_results(monkeypatch):
+    """fields_searched is always reported, not only on empty results."""
+    data = _search(monkeypatch, "LUAD")["data"]
+    assert data["fields_searched"][0] == "disease_type"
+    assert "note" not in data
+
+
+def test_missing_query_is_an_error():
+    """A blank query is a caller error, distinct from an empty result."""
+    out = _tool().run({"operation": "search_studies", "query": "   "})
+    assert out["status"] == "error"
+    assert "query" in out["error"]
+
+
+def test_graphql_error_surfaces_as_error(monkeypatch):
+    """Upstream failures are errors, never a silently empty study list."""
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {"errors": [{"message": "boom"}]}
+    monkeypatch.setattr(pdc_mod.requests, "post", lambda *a, **k: resp)
+
+    out = _tool().run({"operation": "search_studies", "query": "Lung"})
+    assert out["status"] == "error"
+    assert "boom" in out["error"]
+
+
+def test_program_lookup_failure_degrades_with_warning(monkeypatch):
+    """If only the program vocabulary lookup fails, say so instead of lying."""
+
+    def _post(url, json=None, headers=None, timeout=None):
+        document = (json or {}).get("query", "")
+        resp = MagicMock()
+        resp.status_code = 200
+        if "program_name:" in document:
+            resp.json.return_value = {"errors": [{"message": "vocab down"}]}
+        else:
+            resp.json.return_value = {
+                "data": {
+                    "getPaginatedUIStudy": {
+                        "total": len(CATALOG),
+                        "uiStudies": CATALOG,
+                    }
+                }
+            }
+        return resp
+
+    monkeypatch.setattr(pdc_mod.requests, "post", _post)
+    out = _tool().run({"operation": "search_studies", "query": "CPTAC"})
+
+    assert out["status"] == "success"
+    data = out["data"]
+    # Text matching still finds the studies that spell out CPTAC ...
+    assert {s["pdc_study_id"] for s in data["studies"]} == {
+        "PDC000153",
+        "PDC000154",
+    }
+    # ... and the response admits the program lookup was skipped.
+    assert data["warnings"]
+    assert "vocab down" in data["warnings"][0]
+
+
+def test_catalog_is_paginated(monkeypatch):
+    """More studies than one page still get searched."""
+    page_size = pdc_mod.STUDY_CATALOG_PAGE_SIZE
+    big = []
+    for i in range(page_size + 3):
+        entry = dict(CATALOG[0])
+        entry["pdc_study_id"] = "PDCX%05d" % i
+        entry["disease_type"] = "Lung Adenocarcinoma"
+        big.append(entry)
+
+    def _post(url, json=None, headers=None, timeout=None):
+        document = (json or {}).get("query", "")
+        resp = MagicMock()
+        resp.status_code = 200
+        if "program_name:" in document:
+            resp.json.return_value = {
+                "data": {"getPaginatedUIStudy": {"uiStudies": []}}
+            }
+        else:
+            offset = 0 if "offset: 0" in document else page_size
+            resp.json.return_value = {
+                "data": {
+                    "getPaginatedUIStudy": {
+                        "total": len(big),
+                        "uiStudies": big[offset : offset + page_size],
+                    }
+                }
+            }
+        return resp
+
+    monkeypatch.setattr(pdc_mod.requests, "post", _post)
+    out = _tool().run(
+        {"operation": "search_studies", "query": "Lung Adenocarcinoma"}
+    )
+    assert out["data"]["num_studies_searched"] == page_size + 3
+    assert out["data"]["num_results"] == page_size + 3
+
+
+def test_query_with_quotes_does_not_break_the_graphql_document(monkeypatch):
+    """A quote in the query is escaped, not injected into the GraphQL text."""
+    calls = []
+    out = _search(monkeypatch, 'Lung" Adenocarcinoma', calls=calls)
+
+    assert out["status"] == "success"
+    assert out["data"]["num_results"] == 0
+    filtered = [c for c in calls if "program_name:" in c]
+    assert filtered and '\\"' in filtered[0]

--- a/tests/unit/test_tcia_unknown_collection_not_silent_success.py
+++ b/tests/unit/test_tcia_unknown_collection_not_silent_success.py
@@ -1,0 +1,258 @@
+"""
+Regression tests: TCIA must not report an empty archive response as a bare success.
+
+The NBIA v1 API answers every zero-result query with HTTP 200 and a completely
+empty body (verified live against services.cancerimagingarchive.net):
+
+    getModalityValues?Collection=NSCLC-Radiogenomics     -> 200, body ''
+    getModalityValues?Collection=NSCLC%20Radiogenomics   -> 200, [{"Modality":"CT"},...]
+    getSeries?Collection=NSCLC Radiogenomics&Modality=MR -> 200, body ''
+
+Before the fix, BaseRESTTool decoded that empty body as plain text and returned
+``{"status": "success", "data": ""}`` -- an empty *string* with no ``count``,
+identical whether the collection was misspelled ('NSCLC-Radiogenomics') or the
+collection was real and the filter simply matched nothing.
+
+These tests pin the three properties that separate those cases:
+  1. an unknown collection is an error naming the closest real collections,
+  2. a valid collection with no matches is an honest empty *list* with count 0,
+  3. ``data`` is never the empty string.
+
+All HTTP access is patched; no live network.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+DATA_DIR = Path(__file__).parent.parent.parent / "src" / "tooluniverse" / "data"
+
+# Trimmed stand-in for the 155 names getCollectionValues publishes. Note the
+# real archive spells this collection with a space while its neighbours are
+# hyphenated -- that inconsistency is what makes the typo so easy to make.
+COLLECTIONS = [
+    {"Collection": "LIDC-IDRI"},
+    {"Collection": "NSCLC Radiogenomics"},
+    {"Collection": "NSCLC-Radiomics"},
+    {"Collection": "NSCLC-Radiomics-Genomics"},
+    {"Collection": "TCGA-GBM"},
+]
+
+
+def _load_config(filename, tool_name):
+    with open(DATA_DIR / filename) as f:
+        tools = json.load(f)
+    by_name = {t["name"]: t for t in tools}
+    assert tool_name in by_name, f"{tool_name} missing from {filename}"
+    return by_name[tool_name]
+
+
+def _response(text="", status_code=200, url="https://tcia.example/endpoint"):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.ok = 200 <= status_code < 300
+    resp.headers = {} if not text else {"content-type": "application/json"}
+    resp.text = text
+    resp.url = url
+    if text:
+        resp.json.return_value = json.loads(text)
+    else:
+        resp.json.side_effect = ValueError("No JSON object could be decoded")
+    return resp
+
+
+def _tool(tool_name):
+    from tooluniverse import tcia_tool
+
+    tcia_tool._reset_collection_cache()
+    return tcia_tool.TCIATool(_load_config("tcia_tools.json", tool_name))
+
+
+def _run(tool, arguments, main_response, collections=COLLECTIONS):
+    """Run *tool*, stubbing the main request and the collection-list lookup."""
+    with (
+        patch(
+            "tooluniverse.base_rest_tool.request_with_retry",
+            return_value=main_response,
+        ),
+        patch(
+            "tooluniverse.tcia_tool.request_with_retry",
+            return_value=_response(json.dumps(collections)) if collections else None,
+        ) as collection_fetch,
+    ):
+        result = tool.run(arguments)
+    return result, collection_fetch
+
+
+class TestUnknownCollection:
+    def test_typo_collection_is_an_error_naming_the_real_one(self):
+        """'NSCLC-Radiogenomics' does not exist; the tool must say so, not succeed."""
+        tool = _tool("TCIA_get_modality_values")
+        result, _ = _run(tool, {"Collection": "NSCLC-Radiogenomics"}, _response(""))
+
+        assert result["status"] == "error"
+        assert "NSCLC-Radiogenomics" in result["error"]
+        assert "does not exist" in result["error"]
+        # The space-separated real collection is offered first.
+        assert result["suggestions"][0] == "NSCLC Radiogenomics"
+        assert "NSCLC Radiogenomics" in result["error"]
+        assert "data" not in result
+
+    def test_unknown_collection_is_an_error_for_every_tool_in_the_family(self):
+        """The guard lives in one shared code path, so it covers the whole family."""
+        for tool_name in (
+            "TCIA_get_series",
+            "TCIA_get_patients",
+            "TCIA_get_patient_studies",
+            "TCIA_get_body_part_values",
+            "TCIA_get_manufacturer_values",
+        ):
+            tool = _tool(tool_name)
+            result, _ = _run(tool, {"Collection": "No-Such-Collection"}, _response(""))
+            assert result["status"] == "error", tool_name
+            assert "No-Such-Collection" in result["error"], tool_name
+
+    def test_collection_list_is_fetched_only_when_the_result_is_empty(self):
+        """Validation must not tax the success path with an extra request."""
+        payload = json.dumps([{"Modality": "CT"}, {"Modality": "PT"}])
+        tool = _tool("TCIA_get_modality_values")
+        result, collection_fetch = _run(
+            tool, {"Collection": "NSCLC Radiogenomics"}, _response(payload)
+        )
+        assert result["status"] == "success"
+        assert result["count"] == 2
+        assert collection_fetch.call_count == 0
+
+    def test_collection_list_is_fetched_once_per_process(self):
+        """Repeated misses reuse the memoized collection list."""
+        tool = _tool("TCIA_get_modality_values")
+        with (
+            patch(
+                "tooluniverse.base_rest_tool.request_with_retry",
+                return_value=_response(""),
+            ),
+            patch(
+                "tooluniverse.tcia_tool.request_with_retry",
+                return_value=_response(json.dumps(COLLECTIONS)),
+            ) as collection_fetch,
+        ):
+            tool.run({"Collection": "Bad-One"})
+            tool.run({"Collection": "Bad-Two"})
+        assert collection_fetch.call_count == 1
+
+
+class TestEmptyResultIsAnHonestEmptyList:
+    def test_valid_collection_with_impossible_filter_returns_empty_list(self):
+        """A real collection with no matching modality is success with data == []."""
+        tool = _tool("TCIA_get_series")
+        result, _ = _run(
+            tool,
+            {"Collection": "NSCLC Radiogenomics", "Modality": "MR"},
+            _response(""),
+        )
+        assert result["status"] == "success"
+        assert result["data"] == []
+        assert result["count"] == 0
+        # The note must make clear the collection is fine and the filter is not.
+        assert "NSCLC Radiogenomics" in result["note"]
+        assert "Modality" in result["note"]
+
+    def test_empty_result_is_never_the_empty_string(self):
+        """Regression on the original payload: data was "" with no count key."""
+        tool = _tool("TCIA_get_series")
+        result, _ = _run(
+            tool,
+            {"Collection": "NSCLC Radiogenomics", "Modality": "MR"},
+            _response(""),
+        )
+        assert result["data"] != ""
+        assert isinstance(result["data"], list)
+
+    def test_empty_result_without_a_collection_argument(self):
+        """Endpoints keyed on a UID have no collection to validate; still a list."""
+        tool = _tool("TCIA_get_series_size")
+        result, collection_fetch = _run(
+            tool, {"SeriesInstanceUID": "1.2.3.not.real"}, _response("")
+        )
+        assert result["status"] == "success"
+        assert result["data"] == []
+        assert result["count"] == 0
+        assert collection_fetch.call_count == 0
+        assert "exactly" in result["note"]
+
+    def test_empty_collection_list_endpoint_does_not_recurse(self):
+        """TCIA_list_collections is the validation source; it must not call itself."""
+        tool = _tool("TCIA_list_collections")
+        result, collection_fetch = _run(tool, {}, _response(""))
+        assert result["status"] == "success"
+        assert result["data"] == []
+        assert collection_fetch.call_count == 0
+
+
+class TestValidationOutageDegradesGracefully:
+    def test_unreachable_collection_list_does_not_invent_an_error(self):
+        """If the archive's collection list is unavailable, do not claim a typo."""
+        tool = _tool("TCIA_get_modality_values")
+        with (
+            patch(
+                "tooluniverse.base_rest_tool.request_with_retry",
+                return_value=_response(""),
+            ),
+            patch(
+                "tooluniverse.tcia_tool.request_with_retry",
+                side_effect=OSError("connection reset"),
+            ),
+        ):
+            result = tool.run({"Collection": "NSCLC-Radiogenomics"})
+
+        assert result["status"] == "success"
+        assert result["data"] == []
+        assert result["count"] == 0
+        assert "could not be verified" in result["note"]
+
+
+class TestUnchangedBehaviour:
+    def test_non_empty_payload_is_untouched(self):
+        """Responses with a body keep flowing through normal BaseRESTTool parsing."""
+        payload = json.dumps(
+            [{"PatientId": "LUNG1-001", "Collection": "NSCLC-Radiomics"}]
+        )
+        tool = _tool("TCIA_get_patients")
+        result, _ = _run(tool, {"Collection": "NSCLC-Radiomics"}, _response(payload))
+        assert result["status"] == "success"
+        assert result["count"] == 1
+        assert result["data"][0]["PatientId"] == "LUNG1-001"
+
+    def test_http_error_still_reports_the_status_code(self):
+        """A real transport failure must not be masked by the empty-body handler."""
+        tool = _tool("TCIA_get_patients")
+        result, _ = _run(
+            tool, {"Collection": "LIDC-IDRI"}, _response("", status_code=500)
+        )
+        assert result["status"] == "error"
+        assert result["status_code"] == 500
+
+    def test_echoed_url_includes_the_query_string(self):
+        """The response must show what was actually requested."""
+        tool = _tool("TCIA_get_modality_values")
+        requested = (
+            "https://tcia.example/getModalityValues?Collection=NSCLC+Radiogenomics"
+        )
+        result, _ = _run(
+            tool,
+            {"Collection": "NSCLC Radiogenomics"},
+            _response(json.dumps([{"Modality": "CT"}]), url=requested),
+        )
+        assert result["url"] == requested
+
+
+def test_every_tcia_tool_uses_the_hardened_class():
+    """The fix is config-wired for the whole family, not just one tool."""
+    with open(DATA_DIR / "tcia_tools.json") as f:
+        tools = json.load(f)
+    assert len(tools) >= 10
+    assert {t["type"] for t in tools} == {"TCIATool"}

--- a/tests/unit/test_who_gho_series_not_silently_truncated.py
+++ b/tests/unit/test_who_gho_series_not_silently_truncated.py
@@ -1,0 +1,223 @@
+"""WHOGHO_get_indicator_data must not return an arbitrary silent subset.
+
+Regression: the config sent ``$top: 20`` with no ``$orderby`` and no
+``$count``, so a request for a country's time series came back as 20 rows
+in the GHO API's internal ``Id`` order -- an arbitrary, non-chronological
+sample -- with nothing in the response indicating rows were missing.
+Confirmed live against
+https://ghoapi.azureedge.net/api/MDG_0000000020?$filter=SpatialDim eq 'BGD'
+which holds 25 rows (2000-2024): the tool returned years
+2003, 2010, 2004, 2005, 2020, 2002, ... and silently dropped 2006, 2013,
+2017, 2018 and 2021, so a plotted series had invisible, unpredictable
+holes.
+
+Verified live that the GHO OData endpoint supports both ``$count=true``
+(returns ``@odata.count``: 25 for the query above, 5177 for the whole
+indicator) and ``$orderby`` including the composite
+``SpatialDim asc,TimeDim asc``. The fix sends both, raises ``$top`` to
+100, exposes ``orderby``, and opts into ``fields.pagination_disclosure``
+so a capped result carries a top-level ``truncated`` flag, the real
+``total_available`` and a ``truncation_note``. ``fields.echo_request_url``
+makes the echoed ``url`` include the ``$filter``/``$top`` actually sent.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.base_rest_tool import BaseRESTTool  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+CONFIG_PATH = (
+    Path(__file__).parent.parent.parent / "src/tooluniverse/data/who_gho_tools.json"
+)
+
+
+def _tool_config(name):
+    configs = json.loads(CONFIG_PATH.read_text())
+    return next(c for c in configs if c["name"] == name)
+
+
+class _FakeResponse:
+    def __init__(self, payload, url="https://ghoapi.azureedge.net/api/STUB"):
+        self.status_code = 200
+        self._payload = payload
+        self.text = json.dumps(payload)
+        self.headers = {"content-type": "application/json"}
+        self.url = url
+
+    def json(self):
+        return self._payload
+
+
+def _row(year):
+    return {
+        "Id": 1000 + year,
+        "IndicatorCode": "MDG_0000000020",
+        "SpatialDimType": "COUNTRY",
+        "SpatialDim": "BGD",
+        "TimeDim": year,
+        "NumericValue": 221.0,
+        "Value": "221 [161-291]",
+    }
+
+
+def _run(payload, arguments, response_url=None):
+    tool = BaseRESTTool(_tool_config("WHOGHO_get_indicator_data"))
+    captured = {}
+
+    def fake_request(session, method, url, **kwargs):
+        captured["url"] = url
+        captured["params"] = kwargs.get("params", {})
+        return _FakeResponse(
+            payload, url=response_url or "https://ghoapi.azureedge.net/api/STUB"
+        )
+
+    import tooluniverse.base_rest_tool as mod
+
+    original = mod.request_with_retry
+    mod.request_with_retry = fake_request
+    try:
+        return tool.run(dict(arguments)), captured
+    finally:
+        mod.request_with_retry = original
+
+
+# --------------------------------------------------------------------------
+# Config-level guards
+# --------------------------------------------------------------------------
+
+
+def test_odata_count_and_deterministic_order_are_requested():
+    fields = _tool_config("WHOGHO_get_indicator_data")["fields"]
+    assert fields["params"]["$count"] == "true"
+    orderby = fields["params"]["$orderby"]
+    assert "TimeDim" in orderby, "a truncated series must be chronologically ordered"
+    assert fields["params"]["$top"] >= 100
+
+
+def test_orderby_is_exposed_and_mapped_to_the_odata_param():
+    config = _tool_config("WHOGHO_get_indicator_data")
+    assert "orderby" in config["parameter"]["properties"]
+    mapping = config["fields"]["param_mapping"]
+    assert mapping["orderby"] == "$orderby"
+    # pre-existing mappings must survive
+    assert mapping["filter"] == "$filter"
+    assert mapping["top"] == "$top"
+
+
+def test_pagination_disclosure_points_at_the_odata_envelope():
+    fields = _tool_config("WHOGHO_get_indicator_data")["fields"]
+    disclosure = fields["pagination_disclosure"]
+    assert disclosure["total_path"] == ["@odata.count"]
+    assert disclosure["rows_path"] == ["value"]
+    assert fields["echo_request_url"] is True
+
+
+def test_return_schema_does_not_forbid_extra_envelope_keys():
+    schema = _tool_config("WHOGHO_get_indicator_data")["return_schema"]
+    assert schema.get("additionalProperties") is not False
+    for branch in schema.get("oneOf", []):
+        assert branch.get("additionalProperties") is not False
+
+
+# --------------------------------------------------------------------------
+# Runtime behaviour
+# --------------------------------------------------------------------------
+
+
+def test_row_cap_is_disclosed_with_the_real_total():
+    payload = {
+        "@odata.count": 25,
+        "value": [_row(y) for y in range(2000, 2020)],
+    }
+    result, _ = _run(
+        payload,
+        {
+            "indicator_code": "MDG_0000000020",
+            "filter": "SpatialDim eq 'BGD'",
+            "top": 20,
+        },
+    )
+
+    assert result["status"] == "success"
+    assert result["truncated"] is True
+    assert result["total_available"] == 25
+    assert result["count"] == 20
+    note = result["truncation_note"]
+    assert "20 of 25" in note
+    assert "top" in note
+
+
+def test_full_series_is_explicitly_not_truncated():
+    payload = {
+        "@odata.count": 25,
+        "value": [_row(y) for y in range(2000, 2025)],
+    }
+    result, _ = _run(
+        payload,
+        {"indicator_code": "MDG_0000000020", "filter": "SpatialDim eq 'BGD'"},
+    )
+
+    assert result["truncated"] is False
+    assert "truncation_note" not in result
+    assert result["count"] == 25
+    years = [r["TimeDim"] for r in result["data"]["value"]]
+    assert years == sorted(years), "series must come back in chronological order"
+    assert set(range(2000, 2025)) - set(years) == set(), "no holes in the series"
+
+
+def test_no_matching_data_is_not_reported_as_truncation():
+    result, _ = _run(
+        {"@odata.count": 0, "value": []},
+        {"indicator_code": "MDG_0000000020", "filter": "SpatialDim eq 'ZZZ'"},
+    )
+    assert result["truncated"] is False
+    assert result["count"] == 0
+    assert result["total_available"] == 0
+
+
+def test_defaults_and_caller_overrides_reach_the_api():
+    _, captured = _run(
+        {"@odata.count": 0, "value": []},
+        {"indicator_code": "MDG_0000000020"},
+    )
+    params = captured["params"]
+    assert params["$count"] == "true"
+    assert params["$top"] == 100
+    assert "TimeDim" in params["$orderby"]
+
+    _, captured = _run(
+        {"@odata.count": 0, "value": []},
+        {
+            "indicator_code": "MDG_0000000020",
+            "filter": "SpatialDim eq 'BGD'",
+            "top": 500,
+            "orderby": "TimeDim desc",
+        },
+    )
+    params = captured["params"]
+    assert params["$top"] == 500
+    assert params["$orderby"] == "TimeDim desc"
+    assert params["$filter"] == "SpatialDim eq 'BGD'"
+    assert "orderby" not in params
+
+
+def test_echoed_url_includes_the_odata_query_actually_sent():
+    full = (
+        "https://ghoapi.azureedge.net/api/MDG_0000000020"
+        "?%24top=100&%24count=true&%24filter=SpatialDim+eq+%27BGD%27"
+    )
+    result, captured = _run(
+        {"@odata.count": 0, "value": []},
+        {"indicator_code": "MDG_0000000020", "filter": "SpatialDim eq 'BGD'"},
+        response_url=full,
+    )
+    # the request target is still the bare endpoint; only the echo is enriched
+    assert captured["url"] == "https://ghoapi.azureedge.net/api/MDG_0000000020"
+    assert result["url"] == full

--- a/tests/unit/test_worldbank_indicator_pagination_disclosed.py
+++ b/tests/unit/test_worldbank_indicator_pagination_disclosed.py
@@ -1,0 +1,258 @@
+"""WorldBank_get_indicator must not silently drop rows to server-side paging.
+
+Regression: the config pinned ``per_page: "50"`` and exposed no ``page`` /
+``per_page`` parameter, so any query matching more than 50 country-year
+observations returned only the first page while still reporting
+``status: success``. Confirmed live against
+https://api.worldbank.org/v2/country/IND;IDN;MMR;BGD/indicator/NY.GDP.PCAP.CD?date=2010:2024&format=json
+-- upstream reports ``total: 60`` (4 countries x 15 years) but the tool
+returned 50 rows, cutting off part-way through Myanmar so MMR 2010-2019
+(2010 = 1010.53) vanished entirely. The only hint was the World Bank
+metadata object at ``data[0]`` (``{"page": 1, "pages": 2, ...}``), and
+page 2 was unreachable because no paging parameter existed. Top-level
+``count`` was 2 -- the length of the ``[metadata, rows]`` envelope, not a
+row count.
+
+The fix raises the default ``per_page`` to 1000 (32500 is the documented
+maximum; 40000 returns HTTP 400), exposes ``per_page``/``page``, and opts
+the tool into ``fields.pagination_disclosure`` so a partial result carries
+a top-level ``truncated`` flag, the real ``total_available`` and a
+``truncation_note``. ``fields.echo_request_url`` makes the echoed ``url``
+include the query string that was actually sent.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.base_rest_tool import BaseRESTTool  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+CONFIG_PATH = (
+    Path(__file__).parent.parent.parent / "src/tooluniverse/data/worldbank_tools.json"
+)
+
+
+def _tool_config(name):
+    configs = json.loads(CONFIG_PATH.read_text())
+    return next(c for c in configs if c["name"] == name)
+
+
+class _FakeResponse:
+    def __init__(self, payload, url="https://api.worldbank.org/v2/stub?format=json"):
+        self.status_code = 200
+        self._payload = payload
+        self.text = json.dumps(payload)
+        self.headers = {"content-type": "application/json"}
+        self.url = url
+
+    def json(self):
+        return self._payload
+
+
+def _row(iso3, year):
+    return {
+        "indicator": {"id": "NY.GDP.PCAP.CD", "value": "GDP per capita (current US$)"},
+        "country": {"id": iso3[:2], "value": iso3},
+        "countryiso3code": iso3,
+        "date": str(year),
+        "value": 1000.0,
+        "decimal": 1,
+    }
+
+
+def _payload(rows, total, page=1, pages=1, per_page=1000):
+    return [
+        {
+            "page": page,
+            "pages": pages,
+            "per_page": per_page,
+            "total": total,
+            "sourceid": "2",
+        },
+        rows,
+    ]
+
+
+def _run(payload, arguments, response_url=None):
+    config = _tool_config("WorldBank_get_indicator")
+    tool = BaseRESTTool(config)
+    captured = {}
+
+    def fake_request(session, method, url, **kwargs):
+        captured["url"] = url
+        captured["params"] = kwargs.get("params", {})
+        return _FakeResponse(
+            payload, url=response_url or "https://api.worldbank.org/v2/stub"
+        )
+
+    import tooluniverse.base_rest_tool as mod
+
+    original = mod.request_with_retry
+    mod.request_with_retry = fake_request
+    try:
+        return tool.run(dict(arguments)), captured
+    finally:
+        mod.request_with_retry = original
+
+
+# --------------------------------------------------------------------------
+# Config-level guards
+# --------------------------------------------------------------------------
+
+
+def test_default_per_page_is_large_enough_for_ordinary_country_panels():
+    fields = _tool_config("WorldBank_get_indicator")["fields"]
+    per_page = int(fields["params"]["per_page"])
+    # The reported failure was 4 countries x 15 years = 60 rows against a
+    # per_page of 50. Anything at or below 60 reintroduces it.
+    assert per_page >= 1000
+    # 32500 is the largest value the API accepts (40000 -> HTTP 400).
+    assert per_page <= 32500
+
+
+def test_page_and_per_page_are_reachable_as_tool_parameters():
+    props = _tool_config("WorldBank_get_indicator")["parameter"]["properties"]
+    assert "page" in props, "page 2+ must be reachable through the tool"
+    assert "per_page" in props
+
+
+def test_pagination_disclosure_points_at_worldbank_envelope():
+    fields = _tool_config("WorldBank_get_indicator")["fields"]
+    disclosure = fields["pagination_disclosure"]
+    assert disclosure["total_path"] == [0, "total"]
+    assert disclosure["rows_path"] == [1]
+    assert fields["echo_request_url"] is True
+
+
+def test_return_schema_does_not_forbid_extra_envelope_keys():
+    schema = _tool_config("WorldBank_get_indicator")["return_schema"]
+    assert schema.get("additionalProperties") is not False
+    for branch in schema.get("oneOf", []):
+        assert branch.get("additionalProperties") is not False
+
+
+# --------------------------------------------------------------------------
+# Runtime behaviour
+# --------------------------------------------------------------------------
+
+
+def test_partial_page_is_flagged_truncated_with_the_real_total():
+    rows = [_row("BGD", y) for y in range(2010, 2025)]
+    rows += [_row("IDN", y) for y in range(2010, 2025)]
+    rows += [_row("IND", y) for y in range(2010, 2025)]
+    rows += [_row("MMR", y) for y in range(2020, 2025)]  # cut off mid-Myanmar
+    result, _ = _run(
+        _payload(rows, total=60, page=1, pages=2, per_page=50),
+        {
+            "country": "IND;IDN;MMR;BGD",
+            "indicator": "NY.GDP.PCAP.CD",
+            "date": "2010:2024",
+        },
+    )
+
+    assert result["status"] == "success"
+    assert result["truncated"] is True
+    assert result["total_available"] == 60
+    # `count` must be the row count, not the length of the [meta, rows] envelope.
+    assert result["count"] == 50
+    note = result["truncation_note"]
+    assert "50 of 60" in note
+    assert "page 1 of 2" in note
+    assert "per_page" in note and "page" in note
+
+
+def test_complete_page_is_explicitly_not_truncated():
+    rows = [_row("BGD", y) for y in range(2010, 2025)]
+    rows += [_row("IDN", y) for y in range(2010, 2025)]
+    rows += [_row("IND", y) for y in range(2010, 2025)]
+    rows += [_row("MMR", y) for y in range(2010, 2025)]
+    result, _ = _run(
+        _payload(rows, total=60, page=1, pages=1, per_page=1000),
+        {
+            "country": "IND;IDN;MMR;BGD",
+            "indicator": "NY.GDP.PCAP.CD",
+            "date": "2010:2024",
+        },
+    )
+
+    assert result["truncated"] is False
+    assert "truncation_note" not in result
+    assert result["count"] == 60
+    assert result["total_available"] == 60
+    assert any(r["countryiso3code"] == "MMR" and r["date"] == "2010" for r in rows)
+
+
+def test_empty_result_is_reported_as_no_data_not_as_truncated():
+    result, _ = _run(
+        _payload([], total=0),
+        {"country": "XKX", "indicator": "NY.GDP.PCAP.CD", "date": "1800"},
+    )
+    assert result["truncated"] is False
+    assert result["count"] == 0
+    assert result["total_available"] == 0
+
+
+def test_default_and_caller_supplied_paging_params_reach_the_api():
+    _, captured = _run(
+        _payload([], total=0),
+        {"country": "USA", "indicator": "NY.GDP.PCAP.CD"},
+    )
+    assert captured["params"]["per_page"] == "1000"
+
+    _, captured = _run(
+        _payload([], total=0),
+        {"country": "USA", "indicator": "NY.GDP.PCAP.CD", "per_page": 5000, "page": 3},
+    )
+    assert captured["params"]["per_page"] == 5000
+    assert captured["params"]["page"] == 3
+
+
+def test_echoed_url_includes_the_query_string_actually_sent():
+    full = (
+        "https://api.worldbank.org/v2/country/USA/indicator/NY.GDP.PCAP.CD"
+        "?format=json&per_page=1000&date=2010%3A2024"
+    )
+    result, _ = _run(
+        _payload([], total=0),
+        {"country": "USA", "indicator": "NY.GDP.PCAP.CD", "date": "2010:2024"},
+        response_url=full,
+    )
+    assert result["url"] == full
+
+
+# --------------------------------------------------------------------------
+# The shared BaseRESTTool additions must stay opt-in
+# --------------------------------------------------------------------------
+
+
+def test_tools_without_the_new_flags_are_unaffected():
+    config = {
+        "name": "StubTool",
+        "type": "BaseRESTTool",
+        "parameter": {"type": "object", "properties": {}},
+        "fields": {"endpoint": "https://example.invalid/api"},
+    }
+    tool = BaseRESTTool(config)
+
+    import tooluniverse.base_rest_tool as mod
+
+    original = mod.request_with_retry
+    mod.request_with_retry = lambda session, method, url, **kw: _FakeResponse(
+        [{"total": 60}, [{"a": 1}]], url="https://example.invalid/api?x=1"
+    )
+    try:
+        result = tool.run({})
+    finally:
+        mod.request_with_retry = original
+
+    assert result["url"] == "https://example.invalid/api"
+    assert result["count"] == 2  # unchanged: length of the raw list payload
+    assert "truncated" not in result
+    assert "total_available" not in result
+    assert "truncation_note" not in result


### PR DESCRIPTION
Seven verified defects, all found by researcher personas in three domains not previously exercised (vaccine immunoinformatics, epidemiology/global health surveillance, medical imaging/radiogenomics) and each re-verified via the CLI before any fix was written. Root cause for every one was established against the upstream API directly, not inferred from tool behaviour.

The theme this round is **a partial or wrong answer presented as a complete, correct one**.

### 1. World Bank and WHO GHO returned an arbitrary slice as the whole series

`WorldBank_get_indicator` for four countries over 2010-2024 returned 50 of 60 rows with `status: success`, ending part-way through Myanmar — **Myanmar 2010-2019 vanished silently**. `pages: 2` was buried in the upstream metadata at `data[0]`; `count: 2` was the length of the `[metadata, rows]` envelope, not a row count; and no `page`/`per_page` parameter existed, so page 2 was unreachable through the tool.

`WHOGHO_get_indicator_data` sent `$top=20` with no `$orderby`, returning 20 rows in the API's internal `Id` order — an unpredictable, non-chronological sample of a 25-year series (2006, 2013, 2017, 2018, 2021 dropped). A trend line built from it has invisible holes.

Verified upstream: `per_page=100` returns all 60 records (Myanmar 2010 = 1010.53); `per_page` accepts up to 32500 and 400s at 40000. GHO applies `$orderby` before `$top`, and `$count=true` returns `@odata.count: 25`.

Both now report the true total, an explicit `truncated` flag, and a note naming the next step; WHO GHO results are ordered so a capped result is a contiguous prefix; both echo the fully-resolved request URL so a suspected dropped filter can be audited. The two `BaseRESTTool` hooks are opt-in `fields.*` keys and are no-ops for every tool that does not set them.

### 2. Nextstrain reported a total that counted only what it had truncated

`Nextstrain_list_datasets` capped each pathogen's `datasets` array at 10, then summed those capped arrays into `metadata.total_datasets` — reporting **113 for a catalogue of 295**, wrong by 2.6x, next to per-pathogen `dataset_count` fields that told the truth and contradicted it (avian-flu 66, ncov 86). Nothing disclosed the cap and no parameter could page past it.

Verified against `nextstrain.org/charon/getAvailable`: 295 datasets across 23 pathogens. The total is now real, what was returned moved to `listed_datasets`, and the cap is disclosed and controllable. The sibling `get_dataset` cut `available_colorings` at 15 where a real build has 20; it now returns all.

### 3. A GTDB species query returned a different species and the genus count

`GTDB_search_genomes` for `Mycobacterium tuberculosis` returned **Mycobacterium leprae** among the top five and reported `total_results: 13381`.

Root cause proven, not inferred: appending a term GTDB cannot match (`Mycobacterium xyzzyplop`) leaves the count and rows byte-identical to a bare `Mycobacterium` search — the second term is discarded. And 13381 exceeds the 13027 genomes in the genus, so the figure was `Mycobacterium ∪ tuberculosis`. The endpoint ORs query terms.

The documented `filterText` parameter applies an AND substring test; probing established it is case-insensitive but order- and whitespace-literal, so queries are normalized first. The precise lookup runs first, the loose search is a disclosed fallback, and the same query now returns 7869 with all five results *M. tuberculosis*. A genus query still matches the genus.

### 4. PDC promised disease-name search but only matched study titles

`PDC_search_studies` advertises "search by disease name (e.g. 'Breast', 'Lung', 'CCRCC')". Searching `Lung Adenocarcinoma` returned **zero** studies; `LUAD` returned 18. It called `studySearch(name:)`, which compares against the title alone — the documented `Breast` example worked only because CPTAC breast titles contain the word.

Verified upstream: `getPaginatedUIStudy(disease_type: "Lung Adenocarcinoma")` returns `total: 22`, including PDC000153 whose `disease_type` is `"Lung Adenocarcinoma;Other"`. A researcher looking for the matched molecular partner of the CPTAC-LUAD imaging collection was told it did not exist.

Search now covers the curated metadata PDC publishes and reports which field matched, so a title-only hit is never mistaken for curated evidence. Two further defects surfaced and are fixed: the old path silently capped at 100 results, and the description advertised HTAN, which is not a PDC program.

### 5. cBioPortal and Europe PMC hid the totals that reveal a result is partial

`cBioPortal_get_cancer_studies` returned 20 of 539 with `count: 20` and no total — a silent default, not an API limit (`limit: 1000` returns all 539). A persona concluded the NSCLC cohorts they needed were absent from cBioPortal when they were merely past position 20. There was no `offset`, so paging was impossible.

`EuropePMC_search_articles` parsed a payload containing `hitCount: 103` and reported only `metadata.count: 6`.

Both now report the true total under an unambiguous name, keep the returned count separate, and disclose truncation. cBioPortal reports its total only via a `projection=META` probe with paging params absent; the probe is skipped for unpaged endpoints and short-circuits on a short page, so it costs a request only when the answer is genuinely unknown.

### 6. A misspelled TCIA collection was indistinguishable from an empty one

`TCIA_get_modality_values '{"Collection":"NSCLC-Radiogenomics"}'` returned `status: success` with `data: ""`. That collection does not exist — the real name has a space — but every neighbour is hyphenated, so it is the natural typo, and a genuine filter miss on a *valid* collection produced the byte-identical payload.

Root cause: the NBIA v1 API answers every zero-result query with HTTP 200 and a completely empty body, which fell through to the plain-text branch and became `""` — also making `data` a string on the miss path and a list on the hit path, with no `count` at all.

An unknown collection is now an error naming the closest real names; a valid collection with no matches returns an honest empty list with `count: 0` and a note. The collection list is fetched only on the empty-result path and memoized on success, so a transient outage degrades to a caveat rather than a false "does not exist".

### 7. IEDB epitope prediction hung for two minutes and then gave up

`IEDB_predict_mhci_binding`, `IEDB_predict_mhcii_binding` and `IEDB_predict_antigen_processing` each stalled for the full 120 s client timeout and returned "IEDB prediction timed out" — **including on their own registered test examples**. A nine-residue peptide cannot legitimately take two minutes, so the message blamed the clock for something that was never going to finish. The whole T-cell epitope prediction capability was unusable, which for vaccine design is the load-bearing step.

The cause is upstream and total. Probed directly:

```
GET  tools-cluster-interface.iedb.org/tools_api/mhci/        -> 405 in 0.40 s   (host up)
POST tools-cluster-interface.iedb.org/tools_api/mhci/        -> 0 bytes, killed at 90 s
POST tools-cluster-interface.iedb.org/tools_api/processing/  -> 0 bytes, killed at 120 s
POST tools-cluster-interface.iedb.org/tools_api/bcell/       -> HTTP 200, real TSV, 66.8 s
```

The legacy host accepts the POST and never answers. `bcell/` still works, which is why B-cell prediction kept functioning and masked how broad the outage was.

These three tools now run on IEDB's next-generation asynchronous pipeline API (submit + bounded poll, per-request timeouts). `bcell` deliberately stays on the legacy route because that route still works.

Three contract details were established against the live API rather than assumed, each of which would have been a defect if guessed:
- **A failed stage leaves `status: "pending"` indefinitely while populating `data.errors`** — polling on `status` alone reproduces the original hang. Observed for 180 s.
- Validation failures return **HTTP 200 with `errors` and no `result_id`**; an invalid *method* returns an opaque HTML 500.
- Alleles are spelled **`H2-Kd`, not `H-2-Kd`** — which is the MHC-I tool's own first `test_example`, so it needed translating.

| | before | after |
|---|---|---|
| `IEDB_predict_mhci_binding` (own example) | timeout after **2m 01.8s** | real prediction, **16.1 s** |
| `IEDB_predict_mhcii_binding` (own example) | timeout after **2m 01.7s** | real prediction, **16.0 s** |
| `IEDB_predict_antigen_processing` | same 120 s hang | 23 scored peptides, **22.6 s** |
| `IEDB_predict_bcell_epitopes` | working | unchanged |

The MHC-I result for GILGFVFTL / HLA-A\*02:01 is `netmhcpan_el_score 0.789948`, `percentile 0.09` — correct for the influenza M1 immunodominant epitope.

The processing tool's output columns necessarily change: the legacy proteasome/TAP/total triple does not exist in the new API, and NetCTLpan's cleavage/TAP/MHC/combined scores are the closest true equivalent. The description and `return_schema` describe what is actually returned rather than renaming columns to imitate the retired shape.

Three pre-existing test files asserted the retired TSV contract and are rewritten against the new transport, preserving each original guard's intent — most importantly that an upstream failure is never reported as a prediction.

---

**Verification.** Every fix re-verified by re-running the original failing CLI command. `tests/unit` + `tests/integration` pass with zero failures both before and after (86 new assertions across 8 new regression test files, all mocking the HTTP layer). Each worker grepped `tests/` for assertions on the old behaviour; four pre-existing test files needed changes: `test_clinical_imaging_archives_depth.py` (three TCIA fixtures constructed `BaseRESTTool` directly, repointed to `TCIATool` with identical payloads) and the three IEDB files that asserted the retired TSV contract.

**Scope.** Deliberately avoids every file owned by open PRs #500, #501 and #502. Two verified defects were dropped for that reason and are noted for a later round: `proteins_api_get_epitopes` returns an empty success for P03420 while the upstream EBI epitope endpoint holds 47 features, and `BVBRC_search_surveillance` swallows an unknown parameter and blames the caller for the resulting omission.

