### PR TITLE
Fix Round 31: numbers that were confidently wrong, and tools that blamed the caller

### DIFF
--- a/src/tooluniverse/data/drugcentral_tools.json
+++ b/src/tooluniverse/data/drugcentral_tools.json
@@ -54,16 +54,37 @@
             "description": "SMILES chemical structure"
           },
           "approval": {
-            "type": ["array", "null"],
-            "description": "Regulatory approval records",
-            "items": {
-              "type": "object",
-              "properties": {
-                "agency": {"type": ["string", "null"]},
-                "company": {"type": ["string", "null"]},
-                "date": {"type": ["string", "null"]}
-              }
-            }
+            "description": "Regulatory approval record(s), passed through from DrugCentral unchanged. Upstream returns a single object when the drug has exactly one approval record (e.g. praziquantel) and an array when it has several (e.g. metformin: FDA, EMA, PMDA), so both shapes occur.",
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "agency": {"type": ["string", "null"]},
+                  "company": {"type": ["string", "null"]},
+                  "date": {"type": ["string", "null"]},
+                  "orphan": {
+                    "type": ["string", "null"],
+                    "description": "Orphan-drug designation flag, reported upstream as the string 'True' or 'False'."
+                  }
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "agency": {"type": ["string", "null"]},
+                    "company": {"type": ["string", "null"]},
+                    "date": {"type": ["string", "null"]},
+                    "orphan": {
+                      "type": ["string", "null"],
+                      "description": "Orphan-drug designation flag, reported upstream as the string 'True' or 'False'."
+                    }
+                  }
+                }
+              },
+              {"type": "null"}
+            ]
           },
           "drugbank_id": {
             "type": ["string", "null"],
@@ -208,7 +229,7 @@
   {
     "name": "DrugCentral_get_targets",
     "type": "DrugCentralTool",
-    "description": "Get drug target information from DrugCentral for a specific drug by its InChIKey or ChEMBL ID. Returns bioactivity data including target protein names, target classes (Enzyme, Kinase, Transporter, GPCR, etc.), organisms, action types (INHIBITOR, AGONIST, etc.), activity values (IC50, Ki, EC50), mechanism of action (MoA) flags, UniProt protein IDs, and gene symbols. DrugCentral data accessed via MyChem.info. Example: 'XZWYZXLIPXDOLR-UHFFFAOYSA-N' returns metformin targets (AMPK, Complex I, OCT1/2/3, DPP4).",
+    "description": "Get drug target information from DrugCentral for a specific drug by its InChIKey or ChEMBL ID. Returns bioactivity data including target protein names, target classes (Enzyme, Kinase, Transporter, GPCR, etc.), organisms, action types (INHIBITOR, AGONIST, etc.), potency measurements, mechanism of action (MoA) flags, UniProt protein IDs, and gene symbols. IMPORTANT - POTENCY UNITS: DrugCentral reports potency on the p-scale, i.e. 'activity_value' is the -log10 of the molar potency (the pChEMBL convention), NOT a concentration in nM or uM. So an entry reading activity_type 'IC50' with activity_value '4.01' means pIC50 = 4.01, i.e. an IC50 of 10^-4.01 M = ~96800 nM (96.8 uM) - weak, not sub-micromolar. Higher activity_value means more potent. For convenience each target also carries 'activity_type_reported' (the p-scale name, e.g. 'pIC50'), 'activity_value_scale' (a plain-language note on the scale), and 'activity_value_nM' (the same potency converted to nanomolar, or null when upstream reports no numeric value). DrugCentral data accessed via MyChem.info. Example: 'XZWYZXLIPXDOLR-UHFFFAOYSA-N' returns metformin targets (AMPK, Complex I, OCT1/2/3, DPP4).",
     "parameter": {
       "type": "object",
       "properties": {
@@ -267,11 +288,23 @@
                       },
                       "activity_type": {
                         "type": ["string", "null"],
-                        "description": "Activity measure type (IC50, Ki, EC50, Kd, etc.)"
+                        "description": "Raw DrugCentral activity measure type (IC50, Ki, EC50, Kd, etc.). NOTE: the accompanying activity_value is the p-scale (-log10 M) form of this measure, not a concentration -- see activity_type_reported."
                       },
                       "activity_value": {
                         "type": ["string", "null"],
-                        "description": "Activity value (typically log scale, e.g., '4.54' for 10^-4.54 M)"
+                        "description": "Potency on the p-scale: -log10 of the molar potency, as reported by DrugCentral (e.g. '4.01' means 10^-4.01 M = ~96800 nM). This is NOT a nM/uM concentration. Higher = more potent."
+                      },
+                      "activity_type_reported": {
+                        "type": ["string", "null"],
+                        "description": "Name of the quantity actually reported in activity_value, i.e. the p-scale form of activity_type (e.g. 'pIC50', 'pKi', 'pKd'). Null when DrugCentral reports no activity type."
+                      },
+                      "activity_value_scale": {
+                        "type": "string",
+                        "description": "Plain-language statement of the scale and units of activity_value (constant: pActivity, -log10 molar, with the nM conversion formula)."
+                      },
+                      "activity_value_nM": {
+                        "type": ["number", "null"],
+                        "description": "activity_value converted to nanomolar as 10**(9 - activity_value), rounded to 4 significant figures. Null when activity_value is missing or non-numeric."
                       },
                       "is_moa": {
                         "type": "boolean",

--- a/src/tooluniverse/data/ensembl_vep_tools.json
+++ b/src/tooluniverse/data/ensembl_vep_tools.json
@@ -122,6 +122,13 @@
                       "null"
                     ]
                   },
+                  "variant_allele": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "The alternate allele this consequence is predicted for. For multi-allelic variants the same transcript appears once per allele, so this field is required to attribute a consequence to the correct allele."
+                  },
                   "consequence_terms": {
                     "type": "array",
                     "items": {
@@ -304,6 +311,13 @@
                       "string",
                       "null"
                     ]
+                  },
+                  "variant_allele": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "The alternate allele this consequence is predicted for. For multi-allelic variants the same transcript appears once per allele, so this field is required to attribute a consequence to the correct allele."
                   },
                   "consequence_terms": {
                     "type": "array",

--- a/src/tooluniverse/data/gwas_sumstats_tools.json
+++ b/src/tooluniverse/data/gwas_sumstats_tools.json
@@ -68,7 +68,7 @@
   },
   {
     "name": "GWASSumStats_get_region_associations",
-    "description": "Query full GWAS summary statistics for variants in a chromosomal region. Returns variant-level association data including p-values, effect sizes (beta/OR), allele frequencies, and study/trait information. Unlike gwas_search_associations (which returns curated top hits), this endpoint provides complete summary statistics from deposited studies. Filter by chromosome region, p-value threshold, and optionally by specific study.",
+    "description": "Query full GWAS summary statistics for variants in a chromosomal region. Returns variant-level association data including p-values, effect sizes (beta/OR), allele frequencies, and study/trait information. Unlike gwas_search_associations (which returns curated top hits), this endpoint provides complete summary statistics from deposited studies. Filter by chromosome region, p-value threshold, and optionally by specific study. Results are sorted most-significant-first. Some deposited studies encode an unreported p-value as the GWAS Catalog missing-value sentinel -99; such rows cannot satisfy p_upper and are excluded when p_upper is set (the count is reported in metadata.sentinel_rows_excluded). Omit p_upper to retain them, flagged with p_value_reported = false.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -128,6 +128,14 @@
           "chromosome": {"type": ["integer", "null"]},
           "position": {"type": ["integer", "null"]},
           "p_value": {"type": ["number", "null"]},
+          "p_value_reported": {
+            "type": "boolean",
+            "description": "False when p_value is the GWAS Catalog missing-value sentinel (-99) or otherwise not a finite number in [0, 1] rather than a real p-value. Such rows are excluded whenever p_upper is set."
+          },
+          "code": {
+            "type": ["integer", "null"],
+            "description": "Upstream GWAS Catalog harmonisation code for the variant (e.g. 10 = forward strand, alleles already correctly oriented; 14 = variant could not be validated for harmonisation). This describes allele harmonisation only and does NOT indicate whether p_value is real -- use p_value_reported for that."
+          },
           "beta": {"type": ["number", "null"]},
           "odds_ratio": {"type": ["number", "null"]},
           "effect_allele": {"type": ["string", "null"]},

--- a/src/tooluniverse/data/gwas_tools.json
+++ b/src/tooluniverse/data/gwas_tools.json
@@ -2,7 +2,7 @@
   {
     "type": "GWASAssociationSearch",
     "name": "gwas_search_associations",
-    "description": "Search the GWAS Catalog for genome-wide association study results by keyword. Accepts free-text disease/trait names (e.g., 'melanoma', 'diabetes', 'breast cancer'), SNP rs IDs, EFO ontology IDs, or study accession IDs. This is the primary tool for discovering GWAS associations when you do NOT already have a specific association ID. Returns SNPs, p-values, odds ratios, mapped genes, and study metadata with pagination support.",
+    "description": "Search the GWAS Catalog for genome-wide association study results by keyword. Accepts free-text disease/trait names (e.g., 'melanoma', 'diabetes', 'breast cancer'), SNP rs IDs, EFO ontology IDs, or study accession IDs. This is the primary tool for discovering GWAS associations when you do NOT already have a specific association ID. Returns SNPs, p-values, odds ratios, mapped genes, and study metadata with pagination support. Response envelope keys beyond 'data': 'metadata.pagination' (upstream page block - its totalElements/totalPages always describe the UNFILTERED result set); when a p_value threshold is given, 'metadata.p_value_filter', 'metadata.p_value_filter_scope' and 'metadata.p_value_filter_note' state that the threshold was applied CLIENT-SIDE (GWAS Catalog REST v2 has no server-side p-value filter), 'metadata.pagination_totals_are_prefilter' is true, 'metadata.filtered_total' / 'filtered_total_is_exact' / 'filtered_total_at_least' / 'filtered_total_note' give the post-filter denominator, and 'metadata.sort_override' records that the page was fetched p_value-ascending so the threshold could match anything. When a disease_trait is resolved to an ontology term, 'query_trait', 'resolved_efo_id', 'resolved_efo_label' and 'trait_resolution_source' are returned, plus a 'trait_resolution_note' whenever the resolved label is not an exact match for the trait you asked for. An empty 'data' comes with a 'note' that names the real cause: a client-side filter that removed every row is reported as such, and only a genuinely empty unfiltered result set suggests trying a trait synonym or a gene-based tool.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -36,19 +36,19 @@
         },
         "p_value": {
           "type": "number",
-          "description": "Maximum p-value threshold for filtering (e.g., 5e-8 for genome-wide significance). Applied client-side after retrieval."
+          "description": "Maximum p-value threshold for filtering (e.g., 5e-8 for genome-wide significance). IMPORTANT: the GWAS Catalog REST API v2 has NO server-side p-value filter (its OpenAPI document lists only pubmed_id, rs_id, full_pvalue_set, accession_id, efo_trait, efo_id, show_child_trait, mapped_gene, extended_geneset, sort, direction, page and size on GET /v2/associations), so this threshold is applied CLIENT-SIDE to the page of associations fetched. To make it meaningful the page is fetched p_value-ascending (most-significant-first) whenever sort is 'p_value' (the default), and the surviving rows are then re-ordered into the direction you asked for. metadata.p_value_filter_scope, metadata.filtered_total and metadata.p_value_filter_note report exactly what was filtered."
         },
         "p_value_threshold": {
           "type": "number",
-          "description": "Alias for p_value: maximum p-value threshold."
+          "description": "Alias for p_value: maximum p-value threshold (also applied client-side; see p_value)."
         },
         "sort": {
           "type": "string",
-          "description": "Sort field (e.g., 'p_value', 'or_value')"
+          "description": "Sort field (e.g., 'p_value', 'or_value'). Defaults to 'p_value'. When a p_value threshold is supplied and sort is 'p_value', the upstream page is always fetched ascending so the threshold sees the significant end; metadata.sort_override records this and the returned rows are ordered per your 'direction'."
         },
         "direction": {
           "type": "string",
-          "description": "Sort direction ('asc' or 'desc')"
+          "description": "Sort direction ('asc' or 'desc'). Defaults to 'asc'. Combined with a p_value threshold this orders the RETURNED rows; see metadata.sort_override."
         },
         "size": {
           "type": "integer",
@@ -888,7 +888,7 @@
   {
     "type": "GWASVariantsForTrait",
     "name": "gwas_get_variants_for_trait",
-    "description": "Search the GWAS Catalog for all genetic variants (SNPs) linked to a specific disease or trait. Accepts free-text disease/trait names (e.g., 'diabetes', 'breast cancer'), EFO ontology IDs, or EFO trait labels. Returns variant details including rsIDs, p-values, mapped genes, and genomic locations. Results are sorted by p-value ascending (most significant first) by default, so the first page holds the strongest loci; override with the 'sort' and 'direction' parameters. This is the best tool for finding all GWAS variants for a disease when you do NOT already have a specific variant ID.",
+    "description": "Search the GWAS Catalog for all genetic variants (SNPs) linked to a specific disease or trait. Accepts free-text disease/trait names (e.g., 'diabetes', 'breast cancer'), EFO ontology IDs, or EFO trait labels. Returns variant details including rsIDs, p-values, mapped genes, and genomic locations. Results are sorted by p-value ascending (most significant first) by default, so the first page holds the strongest loci; override with the 'sort' and 'direction' parameters. This is the best tool for finding all GWAS variants for a disease when you do NOT already have a specific variant ID. A free-text disease_trait is resolved to an EFO/MONDO term first, and that resolution is disclosed: 'query_trait', 'resolved_efo_id', 'resolved_efo_label' and 'trait_resolution_source' are returned, plus a 'trait_resolution_note' whenever the resolved label is not an exact match for your query - check them before trusting the results, and pass efo_id explicitly to bypass the resolver.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -1065,7 +1065,7 @@
   {
     "type": "GWASAssociationsForTrait",
     "name": "gwas_get_associations_for_trait",
-    "description": "Get all associations for a specific trait, sorted by p-value (most significant first).",
+    "description": "Get all associations for a specific trait, sorted by p-value (most significant first). A free-text disease_trait is resolved to an EFO/MONDO term first, and that resolution is disclosed in the response: 'query_trait' (what you asked for), 'resolved_efo_id', 'resolved_efo_label' (the term's label in GWAS Catalog) and 'trait_resolution_source', plus a 'trait_resolution_note' whenever the resolved label is not an exact match for your query. Check those before trusting the results: e.g. 'cardiorespiratory fitness' resolves to EFO_0009184 'heart rate response to exercise', which is a different phenotype from VO2max (EFO_0004887 'maximal oxygen uptake measurement'). Pass efo_id explicitly to bypass the resolver.",
     "parameter": {
       "type": "object",
       "properties": {

--- a/src/tooluniverse/data/hpa_tools.json
+++ b/src/tooluniverse/data/hpa_tools.json
@@ -76,7 +76,10 @@
           "description": "Gene name, alias, keyword, or cell line name to search for, e.g., 'EGFR', 'TP53', or 'MCF7'."
         },
         "max_results": {
-          "type": ["integer", "null"],
+          "type": [
+            "integer",
+            "null"
+          ],
           "description": "Maximum number of gene matches to return (default: 50). This search does a broad full-text match with no server-side limit, so a short/common query can otherwise return thousands of results; exact gene-symbol matches are ranked first."
         }
       },
@@ -316,7 +319,7 @@
       ]
     },
     "input_description": "Input Ensembl Gene ID (e.g., ENSG00000064787). The tool will parse HPA's single gene XML page to get the most comprehensive data. Optionally include detailed information for images, antibodies, and expression data.",
-    "output_description": "Returns comprehensive gene details including basic information, tissue immunohistochemistry (IHC) image URL list with metadata, subcellular immunofluorescence (IF) image URL list with metadata, antibody validation data, detailed expression data for tissues and cell lines, subcellular localization information, and statistical summary (antibody count, image count, expression tissue count, etc.).",
+    "output_description": "Returns comprehensive gene details including basic information, tissue immunohistochemistry (IHC) image URL list with metadata, subcellular immunofluorescence (IF) image URL list with metadata, antibody validation data, detailed expression data for tissues and cell lines, subcellular localization information, and a statistical summary. In the summary, 'tissues_with_expression' is the number of DISTINCT tissues with a detected IHC expression level (rows with no level and rows scored 'not detected' are excluded); 'distinct_tissues_assayed' and 'tissue_expression_rows' give the distinct-tissue and raw row counts of the tissue_expression array, which holds one row per tissue x antibody.",
     "test_examples": [
       {
         "ensembl_id": "ENSG00000141510",
@@ -359,10 +362,22 @@
               "type": "integer"
             },
             "tissues_with_expression": {
-              "type": "integer"
+              "type": "integer",
+              "description": "Number of distinct tissues with a detected IHC expression level; blank and 'not detected' rows are excluded."
             },
             "cell_lines_with_expression": {
               "type": "integer"
+            },
+            "distinct_tissues_assayed": {
+              "type": "integer",
+              "description": "Number of distinct tissues present in tissue_expression."
+            },
+            "tissue_expression_rows": {
+              "type": "integer",
+              "description": "Raw length of the tissue_expression array (one row per tissue x antibody, so tissues repeat)."
+            },
+            "summary_note": {
+              "type": "string"
             }
           }
         },
@@ -599,7 +614,7 @@
   {
     "type": "HPAGetRnaExpressionByTissueTool",
     "name": "HPA_get_rna_expression_in_specific_tissues",
-    "description": "Query RNA expression levels (nTPM) for a specific gene in one or more user-specified tissues. Reads HPA's full per-tissue nTPM panel (the 'Tissue RNA - <tissue> [nTPM]' columns), so any of HPA's ~50 published tissues and brain regions can be queried, e.g. 'cerebral cortex', 'basal ganglia', 'midbrain', 'liver'. A tissue reported as 'Not found' means the tissue name is unrecognized by HPA, not that the gene lacks expression there.",
+    "description": "Query RNA expression levels (nTPM) for a specific gene in one or more user-specified tissues. Reads HPA's full per-tissue nTPM panel (the 'Tissue RNA - <tissue> [nTPM]' columns), so any of HPA's 51 published consensus tissues and brain regions can be queried, e.g. 'cerebral cortex', 'basal ganglia', 'midbrain', 'liver'. Common names are mapped to HPA's actual column names, including the ones HPA suffixes with '1' ('skin' -> 'Skin 1', 'stomach' -> 'Stomach 1', 'endometrium' -> 'Endometrium 1'); when a name resolves to a differently-named HPA column the response says so in a 'note'. A tissue reported as 'Not found' means HPA publishes no RNA column for that name (it is a naming problem or a tissue HPA covers only with protein/IHC data), not that the gene lacks expression there.",
     "fields": {
       "endpoint": "https://www.proteinatlas.org/{ensembl_id}.json",
       "timeout": 30,
@@ -617,7 +632,7 @@
           "items": {
             "type": "string"
           },
-          "description": "List of tissue names to query, e.g., ['brain', 'liver', 'heart muscle', 'kidney']. Case-insensitive matching is supported."
+          "description": "List of tissue names to query, e.g., ['skin', 'liver', 'heart muscle', 'kidney']. Case-insensitive; underscores, spaces and hyphens are interchangeable. HPA has no RNA column for 'bronchus', 'nasopharynx', 'oral mucosa' or 'soft tissue' (protein/IHC only)."
         }
       },
       "required": [
@@ -626,7 +641,7 @@
       ]
     },
     "input_description": "Input an Ensembl Gene ID and a list of tissue names. The tool will perform intelligent tissue name matching.",
-    "output_description": "Returns a dictionary mapping queried tissue names to their expression data, including matched tissue name, expression value in nTPM, and categorized expression level (Very high/High/Medium/Low/Very low), and the HPA column the value came from. Also lists the tissues HPA classifies the gene as enriched in.",
+    "output_description": "Returns a dictionary mapping each queried tissue name to its expression data: the HPA tissue the value actually came from (matched_tissue), the expression value, its unit read from the HPA column header (expression_unit), a categorized expression level (Very high/High/Medium/Low/Very low), the HPA column header used (source_field), and a 'note' when the queried name resolved to a differently-named HPA column or matched nothing. Also lists the tissues HPA classifies the gene as enriched in.",
     "test_examples": [
       {
         "ensembl_id": "ENSG00000254647",
@@ -696,7 +711,7 @@
   {
     "type": "HPAGetRnaExpressionBySourceTool",
     "name": "HPA_get_rna_expression_by_source",
-    "description": "Get RNA expression level (nTPM) for a gene in a specific biological source using optimized columns parameter. Supports tissue, blood, brain, and single_cell source types with comprehensive source mappings.",
+    "description": "Get RNA expression for a gene in a specific biological source, read from HPA's dedicated per-source download columns (t_RNA_*, blood_RNA_*, brain_RNA_*, sc_RNA_*). Supports source_type 'tissue', 'blood', 'brain' and 'single_cell'. Units differ by source: single_cell values are nCPM, all others nTPM -- the returned expression_unit is read from HPA's own column header, never assumed.",
     "fields": {
       "endpoint": "https://www.proteinatlas.org/api/search_download.php",
       "timeout": 30,
@@ -711,11 +726,11 @@
         },
         "source_type": {
           "type": "string",
-          "description": "The type of biological source. Choose from: 'tissue', 'blood', 'brain', 'single_cell'."
+          "description": "The type of biological source. Choose from: 'tissue' (51 consensus tissues, nTPM), 'blood' (19 immune cell subsets, nTPM), 'brain' (13 brain regions, nTPM), 'single_cell' (~160 single cell types, nCPM)."
         },
         "source_name": {
           "type": "string",
-          "description": "The specific name of the biological source, e.g., 'liver', 'heart_muscle', 't_cell', 'hepatocytes', 'cerebellum'. Must be a valid name from the comprehensive HPA columns mapping."
+          "description": "The specific source name, e.g. 'liver', 'heart_muscle', 'skin', 't_cell', 'hepatocyte', 'cerebellum'. Case-insensitive; spaces and hyphens are treated as underscores. Names HPA publishes only as subsets (blood 't_cell', 'b_cell', 'monocyte', 'dendritic_cell') resolve to a representative subset column and the response reports which one in a 'note'. An invalid name returns an error listing valid names -- it never returns a silent 'N/A'."
         }
       },
       "required": [
@@ -725,7 +740,7 @@
       ]
     },
     "input_description": "Input gene name (e.g., GFAP), source type (tissue/blood/brain/single_cell), and specific source name (e.g., liver). The tool will directly query the specific column for highly efficient data retrieval.",
-    "output_description": "Returns precise RNA expression data with nTPM value, expression level categorization (Very high/High/Medium/Low/Very low), and metadata about the query. Includes gene information, source details, expression unit explanation, and the specific data column used.",
+    "output_description": "Returns the expression value, its unit taken from HPA's column header (nTPM, or nCPM for single_cell), a categorized expression level, the exact HPA column header the number came from (column_queried), and a 'note' whenever the requested source name resolved to a differently-named HPA column.",
     "test_examples": [
       {
         "gene_name": "TP53",

--- a/src/tooluniverse/data/medlineplus_tools.json
+++ b/src/tooluniverse/data/medlineplus_tools.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "MedlinePlus_search_topics_by_keyword",
-    "description": "Search for relevant information in MedlinePlus Web Service by keyword across health topics or other sub-libraries (such as drugs, genetics, etc.).",
+    "description": "Search MedlinePlus health topics by keyword via NLM's wsearch Web Service. IMPORTANT: although the db parameter accepts seven historical database names, the live service only returns results for healthTopics (English) and healthTopicsSpanish (Spanish); drugs, drugsSpanish, genetics, medicalTests and medicalEncyclopedia are accepted but always answer with zero results. Use MedlinePlus_get_genetics_gene_by_name / MedlinePlus_get_genetics_condition_by_name for genetics, and MedlinePlus_connect_lookup_by_code for drug/test codes.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -20,7 +20,7 @@
             "medicalTests",
             "medicalEncyclopedia"
           ],
-          "description": "Specify the database to search, e.g., healthTopics (English health topics), healthTopicsSpanish (Spanish health topics), drugs (English drugs), etc."
+          "description": "Database to search. Only two values are actually served by NLM's wsearch endpoint: healthTopics (English health topics) and healthTopicsSpanish (Spanish health topics). The remaining values (drugs, drugsSpanish, genetics, medicalTests, medicalEncyclopedia) are still accepted for backward compatibility but the service returns zero results for every query against them; the tool reports that explicitly instead of pretending the term had no match."
         },
         "rettype": {
           "type": "string",
@@ -29,7 +29,7 @@
             "topic",
             "all"
           ],
-          "description": "Result return format, options: brief (concise information, default), topic (detailed XML record), all (includes all available information).",
+          "description": "Result return format (default: topic). topic returns the full structured health-topic record (title, meta description, aliases, full summary, topic groups). brief returns the condensed search-result fields (title, alternate title, full summary, group names and a match snippet, which is surfaced as meta_desc); it carries no language attribute, so the language is derived from db. all returns the brief fields plus the same structured record as topic, and is parsed identically to topic. All three produce the same output keys.",
           "default": "topic"
         }
       },
@@ -40,8 +40,8 @@
     },
     "fields": {
       "endpoint": "https://wsearch.nlm.nih.gov/ws/query?db={db}&term={term}&rettype={rettype}",
-      "input_description": "Input parameters:\n- term: keyword to search (URL encoded);\n- db: database name, e.g., healthTopics, drugs, etc.;\n- rettype: return format, options: brief, topic, all.",
-      "output_description": "Returns MedlinePlus Web Service response XML, will contain title, summary, links, etc. for matching topics, the returned data will be parsed into a Python dictionary for subsequent use."
+      "input_description": "Input parameters:\n- term: keyword to search (URL encoded);\n- db: database name; only healthTopics and healthTopicsSpanish return results (the other enum values are accepted but always yield zero results);\n- rettype: return format, options: topic (default), brief, all.",
+      "output_description": "Returns {\"topics\": [...]} where each entry has title, meta_desc, url, language, rank, also_called, summary and groups, parsed from the wsearch XML. The same keys are produced for all three rettype values. On zero results the tool returns an error naming the cause, including an explicit note when the requested db is one that MedlinePlus wsearch does not serve."
     },
     "type": "MedlinePlusRESTTool",
     "test_examples": [
@@ -49,6 +49,11 @@
         "term": "cancer",
         "db": "healthTopics",
         "rettype": "topic"
+      },
+      {
+        "term": "leishmaniasis",
+        "db": "healthTopics",
+        "rettype": "brief"
       }
     ],
     "return_schema": {

--- a/src/tooluniverse/data/monarch_v3_tools.json
+++ b/src/tooluniverse/data/monarch_v3_tools.json
@@ -32,17 +32,21 @@
   },
   {
     "name": "MonarchV3_get_associations",
-    "description": "Query cross-species associations between biomedical entities in the Monarch Initiative knowledge graph. Find gene-phenotype, disease-phenotype, gene-disease, or gene-pathway associations. Uses Biolink model categories to specify association type. Integrates data from OMIM, ClinVar, HPO, MGI, ZFIN, FlyBase, WormBase. Example: HGNC:11998 (TP53) with category GeneToPhenotypicFeatureAssociation returns phenotypes like hepatocellular carcinoma and reticular hyperpigmentation.",
+    "description": "Query cross-species associations between biomedical entities in the Monarch Initiative knowledge graph. Find gene-phenotype, disease-phenotype, gene-disease, or gene-pathway associations. Uses Biolink model categories to specify association type. Integrates data from OMIM, ClinVar, HPO, MGI, ZFIN, FlyBase, WormBase. Associations are DIRECTED: every category has a fixed subject side and object side, so anchor your entity on the correct side. Supply 'subject', 'object', or both (at least one is required). Example: HGNC:11998 (TP53) as subject with category GeneToPhenotypicFeatureAssociation returns phenotypes like hepatocellular carcinoma; MONDO:0006559 as OBJECT with category CausalGeneToDiseaseAssociation returns the genes that cause that disease (NCSTN, PSENEN, PSEN1).",
     "parameter": {
       "type": "object",
       "properties": {
         "subject": {
           "type": "string",
-          "description": "Subject entity CURIE. Examples: 'HGNC:11998' (TP53), 'MONDO:0005148' (type 2 diabetes), 'HP:0001250' (seizure)."
+          "description": "Subject-side entity CURIE, i.e. the entity on the LEFT of the association (the arrow's source). For gene->disease categories (CausalGeneToDiseaseAssociation, CorrelatedGeneToDiseaseAssociation) the subject is the GENE; for gene->phenotype and gene->pathway the subject is the gene; for DiseaseToPhenotypicFeatureAssociation the subject is the disease. Examples: 'HGNC:11998' (TP53), 'MONDO:0005148' (type 2 diabetes), 'HP:0001250' (seizure). Optional, but at least one of 'subject' / 'object' must be supplied."
+        },
+        "object": {
+          "type": "string",
+          "description": "Object-side entity CURIE, i.e. the entity on the RIGHT of the association (the arrow's target). Use this to query the association backwards. For gene->disease categories the object is the DISEASE, so 'which genes cause this disease?' is object='MONDO:0006559' with category='biolink:CausalGeneToDiseaseAssociation'; for gene/disease->phenotype categories the object is the HP phenotype term. Optional, but at least one of 'subject' / 'object' must be supplied. Supplying both narrows to associations linking exactly that pair."
         },
         "category": {
           "type": "string",
-          "description": "Biolink association category. Options: 'biolink:GeneToPhenotypicFeatureAssociation' (gene->phenotypes), 'biolink:DiseaseToPhenotypicFeatureAssociation' (disease->phenotypes), 'biolink:CorrelatedGeneToDiseaseAssociation' (gene->diseases, correlated), 'biolink:CausalGeneToDiseaseAssociation' (gene->diseases, causal), 'biolink:GeneToPathwayAssociation' (gene->pathways), 'biolink:VariantToDiseaseAssociation' (variant->diseases), 'biolink:GeneToExpressionSiteAssociation' (gene->expression sites/tissues)."
+          "description": "Biolink association category, written as subject->object. Options: 'biolink:GeneToPhenotypicFeatureAssociation' (gene->phenotypes), 'biolink:DiseaseToPhenotypicFeatureAssociation' (disease->phenotypes), 'biolink:CorrelatedGeneToDiseaseAssociation' (gene->diseases, correlated), 'biolink:CausalGeneToDiseaseAssociation' (gene->diseases, causal), 'biolink:GeneToPathwayAssociation' (gene->pathways), 'biolink:VariantToDiseaseAssociation' (variant->diseases), 'biolink:GeneToExpressionSiteAssociation' (gene->expression sites/tissues). The left-hand side goes in 'subject' and the right-hand side goes in 'object'."
         },
         "limit": {
           "type": "integer",
@@ -50,7 +54,6 @@
         }
       },
       "required": [
-        "subject",
         "category"
       ]
     },
@@ -66,6 +69,10 @@
       {
         "subject": "MONDO:0005148",
         "category": "biolink:DiseaseToPhenotypicFeatureAssociation"
+      },
+      {
+        "object": "MONDO:0006559",
+        "category": "biolink:CausalGeneToDiseaseAssociation"
       }
     ],
     "return_schema": {

--- a/src/tooluniverse/data/sider_tools.json
+++ b/src/tooluniverse/data/sider_tools.json
@@ -85,7 +85,7 @@
   {
     "name": "SIDER_get_drug_side_effects",
     "type": "SiderTool",
-    "description": "Get the list of known side effects for a drug from SIDER, including frequency data when available. Side effects are extracted from drug labels and include MedDRA codes, frequency percentages from clinical trials (e.g., '21% - 57.5%'), and placebo comparison rates. Provide either a drug name (will auto-search) or a SIDER drug ID from SIDER_search_drug. Returns adverse reactions recorded in official drug labels.",
+    "description": "Get the list of known side effects for a drug from SIDER, including frequency data when available. Side effects are extracted from drug labels and include MedDRA codes, the frequency reported for the drug (e.g., '21% - 57.5%', '6%', or qualitative terms such as 'postmarketing' or 'rare'), and the placebo-arm rate when the label reports one. Most SIDER labels have no placebo arm, so placebo_frequency is null for the majority of side effects; null means SIDER has no placebo rate, not that the placebo rate is zero or equal to the drug's rate. Provide either a drug name (will auto-search) or a SIDER drug ID from SIDER_search_drug. Returns adverse reactions recorded in official drug labels.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -154,14 +154,14 @@
                   "string",
                   "null"
                 ],
-                "description": "Reported frequency range (e.g., '21% - 57.5%' or '6%') or null if unavailable"
+                "description": "Frequency reported for the drug itself, taken verbatim from the 'Data for drug' column of the SIDER label table. May be a percentage or range ('6%', '21% - 57.5%', '1-10%') or a qualitative term used by the label ('postmarketing', 'rare', 'infrequent', 'frequent'), or a combination ('uncommon, 5% - 7%'). Null when the label reports no frequency."
               },
               "placebo_frequency": {
                 "type": [
                   "string",
                   "null"
                 ],
-                "description": "Placebo group frequency if available"
+                "description": "Frequency observed in the placebo arm, taken verbatim from the separate 'Placebo' column of the SIDER label table. Null whenever that column is empty, which is the common case because most SIDER labels report no placebo arm at all - null therefore means 'SIDER has no placebo rate for this side effect', NOT 'the placebo rate is zero' and NOT 'the placebo rate equals the drug rate'. Never inferred from the drug's own frequency."
               },
               "description": {
                 "type": [

--- a/src/tooluniverse/data/unichem_tools.json
+++ b/src/tooluniverse/data/unichem_tools.json
@@ -63,6 +63,13 @@
                 "null"
               ]
             },
+            "uci": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "UniChem Compound Identifier (UCI) for the matched structure"
+            },
             "source_count": {
               "type": "integer"
             },

--- a/src/tooluniverse/data/worms_tools.json
+++ b/src/tooluniverse/data/worms_tools.json
@@ -2,13 +2,14 @@
   {
     "type": "WoRMSRESTTool",
     "name": "WoRMS_search_species",
-    "description": "Search marine species in the World Register of Marine Species (WoRMS) by name. Returns up to `limit` matching taxon records; WoRMS serves 50 records per request, so larger pages are assembled automatically. `has_more` indicates whether further records exist beyond the returned page \u2014 use `offset` to retrieve them.",
+    "description": "Search species in the World Register of Marine Species (WoRMS) by name. IMPORTANT: WoRMS restricts this search to marine taxa by default, so species recorded only as freshwater or terrestrial (e.g. the parasite Schistosoma mansoni) return zero results \u2014 pass `marine_only=false` to include them. WoRMS also catalogues many non-marine taxa that its other endpoints (WoRMS_get_classification, WoRMS_get_distribution) will serve once you have the AphiaID. Returns up to `limit` matching taxon records; WoRMS serves 50 records per request, so larger pages are assembled automatically. `has_more` indicates whether further records exist beyond the returned page \u2014 use `offset` to retrieve them.",
     "parameter": {
       "type": "object",
       "properties": {
         "query": {"type": "string", "description": "Species name or search term"},
         "limit": {"type": "integer", "default": 20, "description": "Maximum number of taxon records to return (default 20). Pages larger than 50 are assembled from multiple WoRMS requests."},
-        "offset": {"type": "integer", "default": 1, "description": "1-based index of the first record to return (default 1). Use with `limit` and `has_more` to page through large result sets."}
+        "offset": {"type": "integer", "default": 1, "description": "1-based index of the first record to return (default 1). Use with `limit` and `has_more` to page through large result sets."},
+        "marine_only": {"type": "boolean", "default": true, "description": "Whether to restrict the search to marine taxa (default true, matching WoRMS's own default). Set to false to also return freshwater and terrestrial species, such as parasitic helminths, that the marine filter would otherwise hide. The effective value is echoed back as `marine_only` in the response."}
       },
       "required": ["query"]
     },
@@ -65,7 +66,8 @@
     },
     "test_examples": [
       {"query": "Actinia equina", "limit": 5},
-      {"query": "Gadus", "limit": 10, "offset": 1}
+      {"query": "Gadus", "limit": 10, "offset": 1},
+      {"query": "Schistosoma mansoni", "marine_only": false}
     ]
   },
   {
@@ -75,7 +77,7 @@
     "parameter": {
       "type": "object",
       "properties": {
-        "AphiaID": {"type": "integer", "description": "WoRMS AphiaID of the taxon, e.g. 127160 (Solea solea, common sole). Obtain from WoRMS_search_species."}
+        "AphiaID": {"type": "integer", "description": "WoRMS AphiaID of the taxon, e.g. 127160 (Solea solea, common sole). Obtain from WoRMS_search_species — for a freshwater or terrestrial taxon, search there with marine_only=false, since its marine-only default hides such records."}
       },
       "required": ["AphiaID"]
     },
@@ -135,7 +137,7 @@
     "parameter": {
       "type": "object",
       "properties": {
-        "AphiaID": {"type": "integer", "description": "WoRMS AphiaID of the taxon, e.g. 127160 (Solea solea). Obtain from WoRMS_search_species."}
+        "AphiaID": {"type": "integer", "description": "WoRMS AphiaID of the taxon, e.g. 127160 (Solea solea). Obtain from WoRMS_search_species — for a freshwater or terrestrial taxon, search there with marine_only=false, since its marine-only default hides such records."}
       },
       "required": ["AphiaID"]
     },
@@ -194,7 +196,7 @@
     "parameter": {
       "type": "object",
       "properties": {
-        "AphiaID": {"type": "integer", "description": "WoRMS AphiaID of the taxon, e.g. 127160 (Solea solea). Obtain from WoRMS_search_species."}
+        "AphiaID": {"type": "integer", "description": "WoRMS AphiaID of the taxon, e.g. 127160 (Solea solea). Obtain from WoRMS_search_species — for a freshwater or terrestrial taxon, search there with marine_only=false, since its marine-only default hides such records."}
       },
       "required": ["AphiaID"]
     },
@@ -298,7 +300,7 @@
     "parameter": {
       "type": "object",
       "properties": {
-        "AphiaID": {"type": "integer", "description": "WoRMS AphiaID of the accepted taxon, e.g. 127160 (Solea solea). Obtain from WoRMS_search_species."}
+        "AphiaID": {"type": "integer", "description": "WoRMS AphiaID of the accepted taxon, e.g. 127160 (Solea solea). Obtain from WoRMS_search_species — for a freshwater or terrestrial taxon, search there with marine_only=false, since its marine-only default hides such records."}
       },
       "required": ["AphiaID"]
     },

--- a/src/tooluniverse/drugcentral_tool.py
+++ b/src/tooluniverse/drugcentral_tool.py
@@ -17,12 +17,62 @@ This tool queries MyChem.info and extracts DrugCentral-specific fields:
 No authentication required.
 """
 
+import math
 import requests
 from typing import Dict, Any
 from .base_tool import BaseTool
 from .tool_registry import register_tool
 
 MYCHEM_BASE = "https://mychem.info/v1"
+
+# DrugCentral stores bioactivity potency in "act_value" on the p-scale --
+# -log10 of the molar potency (the pChEMBL convention) -- NOT as a
+# concentration in nM or uM. Reporting that number next to an "IC50" label
+# with no units reads as "IC50 = 4.01 (nM?)" when the underlying IC50 is
+# 10^-4.01 M = ~96.8 uM, i.e. a ~5-order-of-magnitude misstatement
+# (verified against ChEMBL: praziquantel/ABCB11 IC50 96800 nM, pchembl 4.01).
+# These constants/helpers let the tool disclose the scale explicitly without
+# changing the value it has always returned.
+P_ACTIVITY_SCALE = (
+    "pActivity: -log10 of the molar potency, not a concentration. "
+    "Higher = more potent. Convert with nM = 10**(9 - value); "
+    "e.g. 4.01 -> ~96800 nM (96.8 uM), 9.0 -> 1 nM."
+)
+
+
+def _p_activity_to_nanomolar(act_value: Any, sig_figs: int = 4) -> "float | None":
+    """Convert a -log10(molar) p-scale potency to nanomolar.
+
+    Returns None when ``act_value`` is missing or does not parse as a finite
+    float, so callers never see a fabricated concentration.
+    """
+    try:
+        p_value = float(act_value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(p_value):
+        return None
+    try:
+        nanomolar = 10.0 ** (9.0 - p_value)
+    except OverflowError:
+        return None
+    if not math.isfinite(nanomolar) or nanomolar <= 0:
+        return None
+    # The p-value upstream carries ~2 decimals, so anything past a few
+    # significant figures in the converted concentration is false precision.
+    decimals = -math.floor(math.log10(nanomolar)) + (sig_figs - 1)
+    return round(nanomolar, decimals)
+
+
+def _p_activity_type(act_type: Any) -> "str | None":
+    """Name the quantity actually reported, e.g. "IC50" -> "pIC50"."""
+    if not isinstance(act_type, str) or not act_type.strip():
+        return None
+    act_type = act_type.strip()
+    # Guard against upstream ever switching to already-p-prefixed labels.
+    if act_type[0] in "pP" and act_type[1:2].isupper():
+        return act_type
+    return f"p{act_type}"
 
 # Fields to retrieve from MyChem for DrugCentral data
 DC_ALL_FIELDS = "drugcentral"
@@ -324,14 +374,23 @@ class DrugCentralTool(BaseTool):
             gene_symbols = [
                 u.get("gene_symbol") for u in uniprot_info if u.get("gene_symbol")
             ]
+            act_type = ba.get("act_type")
+            act_value = ba.get("act_value")
             targets.append(
                 {
                     "target_name": ba.get("target_name"),
                     "target_class": ba.get("target_class"),
                     "organism": ba.get("organism"),
                     "action_type": ba.get("action_type"),
-                    "activity_type": ba.get("act_type"),
-                    "activity_value": ba.get("act_value"),
+                    # "activity_type"/"activity_value" are kept exactly as
+                    # upstream reports them for backward compatibility; the
+                    # three keys below disclose that the value is on the
+                    # p-scale (-log10 M) rather than a nM/uM concentration.
+                    "activity_type": act_type,
+                    "activity_value": act_value,
+                    "activity_type_reported": _p_activity_type(act_type),
+                    "activity_value_scale": P_ACTIVITY_SCALE,
+                    "activity_value_nM": _p_activity_to_nanomolar(act_value),
                     "is_moa": ba.get("moa") == "1",
                     "source": ba.get("act_source"),
                     "uniprot_ids": uniprot_ids,

--- a/src/tooluniverse/ensembl_vep_tool.py
+++ b/src/tooluniverse/ensembl_vep_tool.py
@@ -214,6 +214,12 @@ class EnsemblVEPTool(BaseTool):
                 "gene_id": tc.get("gene_id"),
                 "transcript_id": tc.get("transcript_id"),
                 "biotype": tc.get("biotype"),
+                # The alternate allele this consequence is predicted for. Required to
+                # disambiguate multi-allelic variants, where the same transcript and
+                # protein position yields different (even contradictory) consequences
+                # for different alleles. E.g. rs1815739 (ACTN3, allele_string C/A/T)
+                # is synonymous for A but stop_gained for T on ENST00000502692.
+                "variant_allele": tc.get("variant_allele"),
                 "consequence_terms": tc.get("consequence_terms", []),
                 "impact": tc.get("impact"),
                 "amino_acids": tc.get("amino_acids"),

--- a/src/tooluniverse/gwas_sumstats_tool.py
+++ b/src/tooluniverse/gwas_sumstats_tool.py
@@ -10,12 +10,53 @@ API: https://www.ebi.ac.uk/gwas/summary-statistics/api/
 No authentication required.
 """
 
+import math
+import numbers
+
 import requests
-from typing import Dict, Any, List
+from typing import Any, Dict, List
 from .base_tool import BaseTool
 from .tool_registry import register_tool
 
 GWAS_SS_BASE_URL = "https://www.ebi.ac.uk/gwas/summary-statistics/api"
+
+
+def _p_value_is_reported(p_value: Any) -> bool:
+    """Is ``p_value`` an actual p-value rather than a missing-data sentinel?
+
+    The GWAS Catalog summary-statistics store encodes "not reported" as the
+    numeric sentinel ``-99.0`` (confirmed live: rows from GCST004415 in
+    chr2:179000000-179600000 come back with ``p_value == -99.0`` *and*
+    ``odds_ratio == -99.0``, neither of which is a legal value for its
+    field). Those sentinel rows are served even when the caller asks the
+    API for ``p_upper=5e-8``, because ``-99 <= 5e-8`` is numerically true.
+
+    Note the upstream ``code`` field is *not* a usable discriminator here:
+    it is the harmonisation code, and code 10 means "forward strand,
+    alleles already in the correct orientation" (a success), while code 14
+    means "invalid for harmonisation" -- observed live on rows carrying
+    perfectly real p-values. So the test is on the value itself: a real
+    p-value is a finite number in [0, 1]. ``0.0`` is kept because sumstats
+    legitimately underflow to zero for extremely significant hits.
+    """
+    if isinstance(p_value, bool) or not isinstance(p_value, numbers.Real):
+        return False
+    value = float(p_value)
+    if not math.isfinite(value):
+        return False
+    return 0.0 <= value <= 1.0
+
+
+def _p_sort_key(association: dict[str, Any]):
+    """Ascending-by-significance sort key that never ranks a sentinel first.
+
+    Rows with no reported p-value sort after every row that has one, instead
+    of being lifted to the top by ``-99 < 5e-24``.
+    """
+    p_value = association.get("p_value")
+    if _p_value_is_reported(p_value):
+        return (0, float(p_value))
+    return (1, 0.0)
 
 
 @register_tool("GWASSumStatsTool")
@@ -191,14 +232,35 @@ class GWASSumStatsTool(BaseTool):
         data = resp.json()
 
         assocs_raw = data.get("_embedded", {}).get("associations", {})
+        if isinstance(assocs_raw, dict):
+            assoc_values = list(assocs_raw.values())
+        else:
+            assoc_values = list(assocs_raw or [])
+
         associations: List[Dict[str, Any]] = []
-        for _key, v in assocs_raw.items():
+        sentinel_rows_excluded = 0
+        for v in assoc_values:
+            if not isinstance(v, dict):
+                continue
+            p_value = v.get("p_value")
+            p_value_reported = _p_value_is_reported(p_value)
+
+            # A row whose p-value is a missing-data sentinel (-99) is not a
+            # significant association, so it must not satisfy a p_upper
+            # threshold -- the upstream API lets it through because the
+            # comparison -99 <= 5e-8 is numerically true.
+            if p_upper is not None and not p_value_reported:
+                sentinel_rows_excluded += 1
+                continue
+
             associations.append(
                 {
                     "variant_id": v.get("variant_id"),
                     "chromosome": v.get("chromosome"),
                     "position": v.get("base_pair_location"),
-                    "p_value": v.get("p_value"),
+                    "p_value": p_value,
+                    "p_value_reported": p_value_reported,
+                    "code": v.get("code"),
                     "beta": v.get("beta"),
                     "odds_ratio": v.get("odds_ratio"),
                     "effect_allele": v.get("effect_allele"),
@@ -211,15 +273,26 @@ class GWASSumStatsTool(BaseTool):
                 }
             )
 
-        associations.sort(key=lambda x: x.get("p_value") or 1.0)
+        # Most significant first; rows with no reported p-value always last.
+        associations.sort(key=_p_sort_key)
 
+        metadata: dict[str, Any] = {
+            "source": "EBI GWAS Summary Statistics",
+            "region": f"chr{chromosome}:{bp_lower}-{bp_upper}",
+            "p_upper_filter": p_upper,
+            "num_associations": len(associations),
+            "sentinel_rows_excluded": sentinel_rows_excluded,
+        }
+        if sentinel_rows_excluded:
+            metadata["sentinel_note"] = (
+                f"{sentinel_rows_excluded} of {len(assoc_values)} rows returned by "
+                "the API carried the GWAS Catalog missing-value sentinel "
+                "(p_value = -99) instead of a p-value; they were excluded because "
+                "a missing p-value cannot meet the p_upper threshold. Omit p_upper "
+                "to see them, flagged with p_value_reported = false."
+            )
         return {
             "status": "success",
             "data": associations,
-            "metadata": {
-                "source": "EBI GWAS Summary Statistics",
-                "region": f"chr{chromosome}:{bp_lower}-{bp_upper}",
-                "p_upper_filter": p_upper,
-                "num_associations": len(associations),
-            },
+            "metadata": metadata,
         }

--- a/src/tooluniverse/gwas_tool.py
+++ b/src/tooluniverse/gwas_tool.py
@@ -1,10 +1,41 @@
 import re
 import requests
-from typing import Dict, Any, Optional
+from typing import Dict, Any, List, Optional
 from .base_tool import BaseTool
 from .tool_registry import register_tool
 
 _EFO_ID_RE = re.compile(r"^[A-Z]+[_:]\d+")
+
+# Fix-R31-1: the GWAS Catalog REST API v2 has NO server-side p-value filter.
+# Verified against the published OpenAPI document
+#   https://www.ebi.ac.uk/gwas/rest/api/v2/rest-api-doc.yaml
+# (linked from https://www.ebi.ac.uk/gwas/rest/api/v2/swagger-ui/index.html):
+# GET /v2/associations declares exactly these query parameters --
+_V2_ASSOCIATION_QUERY_PARAMS = (
+    "pubmed_id, rs_id, full_pvalue_set, accession_id, efo_trait, efo_id, "
+    "show_child_trait, mapped_gene, extended_geneset, sort, direction, page, size"
+)
+# -- and nothing else. A `p_upper=` parameter looks supported because the API
+# echoes unknown query parameters back inside the HAL `_links` hrefs, but it is
+# silently ignored: confirmed live that
+#   /v2/associations?efo_id=EFO_0009184&size=100&sort=p_value&direction=asc&p_upper=1e-300
+# still returns all 68 associations (p-values down to 3e-30), identical to the
+# unfiltered call. The same is true of p_value, pvalue_upper, p_value_max,
+# pUpper, p_value_lte, ... -- every candidate returns the full 68 rows.
+# The threshold therefore has to stay CLIENT-SIDE, and that fact plus its
+# consequences must be disclosed to the caller rather than silently mistaken
+# for a property of the trait.
+_CLIENT_SIDE_FILTER_NOTE = (
+    "The p_value threshold is applied CLIENT-SIDE, to the page of associations "
+    "fetched from GWAS Catalog -- not by the API. The GWAS Catalog REST API v2 "
+    "exposes no server-side p-value filter: its OpenAPI document "
+    "(https://www.ebi.ac.uk/gwas/rest/api/v2/rest-api-doc.yaml) declares only "
+    f"[{_V2_ASSOCIATION_QUERY_PARAMS}] on GET /v2/associations, and unknown "
+    "parameters such as 'p_upper' are echoed back in _links but do not filter "
+    "anything. To make the client-side threshold meaningful this tool fetches "
+    "the page in p_value-ascending (most-significant-first) order, so the rows "
+    "it filters are the ones that can actually pass."
+)
 
 
 class GWASRESTTool(BaseTool):
@@ -42,6 +73,15 @@ class GWASRESTTool(BaseTool):
         except (TypeError, ValueError):
             return None
 
+    @staticmethod
+    def _coerce_float(value: Any) -> Optional[float]:
+        if value is None or isinstance(value, bool):
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
     def _efo_id_from_uri_or_id(self, value: Any) -> Optional[str]:
         """
         Best-effort normalize an EFO/OBA/etc identifier.
@@ -67,12 +107,25 @@ class GWASRESTTool(BaseTool):
         s = s.strip()
         return s or None
 
-    def _resolve_trait_to_efo_id(self, disease_trait: str) -> Optional[str]:
-        """Resolve a disease trait name to an EFO ID.
+    def _resolve_trait_to_efo(self, disease_trait: str) -> Optional[Dict[str, Any]]:
+        """Resolve a disease trait name to an EFO term.
+
+        Returns ``{"efo_id": ..., "efo_label": ..., "source": ...}`` or None.
 
         Tries the GWAS Catalog efoTraits endpoint first, then falls back to
         a study-based resolution. The /v2/associations endpoint ignores the
         disease_trait query parameter, so we must resolve to an EFO ID.
+
+        Fix-R31-2: this used to return the bare ID, so callers could only
+        surface ``resolved_efo_id`` with no label -- and a *substitution* was
+        indistinguishable from an exact hit. Confirmed live:
+        disease_trait="cardiorespiratory fitness" finds nothing in efoTraits
+        and falls through to /v2/studies, whose single matching study
+        (GCST90310239, disease_trait "Cardiorespiratory fitness") is tagged
+        EFO_0009184 = "heart rate response to exercise" -- a different
+        physiological construct from VO2max (EFO_0004887, "maximal oxygen
+        uptake measurement"). The label travels with the ID now so callers
+        can see the substitution instead of trusting a bare accession.
         """
         # Primary: GWAS Catalog efoTraits endpoint (v1)
         try:
@@ -86,7 +139,11 @@ class GWASRESTTool(BaseTool):
                 if traits:
                     short_name = traits[0].get("shortForm")
                     if short_name:
-                        return short_name
+                        return {
+                            "efo_id": short_name,
+                            "efo_label": self._coerce_str(traits[0].get("trait")),
+                            "source": "GWAS Catalog efoTraits trait-label lookup",
+                        }
         except Exception:
             pass
 
@@ -104,25 +161,186 @@ class GWASRESTTool(BaseTool):
                     if efo_traits:
                         efo_id = efo_traits[0].get("efo_id")
                         if efo_id:
-                            return efo_id
+                            return {
+                                "efo_id": efo_id,
+                                "efo_label": self._coerce_str(
+                                    efo_traits[0].get("efo_trait")
+                                ),
+                                "source": (
+                                    "EFO term tagged on GWAS Catalog study "
+                                    f"{studies[0].get('accession_id')} "
+                                    f"(reported trait: "
+                                    f"{studies[0].get('disease_trait')!r})"
+                                ),
+                            }
         except Exception:
             pass
 
         return None
+
+    def _resolve_trait_to_efo_id(self, disease_trait: str) -> Optional[str]:
+        """Backwards-compatible wrapper returning only the EFO ID."""
+        resolved = self._resolve_trait_to_efo(disease_trait)
+        return resolved.get("efo_id") if resolved else None
+
+    def _trait_candidates_from_free_text_search(
+        self, disease_trait: str, max_studies: int = 3
+    ) -> List[Dict[str, str]]:
+        """Look up candidate EFO terms via GWAS Catalog's own free-text search.
+
+        Fix-R31-2 (additive): both resolver tiers above are exact-ish label
+        matches, so a common informal name hard-errors even when the Catalog
+        plainly holds the data -- e.g. 'VO2max' and 'maximal oxygen uptake'
+        both fail, yet https://www.ebi.ac.uk/gwas/api/search?q=VO2max finds
+        study GCST90296672 tagged EFO_0004887 "maximal oxygen uptake
+        measurement".
+
+        This deliberately does NOT auto-select a term: the top study for
+        'VO2max' is tagged both EFO_0007768 ("response to exercise", a broad
+        parent) and EFO_0004887, and picking one would be exactly the kind of
+        silent substitution Fix-R31-2 exists to prevent. The candidates are
+        only used to turn an unhelpful hard error into an actionable one.
+        """
+        candidates: List[Dict[str, str]] = []
+        seen = set()
+        try:
+            resp = requests.get(
+                "https://www.ebi.ac.uk/gwas/api/search",
+                params={"q": disease_trait, "max": 10},
+                timeout=15,
+            )
+            if resp.status_code != 200:
+                return []
+            docs = resp.json().get("response", {}).get("docs", []) or []
+        except Exception:
+            return []
+
+        accessions = []
+        for doc in docs:
+            if not isinstance(doc, dict):
+                continue
+            acc = doc.get("accessionId")
+            if acc and acc not in accessions:
+                accessions.append(acc)
+            if len(accessions) >= max_studies:
+                break
+
+        for acc in accessions:
+            study = self._fetch_study(acc)
+            if not study:
+                continue
+            for term in study.get("efo_traits", []) or []:
+                efo_id = term.get("efo_id")
+                if not efo_id or efo_id in seen:
+                    continue
+                seen.add(efo_id)
+                candidates.append(
+                    {
+                        "efo_id": efo_id,
+                        "efo_label": term.get("efo_trait") or "",
+                        "study_accession": acc,
+                        "study_reported_trait": study.get("disease_trait") or "",
+                    }
+                )
+        return candidates
+
+    def _fetch_study(self, accession_id: str) -> Optional[Dict[str, Any]]:
+        """Fetch one study record, or None if it cannot be retrieved."""
+        try:
+            resp = requests.get(
+                f"{self.base_url}/v2/studies/{accession_id}", timeout=15
+            )
+            if resp.status_code == 200:
+                study = resp.json()
+                return study if isinstance(study, dict) else None
+        except Exception:
+            pass
+        return None
+
+    def _unresolved_trait_hint(self, disease_trait: str) -> str:
+        """Suffix listing candidate EFO terms found by free-text search."""
+        candidates = self._trait_candidates_from_free_text_search(disease_trait)
+        if not candidates:
+            return ""
+        rendered = "; ".join(
+            f"{c['efo_id']} ({c['efo_label']}) -- from study "
+            f"{c['study_accession']} '{c['study_reported_trait']}'"
+            for c in candidates
+        )
+        return (
+            " GWAS Catalog's own free-text search DOES find studies matching "
+            f"'{disease_trait}'. Candidate EFO terms tagged on them: {rendered}. "
+            "Re-run with efo_id set to whichever of those is the phenotype you "
+            "mean -- this tool will not guess between them for you."
+        )
+
+    @staticmethod
+    def _trait_substitution_note(
+        disease_trait: str, efo_id: str, efo_label: Optional[str], source: str
+    ) -> Optional[str]:
+        """Warn when the resolved EFO label is not the submitted trait."""
+        if not efo_label:
+            return (
+                f"Your trait query '{disease_trait}' was resolved to EFO term "
+                f"'{efo_id}' ({source}); GWAS Catalog returned no label for that "
+                "term, so the substitution could not be verified. Results below "
+                f"describe '{efo_id}', not necessarily '{disease_trait}'."
+            )
+        if efo_label.strip().casefold() == disease_trait.strip().casefold():
+            return None
+        return (
+            f"TRAIT SUBSTITUTION: your query '{disease_trait}' was resolved to "
+            f"EFO term '{efo_id}' whose label is '{efo_label}', which is NOT an "
+            f"exact match for what you asked for ({source}). Every result below "
+            f"describes '{efo_label}'. Confirm that is the phenotype you meant "
+            "before using these associations; if it is not, pass efo_id "
+            "explicitly."
+        )
+
+    def _annotate_trait_resolution(
+        self, result: Dict[str, Any], disease_trait: Optional[str], resolution: Any
+    ) -> None:
+        """Attach resolved EFO id + label + original query to a result."""
+        if not disease_trait or not isinstance(result, dict):
+            return
+        if isinstance(resolution, dict):
+            efo_id = resolution.get("efo_id")
+            efo_label = resolution.get("efo_label")
+            source = resolution.get("source")
+        else:
+            efo_id, efo_label, source = resolution, None, None
+        if not efo_id:
+            return
+        result["query_trait"] = disease_trait
+        result["resolved_efo_id"] = efo_id
+        if not source:
+            # The caller supplied efo_id explicitly; no lookup happened, so
+            # there is no substitution to disclose.
+            result["trait_resolution_source"] = (
+                "efo_id supplied by the caller (the trait text was not used "
+                "to look anything up)"
+            )
+            return
+        result["resolved_efo_label"] = efo_label
+        result["trait_resolution_source"] = source
+        note = self._trait_substitution_note(disease_trait, efo_id, efo_label, source)
+        if note:
+            result["trait_resolution_note"] = note
 
     def _resolve_trait_or_error(
         self, disease_trait: Optional[str], efo_id: Optional[str]
     ) -> Dict[str, Any]:
         """Resolve disease_trait to efo_id if needed.
 
-        Returns {"efo_id": <str>} on success, or {"error": <dict>} when
-        resolution fails and would produce an unfiltered query.
+        Returns {"efo_id": <str>, "efo_label": <str|None>, "source": <str|None>}
+        on success, or {"error": <dict>} when resolution fails and would produce
+        an unfiltered query.
         Callers check ``"error" in result`` and return ``result["error"]``.
         """
         if disease_trait and not efo_id:
-            resolved = self._resolve_trait_to_efo_id(disease_trait)
+            resolved = self._resolve_trait_to_efo(disease_trait)
             if resolved:
-                return {"efo_id": resolved}
+                return dict(resolved)
             return {
                 "error": {
                     "status": "error",
@@ -134,10 +352,11 @@ class GWASRESTTool(BaseTool):
                         "'antidepressant response'). Or provide efo_id directly "
                         "(e.g., 'MONDO_0002009' for major depressive disorder, "
                         "'EFO_0000305' for breast carcinoma)."
+                        + self._unresolved_trait_hint(disease_trait)
                     ),
                 },
             }
-        return {"efo_id": efo_id}
+        return {"efo_id": efo_id, "efo_label": None, "source": None}
 
     @staticmethod
     def _empty_result_note(efo_id: str) -> str:
@@ -183,11 +402,63 @@ class GWASRESTTool(BaseTool):
             "instead, which search by gene rather than by trait term."
         )
 
+    @staticmethod
+    def _filtered_to_empty_note(
+        efo_id: Optional[str],
+        removed: int,
+        threshold: Any,
+        total_elements: Any,
+    ) -> str:
+        """Note for 'empty because a CLIENT-SIDE filter removed every row'.
+
+        Fix-R31-1: this case used to fall through to _empty_result_note, which
+        blames the trait term and tells the caller to try a synonym or a
+        gene-based tool -- advice that is guaranteed useless, because the trait
+        was never the problem. Confirmed live: efo_id=EFO_0004340 (BMI) with
+        p_value=5e-08 returned data=[] together with, in the same payload,
+        pagination.totalElements=23608. The message must name the filter.
+        """
+        subject = f"EFO ID '{efo_id}'" if efo_id else "this query"
+        catalog_total = ""
+        if isinstance(total_elements, int):
+            catalog_total = (
+                f" GWAS Catalog holds {total_elements} association(s) for "
+                f"{subject} in total (see metadata.pagination.totalElements, "
+                "which counts the UNFILTERED set)."
+            )
+        return (
+            f"0 associations returned because the client-side p_value <= "
+            f"{threshold} filter removed all {removed} association(s) fetched "
+            f"for {subject}. The filter removed them -- the trait term is NOT "
+            f"the problem.{catalog_total} Re-run without p_value, or with a "
+            "less strict threshold, to see the associations that do exist. "
+            + _CLIENT_SIDE_FILTER_NOTE
+        )
+
     def _add_empty_result_note(
-        self, result: Dict[str, Any], efo_id: Optional[str]
+        self,
+        result: Dict[str, Any],
+        efo_id: Optional[str],
+        filter_removed: int = 0,
+        filter_threshold: Any = None,
     ) -> None:
-        """Add a suggestion note to result if the data list is empty."""
-        if efo_id and isinstance(result.get("data"), list) and not result["data"]:
+        """Add a suggestion note to result if the data list is empty.
+
+        ``filter_removed`` is the number of rows a client-side filter deleted.
+        When it is non-zero the emptiness is attributed to the filter, not to
+        the trait term (Fix-R31-1).
+        """
+        if not (isinstance(result.get("data"), list) and not result["data"]):
+            return
+        if filter_removed:
+            total_elements = (
+                (result.get("metadata") or {}).get("pagination") or {}
+            ).get("totalElements")
+            result["note"] = self._filtered_to_empty_note(
+                efo_id, filter_removed, filter_threshold, total_elements
+            )
+            return
+        if efo_id:
             result["note"] = self._empty_result_note(efo_id)
 
     def _extract_embedded_data(
@@ -261,10 +532,11 @@ class GWASAssociationSearch(GWASRESTTool):
         # Auto-resolve trait name to efo_id for reliable filtering.
         # Feature-81B-008: if resolution fails, return error instead of silently
         # running an unfiltered search that returns 1M+ unrelated associations.
+        resolution: Optional[Dict[str, Any]] = None
         if disease_trait and not efo_id:
-            resolved = self._resolve_trait_to_efo_id(disease_trait)
-            if resolved:
-                efo_id = resolved
+            resolution = self._resolve_trait_to_efo(disease_trait)
+            if resolution:
+                efo_id = resolution["efo_id"]
             else:
                 return {
                     "status": "error",
@@ -276,6 +548,7 @@ class GWASAssociationSearch(GWASRESTTool):
                         "'coronary artery disease' instead of 'statin response'). "
                         "Or provide efo_id directly (e.g., 'MONDO_0002009' for "
                         "major depressive disorder, 'EFO_0001645' for myocardial infarction)."
+                        + self._unresolved_trait_hint(disease_trait)
                     ),
                 }
 
@@ -294,6 +567,12 @@ class GWASAssociationSearch(GWASRESTTool):
         if accession_id:
             params["accession_id"] = accession_id
 
+        p_threshold = self._coerce_float(
+            arguments.get("p_value")
+            if arguments.get("p_value") is not None
+            else arguments.get("p_value_threshold")
+        )
+
         sort = self._coerce_str(arguments.get("sort"))
         direction = self._coerce_str(arguments.get("direction"))
         # The API returns associations UNSORTED by default, so a plain
@@ -311,10 +590,41 @@ class GWASAssociationSearch(GWASRESTTool):
             sort = "p_value"
             if not direction:
                 direction = "asc"
-        if sort:
-            params["sort"] = sort
-        if direction:
-            params["direction"] = direction
+
+        # Fix-R31-1: defaulting the sort is not enough. When the caller asks
+        # for direction=desc AND a p_value threshold, page 0 holds the LEAST
+        # significant rows, so the client-side filter deletes every one of
+        # them and the tool reports "no associations for this trait" for a
+        # trait with tens of thousands of them (EFO_0004340 / BMI: data=[]
+        # alongside pagination.totalElements=23608). Since the API cannot do
+        # the filtering (see _CLIENT_SIDE_FILTER_NOTE), fetch the page in
+        # p_value-ascending order whenever a threshold is present and the
+        # caller is sorting by p_value, then present the surviving rows in
+        # the direction the caller actually asked for. Any other sort field
+        # (or_value, beta_num, ...) is left exactly as requested.
+        fetch_sort, fetch_direction = sort, direction
+        sort_override: Optional[Dict[str, Any]] = None
+        if p_threshold is not None and sort == "p_value":
+            fetch_sort = "p_value"
+            if direction and direction != "asc":
+                sort_override = {
+                    "requested_sort": sort,
+                    "requested_direction": direction,
+                    "fetched_sort": "p_value",
+                    "fetched_direction": "asc",
+                    "reason": (
+                        "A p_value threshold can only be honoured by scanning "
+                        "the most-significant end of the result set; the page "
+                        "was fetched p_value-ascending and the surviving rows "
+                        f"were re-ordered '{direction}' for you."
+                    ),
+                }
+            fetch_direction = "asc"
+
+        if fetch_sort:
+            params["sort"] = fetch_sort
+        if fetch_direction:
+            params["direction"] = fetch_direction
 
         size = self._coerce_int(arguments.get("size") or arguments.get("limit"))
         if size is not None:
@@ -338,28 +648,121 @@ class GWASAssociationSearch(GWASRESTTool):
         data = self._make_request(self.endpoint, params)
         result = self._extract_embedded_data(data, "associations")
 
-        # Client-side p_value filter (GWAS Catalog API does not support server-side p-value filtering)
-        p_threshold = arguments.get("p_value") or arguments.get("p_value_threshold")
+        removed = 0
         if p_threshold is not None and result.get("status") == "success":
-            try:
-                p_threshold = float(p_threshold)
-                assocs = result.get("data", [])
-                if isinstance(assocs, list):
-                    filtered = [
-                        a
-                        for a in assocs
-                        if a.get("p_value") is not None
-                        and float(a["p_value"]) <= p_threshold
-                    ]
-                    result["data"] = filtered
-                    result.setdefault("metadata", {})["p_value_filter"] = p_threshold
-                    result["metadata"]["filtered_count"] = len(filtered)
-                    result["metadata"]["total_before_filter"] = len(assocs)
-            except (ValueError, TypeError):
-                pass
+            removed = self._apply_client_side_p_value_filter(
+                result,
+                p_threshold=p_threshold,
+                params=params,
+                prefix_scan=(fetch_sort == "p_value" and fetch_direction == "asc"),
+                sort_override=sort_override,
+            )
 
-        self._add_empty_result_note(result, efo_id)
+        self._add_empty_result_note(
+            result, efo_id, filter_removed=removed, filter_threshold=p_threshold
+        )
+        # Fix-R31-2: surface the resolved EFO term's label and the caller's
+        # original query string so a trait substitution is visible.
+        self._annotate_trait_resolution(result, disease_trait, resolution)
         return result
+
+    def _apply_client_side_p_value_filter(
+        self,
+        result: Dict[str, Any],
+        p_threshold: float,
+        params: Dict[str, Any],
+        prefix_scan: bool,
+        sort_override: Optional[Dict[str, Any]],
+    ) -> int:
+        """Apply the p_value threshold client-side and disclose that it was.
+
+        Returns the number of rows removed. Also records, in ``metadata``:
+
+        * ``p_value_filter_scope`` / ``p_value_filter_note`` -- the filter is
+          client-side, so its result is a property of *this page*, not of the
+          trait (Fix-R31-1).
+        * ``pagination_totals_are_prefilter`` -- ``pagination.totalElements``
+          and ``pagination.totalPages`` keep their existing (UNFILTERED)
+          meaning; this flag plus ``filtered_total`` say so explicitly rather
+          than re-meaning an established key.
+        * ``filtered_total`` / ``filtered_total_is_exact`` -- how many rows in
+          the whole result set pass the threshold, when that is knowable.
+        """
+        assocs = result.get("data")
+        if not isinstance(assocs, list):
+            return 0
+
+        kept: List[Any] = []
+        removed_over_threshold = 0
+        removed_missing_p = 0
+        for assoc in assocs:
+            p_value = (
+                self._coerce_float(assoc.get("p_value"))
+                if isinstance(assoc, dict)
+                else None
+            )
+            if p_value is None:
+                removed_missing_p += 1
+                continue
+            if p_value <= p_threshold:
+                kept.append(assoc)
+            else:
+                removed_over_threshold += 1
+
+        if sort_override:
+            # Present the surviving rows in the direction the caller asked for.
+            kept.sort(
+                key=lambda a: self._coerce_float(a.get("p_value")) or 0.0,
+                reverse=True,
+            )
+
+        result["data"] = kept
+        metadata = result.setdefault("metadata", {})
+        metadata["p_value_filter"] = p_threshold
+        metadata["filtered_count"] = len(kept)
+        metadata["total_before_filter"] = len(assocs)
+        metadata["p_value_filter_scope"] = "client-side (applied to the fetched page)"
+        metadata["p_value_filter_note"] = _CLIENT_SIDE_FILTER_NOTE
+        metadata["pagination_totals_are_prefilter"] = True
+        if sort_override:
+            metadata["sort_override"] = sort_override
+
+        pagination = metadata.get("pagination") or {}
+        page_size = self._coerce_int(pagination.get("size")) or self._coerce_int(
+            params.get("size")
+        )
+        page_number = self._coerce_int(pagination.get("number"))
+        if page_number is None:
+            page_number = self._coerce_int(params.get("page")) or 0
+        rows_before_this_page = (page_size or 0) * page_number
+
+        # With the page fetched p_value-ascending, the rows that pass the
+        # threshold are a PREFIX of the full ordering. So if this page contains
+        # the crossover (i.e. some row failed), everything after it fails too
+        # and the filtered total is known exactly.
+        if prefix_scan and removed_over_threshold > 0 and removed_missing_p == 0:
+            metadata["filtered_total"] = rows_before_this_page + len(kept)
+            metadata["filtered_total_is_exact"] = True
+            metadata["filtered_total_note"] = (
+                f"{metadata['filtered_total']} association(s) in the whole "
+                f"result set pass p_value <= {p_threshold}. "
+                "pagination.totalElements / totalPages below keep their "
+                "original meaning and describe the UNFILTERED set "
+                f"({pagination.get('totalElements')} element(s)), so they will "
+                "not match the number of rows returned."
+            )
+        else:
+            metadata["filtered_total"] = None
+            metadata["filtered_total_is_exact"] = False
+            if prefix_scan:
+                metadata["filtered_total_at_least"] = rows_before_this_page + len(kept)
+            metadata["filtered_total_note"] = (
+                "The number of associations passing the threshold across the "
+                "WHOLE result set is not known from this single page. "
+                "pagination.totalElements / totalPages below describe the "
+                "UNFILTERED set and are unaffected by p_value."
+            )
+        return removed_over_threshold + removed_missing_p
 
 
 @register_tool("GWASStudySearch")
@@ -552,9 +955,9 @@ class GWASVariantsForTrait(GWASRESTTool):
 
         data = self._make_request(self.endpoint, params)
         result = self._extract_embedded_data(data, "associations")
-        if efo_id and disease_trait:
-            result["resolved_efo_id"] = efo_id
         self._add_empty_result_note(result, efo_id)
+        if efo_id and disease_trait:
+            self._annotate_trait_resolution(result, disease_trait, resolution)
         return result
 
 
@@ -605,9 +1008,9 @@ class GWASAssociationsForTrait(GWASRESTTool):
 
         data = self._make_request(self.endpoint, params)
         result = self._extract_embedded_data(data, "associations")
-        if efo_id and disease_trait:
-            result["resolved_efo_id"] = efo_id
         self._add_empty_result_note(result, efo_id)
+        if efo_id and disease_trait:
+            self._annotate_trait_resolution(result, disease_trait, resolution)
         return result
 
 

--- a/src/tooluniverse/hpa_tool.py
+++ b/src/tooluniverse/hpa_tool.py
@@ -12,6 +12,456 @@ HPA_BASE = "https://www.proteinatlas.org"
 HPA_JSON_API_TEMPLATE = "https://www.proteinatlas.org/{ensembl_id}.json"
 HPA_XML_API_TEMPLATE = "https://www.proteinatlas.org/{ensembl_id}.xml"
 
+# ---------------------------------------------------------------------------
+# HPA download-column catalogue
+# ---------------------------------------------------------------------------
+# search_download.php SILENTLY DROPS any column code it does not recognise: an
+# unknown code and a gene with no data produce byte-identical responses. Every
+# code below is an exact `data-abbr` value scraped from
+# https://www.proteinatlas.org/search and re-verified against the live API.
+# Do not invent codes here -- a wrong one is indistinguishable from "no data"
+# and gets blamed on the caller's input.
+#
+# Fix-R31: several previously-mapped names had no matching column, e.g.
+#   ?columns=g,eg,t_RNA_skin,t_RNA_skin_1,t_RNA_liver  ->
+#   {"Gene":"NCSTN","Tissue RNA - liver [nTPM]":"48.9",
+#    "Tissue RNA - skin 1 [nTPM]":"34.4"}       <- no "skin" key at all
+# so 'skin' was reported as an unrecognised tissue name for every gene that is
+# not skin-enriched. Likewise `rnascm`/`rnablm` are not column codes at all
+# (the real ones are `rnascsm`/`rnabcsm`), so source_type single_cell and blood
+# never returned anything.
+
+# t_RNA_<x> -> "Tissue RNA - <x> [nTPM]" (consensus tissue panel, 51 tissues)
+HPA_TISSUE_RNA_COLUMNS = (
+    "adipose_tissue",
+    "adrenal_gland",
+    "amygdala",
+    "appendix",
+    "basal_ganglia",
+    "blood_vessel",
+    "bone_marrow",
+    "breast",
+    "cerebellum",
+    "cerebral_cortex",
+    "cervix",
+    "choroid_plexus",
+    "colon",
+    "duodenum",
+    "endometrium_1",
+    "epididymis",
+    "esophagus",
+    "fallopian_tube",
+    "gallbladder",
+    "heart_muscle",
+    "hippocampal_formation",
+    "hypothalamus",
+    "kidney",
+    "liver",
+    "lung",
+    "lymph_node",
+    "midbrain",
+    "ovary",
+    "pancreas",
+    "parathyroid_gland",
+    "pituitary_gland",
+    "placenta",
+    "prostate",
+    "rectum",
+    "retina",
+    "salivary_gland",
+    "seminal_vesicle",
+    "skeletal_muscle",
+    "skin_1",
+    "small_intestine",
+    "smooth_muscle",
+    "spinal_cord",
+    "spleen",
+    "stomach_1",
+    "testis",
+    "thymus",
+    "thyroid_gland",
+    "tongue",
+    "tonsil",
+    "urinary_bladder",
+    "vagina",
+)
+
+# brain_RNA_<x> -> "Brain RNA - <x> [nTPM]"
+HPA_BRAIN_RNA_COLUMNS = (
+    "amygdala",
+    "basal_ganglia",
+    "cerebellum",
+    "cerebral_cortex",
+    "choroid_plexus",
+    "hippocampal_formation",
+    "hypothalamus",
+    "medulla_oblongata",
+    "midbrain",
+    "pons",
+    "spinal_cord",
+    "thalamus",
+    "white_matter",
+)
+
+# blood_RNA_<x> -> "Blood RNA - <x> [nTPM]".  HPA's blood atlas publishes
+# immune cell *subsets*; there is no aggregate "T-cell"/"B-cell"/"monocyte"
+# column, hence the fan-out aliases below.
+HPA_BLOOD_RNA_COLUMNS = (
+    "basophil",
+    "classical_monocyte",
+    "eosinophil",
+    "gdT-cell",
+    "intermediate_monocyte",
+    "MAIT_T-cell",
+    "memory_B-cell",
+    "memory_CD4_T-cell",
+    "memory_CD8_T-cell",
+    "myeloid_DC",
+    "naive_B-cell",
+    "naive_CD4_T-cell",
+    "naive_CD8_T-cell",
+    "neutrophil",
+    "NK-cell",
+    "non-classical_monocyte",
+    "plasmacytoid_DC",
+    "T-reg",
+    "total_PBMC",
+)
+
+# sc_RNA_<x> -> "Single Cell Type RNA - <x> [nCPM]".  Note the unit: single
+# cell data is nCPM, NOT nTPM.  Codes are case-sensitive (sc_RNA_hepatocytes
+# is dropped, sc_RNA_Hepatocytes is not).
+HPA_SINGLE_CELL_RNA_COLUMNS = (
+    "Adipocytes",
+    "Adrenal_cortex_cells",
+    "Adrenal_medulla_cells",
+    "Alveolar_cells_type_1",
+    "Alveolar_cells_type_2",
+    "Astrocytes",
+    "B-cells",
+    "Basal_keratinocytes",
+    "Basal_prostatic_cells",
+    "Bergmann_glia",
+    "Brain_excitatory_neurons",
+    "Brain_inhibitory_neurons",
+    "Breast_hormone-responsive_cells",
+    "Breast_lactating_cells",
+    "Breast_myoepithelial_cells",
+    "Breast_secretory_cells",
+    "Cardiomyocytes",
+    "cDC",
+    "Cholangiocytes",
+    "Choroid_plexus_epithelial_cells",
+    "Colonocytes",
+    "Cone_photoreceptor_cells",
+    "Conjunctival_goblet_cells",
+    "Corticotrophs",
+    "Cytotrophoblasts",
+    "Decidual_stromal_cells",
+    "Differentiating_spermatogonia",
+    "Distal_convoluted_tubule_cells",
+    "Early_primary_spermatocytes",
+    "Early_spermatids",
+    "Endometrial_ciliated_cells",
+    "Endometrial_glandular_cells",
+    "Endometrial_luminal_cells",
+    "Endometrial_secretory_cells",
+    "Endometrial_stromal_cells",
+    "Enteric_stem_cells",
+    "Enteric_transient_amplifying_cells",
+    "Enterocytes",
+    "Ependymal_cells",
+    "Epicardial_cells",
+    "Epididymal_basal_cells",
+    "Epididymal_clear_cells",
+    "Epididymal_efferent_duct_absorptive_cells",
+    "Epididymal_efferent_duct_ciliated_cells",
+    "Epididymal_principal_cells",
+    "Erythrocyte_progenitors",
+    "Erythrocytes",
+    "Esophageal_apical_cells",
+    "Esophageal_basal_cells",
+    "Esophageal_suprabasal_cells",
+    "Extravillous_trophoblasts",
+    "Fallopian_secretory_cells",
+    "Fallopian_tube_ciliated_cells",
+    "Fibro-adipogenic_progenitors",
+    "Fibroblasts",
+    "Foveolar_cells",
+    "Gastric_chief_cells",
+    "Gastric_progenitor_cells",
+    "Goblet_cells",
+    "Gonadotrophs",
+    "Granulosa_cells",
+    "Hematopoietic_stem_cells",
+    "Hepatic_stellate_cells",
+    "Hepatocytes",
+    "Hofbauer_cells",
+    "Innate_lymphoid_cells",
+    "Kupffer_cells",
+    "Lacrimal_acinar_cells",
+    "Lactotrophs",
+    "Late_primary_spermatocytes",
+    "Late_spermatids",
+    "Leydig_cells",
+    "Loop_of_henle_epithelial_cells",
+    "Lymphatic_endothelial_cells",
+    "Macrophages",
+    "Mast_cells",
+    "Medullary_thymic_epithelial_cells",
+    "Megakaryocyte-Erythroid_progenitors",
+    "Megakaryocyte_progenitors",
+    "Megakaryocytes",
+    "Melanocytes",
+    "Mesothelial_cells",
+    "Microglia",
+    "Migrating_cytotrophoblasts",
+    "Monocyte_progenitors",
+    "monocytes",
+    "Mucous_neck_cells",
+    "Müller_glia",
+    "Myonuclei",
+    "Myosatellite_cells",
+    "Neuroendocrine_cells",
+    "Neutrophil_progenitors",
+    "Neutrophils",
+    "NK-cells",
+    "Ocular_epithelial_cells",
+    "Oligodendrocyte_progenitor_cells",
+    "Oligodendrocytes",
+    "Oocytes",
+    "Other_brain_neurons",
+    "Ovarian_stromal_cells",
+    "Pancreatic_acinar_cells",
+    "Pancreatic_duct_cells",
+    "Pancreatic_islet_cells",
+    "Paneth_cells",
+    "Papillary_tip_epithelial_cells",
+    "Parietal_cells",
+    "pDCs",
+    "Pericytes",
+    "Peritubular_myoid_cells",
+    "Pituicytes/FSCs",
+    "Pituitary_stem_cells",
+    "Plasma_cells",
+    "Platelets",
+    "Podocytes",
+    "Prostatic_club_cells",
+    "Prostatic_glandular_cells",
+    "Prostatic_hillock_cells",
+    "Proximal_tubule_cells",
+    "Renal_collecting_duct_intercalated_cells",
+    "Renal_collecting_duct_principal_cells",
+    "Renal_connecting_tubule_cells",
+    "Respiratory_basal_cells",
+    "Respiratory_ciliated_cells",
+    "Respiratory_deuterosomal_cells",
+    "Respiratory_ionocytes",
+    "Respiratory_secretory_cells",
+    "Retinal_amacrine_cells",
+    "Retinal_bipolar_cells",
+    "Retinal_ganglion_cells",
+    "Retinal_horizontal_cells",
+    "Retinal_pigment_epithelial_cells",
+    "Rod_photoreceptor_cells",
+    "Salivary_acinar_cells",
+    "Salivary_basal_cells",
+    "Salivary_duct_cells",
+    "Salivary_ionocytes",
+    "Salivary_myoepithelial_cells",
+    "Schwann_cells",
+    "Sertoli_cells",
+    "Smooth_muscle_cells",
+    "Somatotrophs",
+    "Submucosal_glandular_cells",
+    "Suprabasal_keratinocytes",
+    "Syncytiotrophoblasts",
+    "T-cells",
+    "Thymic_myoid_cells",
+    "Thymocytes",
+    "Thyrotrophs",
+    "Transitional_alveolar_cells",
+    "Tuft_cells",
+    "Undifferentiated_spermatogonia",
+    "Urothelial_cells",
+    "Vascular_endothelial_cells",
+    "Vascular_smooth_muscle_cells",
+)
+
+
+def hpa_slug(name: Any) -> str:
+    """Normalise a tissue/cell-type name or column suffix to a comparison key.
+
+    'Skin 1' / 'skin_1' -> 'skin_1'; 'T-reg' -> 't_reg'; 'Muller glia' and
+    'Müller_glia' both collapse to 'm_ller_glia'.
+    """
+    return re.sub(r"[^a-z0-9]+", "_", str(name).strip().lower()).strip("_")
+
+
+def _column_alias_map(
+    columns: tuple[str, ...],
+    extra: dict[str, list[str]] | None = None,
+    singularize: bool = False,
+) -> dict[str, list[str]]:
+    """Build {caller-supplied name -> [exact HPA column suffixes]}.
+
+    Every column is registered under its own slug. `singularize` additionally
+    registers a singular alias for plural columns ('Hepatocytes' ->
+    'hepatocyte'), which is only sensible for the single cell catalogue.
+    `extra` adds hand-written aliases and always wins.
+    """
+    aliases: dict[str, list[str]] = {}
+    for column in columns:
+        aliases.setdefault(hpa_slug(column), [column])
+    if singularize:
+        for column in columns:
+            slug = hpa_slug(column)
+            if slug.endswith("s") and not slug.endswith("ss"):
+                aliases.setdefault(slug[:-1], [column])
+    for name, targets in (extra or {}).items():
+        aliases[hpa_slug(name)] = list(targets)
+    return aliases
+
+
+# Names HPA once published (or that callers reasonably try) for which HPA has
+# NO RNA column at all -- verified live: every one of
+# t_RNA_bronchus / t_RNA_nasopharynx / t_RNA_oral_mucosa / t_RNA_soft_tissue /
+# brain_RNA_brainstem is dropped from the response. Reporting them as valid
+# source names produced a permanent, unexplained "N/A".
+HPA_UNAVAILABLE_SOURCES = {
+    "tissue": {
+        "bronchus": "HPA covers bronchus only in its protein/IHC tissue atlas; there is no consensus RNA nTPM column for it. Closest RNA tissues: 'lung'.",
+        "nasopharynx": "HPA covers nasopharynx only in its protein/IHC tissue atlas; there is no consensus RNA nTPM column for it.",
+        "oral_mucosa": "HPA covers oral mucosa only in its protein/IHC tissue atlas; there is no consensus RNA nTPM column for it. Closest RNA tissues: 'esophagus', 'tongue'.",
+        "soft_tissue": "HPA covers soft tissue only in its protein/IHC tissue atlas; there is no consensus RNA nTPM column for it. Closest RNA tissues: 'adipose_tissue', 'smooth_muscle'.",
+    },
+    "brain": {
+        "brainstem": "HPA's brain atlas has no 'brainstem' column; query its components instead: 'medulla_oblongata', 'pons', 'midbrain'.",
+    },
+    "blood": {},
+    "single_cell": {},
+}
+
+HPA_TISSUE_COLUMN_ALIASES = _column_alias_map(
+    HPA_TISSUE_RNA_COLUMNS,
+    {
+        # HPA suffixes its two re-sampled tissues with "_1"; callers say the
+        # bare organ name.
+        "skin": ["skin_1"],
+        "stomach": ["stomach_1"],
+        "endometrium": ["endometrium_1"],
+        "hippocampus": ["hippocampal_formation"],
+        "heart": ["heart_muscle"],
+        "muscle": ["skeletal_muscle"],
+        "brain": ["cerebral_cortex"],
+        "cortex": ["cerebral_cortex"],
+        "fat": ["adipose_tissue"],
+        "adrenal": ["adrenal_gland"],
+        "thyroid": ["thyroid_gland"],
+        "pituitary": ["pituitary_gland"],
+        "parathyroid": ["parathyroid_gland"],
+        "salivary": ["salivary_gland"],
+        "bladder": ["urinary_bladder"],
+        "oesophagus": ["esophagus"],
+        "gut": ["small_intestine"],
+    },
+)
+
+HPA_BRAIN_COLUMN_ALIASES = _column_alias_map(
+    HPA_BRAIN_RNA_COLUMNS,
+    {
+        "hippocampus": ["hippocampal_formation"],
+        "cortex": ["cerebral_cortex"],
+        "striatum": ["basal_ganglia"],
+    },
+)
+
+HPA_BLOOD_COLUMN_ALIASES = _column_alias_map(
+    HPA_BLOOD_RNA_COLUMNS,
+    {
+        # No aggregate lineage columns exist -- fan out to the subsets HPA
+        # actually publishes, most-representative first.
+        "t_cell": [
+            "T-reg",
+            "naive_CD4_T-cell",
+            "memory_CD4_T-cell",
+            "naive_CD8_T-cell",
+            "memory_CD8_T-cell",
+            "MAIT_T-cell",
+            "gdT-cell",
+        ],
+        "b_cell": ["naive_B-cell", "memory_B-cell"],
+        "nk_cell": ["NK-cell"],
+        "monocyte": [
+            "classical_monocyte",
+            "intermediate_monocyte",
+            "non-classical_monocyte",
+        ],
+        "dendritic_cell": ["myeloid_DC", "plasmacytoid_DC"],
+        "pbmc": ["total_PBMC"],
+    },
+)
+
+HPA_SINGLE_CELL_COLUMN_ALIASES = _column_alias_map(
+    HPA_SINGLE_CELL_RNA_COLUMNS,
+    {
+        "t_cell": ["T-cells"],
+        "b_cell": ["B-cells"],
+        "nk_cell": ["NK-cells"],
+        "neuron": [
+            "Brain_excitatory_neurons",
+            "Brain_inhibitory_neurons",
+            "Other_brain_neurons",
+        ],
+        "keratinocyte": ["Basal_keratinocytes", "Suprabasal_keratinocytes"],
+        "dendritic_cell": ["cDC", "pDCs"],
+    },
+    singularize=True,
+)
+
+# source_type -> column prefix, unit, alias map and the canonical HPA names
+# (used for error messages -- the alias map also holds synonyms and would make
+# the list several times longer than the catalogue it describes).  The unit is
+# HPA's, not a guess: sc_RNA_* columns are labelled [nCPM], the rest [nTPM].
+HPA_SOURCE_COLUMNS: dict[str, dict[str, Any]] = {
+    "tissue": {
+        "prefix": "t_RNA_",
+        "unit": "nTPM",
+        "aliases": HPA_TISSUE_COLUMN_ALIASES,
+        "canonical": HPA_TISSUE_RNA_COLUMNS,
+    },
+    "blood": {
+        "prefix": "blood_RNA_",
+        "unit": "nTPM",
+        "aliases": HPA_BLOOD_COLUMN_ALIASES,
+        "canonical": HPA_BLOOD_RNA_COLUMNS,
+    },
+    "brain": {
+        "prefix": "brain_RNA_",
+        "unit": "nTPM",
+        "aliases": HPA_BRAIN_COLUMN_ALIASES,
+        "canonical": HPA_BRAIN_RNA_COLUMNS,
+    },
+    "single_cell": {
+        "prefix": "sc_RNA_",
+        "unit": "nCPM",
+        "aliases": HPA_SINGLE_CELL_COLUMN_ALIASES,
+        "canonical": HPA_SINGLE_CELL_RNA_COLUMNS,
+    },
+}
+
+
+def hpa_unit_from_column_label(label: Any, default: str = "") -> str:
+    """Read the unit out of an HPA column header.
+
+    'Single Cell Type RNA - Hepatocytes [nCPM]' -> 'nCPM'.  Never hard-code
+    the unit: HPA reports single cell data in nCPM and everything else in
+    nTPM, and mislabelling silently changes the meaning of the number.
+    """
+    match = re.search(r"\[([^\[\]]+)\]\s*$", str(label or ""))
+    return match.group(1).strip() if match else default
+
+
 # --- Base Tool Classes ---
 
 
@@ -258,7 +708,13 @@ class HPAGetRnaExpressionBySourceTool(HPASearchApiTool):
 
     def __init__(self, tool_config):
         super().__init__(tool_config)
-        # Use correct HPA API column identifiers
+        # Aggregate "*specific nTPM" enrichment-summary columns, kept only as a
+        # last-resort fallback. NOTE: of these four codes only `rnatsm` is a
+        # real HPA column -- `rnablm`/`rnabrm`/`rnascm` are silently dropped
+        # (the real codes are `rnabcsm`/`rnabrsm`/`rnascsm`). They are left
+        # verbatim for backwards compatibility; the per-source columns below
+        # are what actually answer a query, and they carry a value for every
+        # gene rather than only the ones HPA classifies as enriched.
         self.source_column_mappings = {
             "tissue": "rnatsm",  # RNA tissue specific nTPM
             "blood": "rnablm",  # RNA blood lineage specific nTPM
@@ -266,20 +722,20 @@ class HPAGetRnaExpressionBySourceTool(HPASearchApiTool):
             "single_cell": "rnascm",  # RNA single cell type specific nTPM
         }
 
-        # Fix-R4A-2: the aggregate "*specific nTPM" columns above are populated
-        # only for genes HPA classifies as enriched in that source type, and
-        # "rnabrm" is not a valid HPA column at all -- HPA silently drops
-        # unknown columns, so every brain query returned "N/A" with
-        # status "success". Confirmed live: ?columns=g,rnabrm returns
-        # {"Gene":"GFAP"} with no data column, while
-        # ?columns=g,brain_RNA_thalamus returns 14782.4 nTPM. HPA exposes a
-        # per-source column for each source name; query that first and only
-        # fall back to the aggregate column if it yields nothing.
+        # Fix-R4A-2 / Fix-R31: HPA silently drops unknown column codes, so a
+        # bad code is indistinguishable from "no data" and the tool ended up
+        # blaming the caller's source name. Prefixes and the per-source-name
+        # column catalogue now come from HPA's published `data-abbr` list (see
+        # the module header), so `single_cell` and `blood` return real numbers
+        # instead of a permanent N/A.
         self.source_column_prefixes = {
-            "tissue": "t_RNA_",
-            "blood": "blood_RNA_",
-            "brain": "brain_RNA_",
-            "single_cell": "sc_RNA_",
+            key: spec["prefix"] for key, spec in HPA_SOURCE_COLUMNS.items()
+        }
+
+        # HPA's unit differs per source family: single cell is nCPM, the rest
+        # are nTPM. Never hard-code one unit for all of them.
+        self.source_units = {
+            key: spec["unit"] for key, spec in HPA_SOURCE_COLUMNS.items()
         }
 
         self.api_response_fields = {
@@ -289,89 +745,20 @@ class HPAGetRnaExpressionBySourceTool(HPASearchApiTool):
             "single_cell": "RNA single cell type specific nTPM",
         }
 
-        # Map source names to expected keys in API response
+        # source_name -> the exact HPA column suffixes it resolves to. Values
+        # are real column codes, not free-text guesses.
         self.source_name_mappings = {
-            "tissue": {
-                "adipose_tissue": ["adipose tissue", "fat"],
-                "adrenal_gland": ["adrenal gland", "adrenal"],
-                "appendix": ["appendix"],
-                "bone_marrow": ["bone marrow"],
-                "brain": ["brain", "cerebral cortex"],
-                "breast": ["breast"],
-                "bronchus": ["bronchus"],
-                "cerebellum": ["cerebellum"],
-                "cerebral_cortex": ["cerebral cortex", "brain"],
-                "cervix": ["cervix"],
-                "choroid_plexus": ["choroid plexus"],
-                "colon": ["colon"],
-                "duodenum": ["duodenum"],
-                "endometrium": ["endometrium"],
-                "epididymis": ["epididymis"],
-                "esophagus": ["esophagus"],
-                "fallopian_tube": ["fallopian tube"],
-                "gallbladder": ["gallbladder"],
-                "heart_muscle": ["heart muscle", "heart"],
-                "hippocampal_formation": ["hippocampus", "hippocampal formation"],
-                "hypothalamus": ["hypothalamus"],
-                "kidney": ["kidney"],
-                "liver": ["liver"],
-                "lung": ["lung"],
-                "lymph_node": ["lymph node"],
-                "nasopharynx": ["nasopharynx"],
-                "oral_mucosa": ["oral mucosa"],
-                "ovary": ["ovary"],
-                "pancreas": ["pancreas"],
-                "parathyroid_gland": ["parathyroid gland"],
-                "pituitary_gland": ["pituitary gland"],
-                "placenta": ["placenta"],
-                "prostate": ["prostate"],
-                "rectum": ["rectum"],
-                "retina": ["retina"],
-                "salivary_gland": ["salivary gland"],
-                "seminal_vesicle": ["seminal vesicle"],
-                "skeletal_muscle": ["skeletal muscle"],
-                "skin": ["skin"],
-                "small_intestine": ["small intestine"],
-                "smooth_muscle": ["smooth muscle"],
-                "soft_tissue": ["soft tissue"],
-                "spleen": ["spleen"],
-                "stomach": ["stomach"],
-                "testis": ["testis"],
-                "thymus": ["thymus"],
-                "thyroid_gland": ["thyroid gland"],
-                "tongue": ["tongue"],
-                "tonsil": ["tonsil"],
-                "urinary_bladder": ["urinary bladder"],
-                "vagina": ["vagina"],
-            },
-            "blood": {
-                "t_cell": ["t-cell", "t cell"],
-                "b_cell": ["b-cell", "b cell"],
-                "nk_cell": ["nk-cell", "nk cell", "natural killer"],
-                "monocyte": ["monocyte"],
-                "neutrophil": ["neutrophil"],
-                "eosinophil": ["eosinophil"],
-                "basophil": ["basophil"],
-                "dendritic_cell": ["dendritic cell"],
-            },
-            "brain": {
-                "cerebellum": ["cerebellum"],
-                "cerebral_cortex": ["cerebral cortex", "cortex"],
-                "hippocampus": ["hippocampus", "hippocampal formation"],
-                "hypothalamus": ["hypothalamus"],
-                "amygdala": ["amygdala"],
-                "brainstem": ["brainstem", "brain stem"],
-                "thalamus": ["thalamus"],
-            },
-            "single_cell": {
-                "t_cell": ["t-cell", "t cell"],
-                "b_cell": ["b-cell", "b cell"],
-                "hepatocyte": ["hepatocyte"],
-                "neuron": ["neuron"],
-                "astrocyte": ["astrocyte"],
-                "fibroblast": ["fibroblast"],
-            },
+            key: spec["aliases"] for key, spec in HPA_SOURCE_COLUMNS.items()
         }
+
+        # The canonical HPA names behind those aliases, for error messages.
+        self.source_canonical_names = {
+            key: sorted(spec["canonical"], key=str.lower)
+            for key, spec in HPA_SOURCE_COLUMNS.items()
+        }
+
+        # source_name -> why HPA cannot answer it at all (it has no RNA column).
+        self.unavailable_sources = HPA_UNAVAILABLE_SOURCES
 
     @staticmethod
     def _categorize_expression(expression_value):
@@ -393,7 +780,12 @@ class HPAGetRnaExpressionBySourceTool(HPASearchApiTool):
         return "very low"
 
     def _query_source_column(self, gene_name, source_type, candidate_names):
-        """Fetch a single source's value from its dedicated HPA column.
+        """Fetch a source's value from its dedicated HPA column.
+
+        `candidate_names` are exact HPA column suffixes, most-representative
+        first; they are requested in a single call (HPA drops the ones it does
+        not know without failing the request) and the first candidate that
+        carries a value wins.
 
         Returns (value, column_label) or (None, None) when HPA has no such
         column or no value for this gene.
@@ -402,33 +794,56 @@ class HPAGetRnaExpressionBySourceTool(HPASearchApiTool):
         if not prefix:
             return None, None
 
+        columns = []
         for candidate in candidate_names:
             if not candidate:
                 continue
             column = prefix + str(candidate).strip().replace(" ", "_")
-            try:
-                response = self._make_api_request(gene_name, f"g,{column}")
-            except Exception:
-                continue
-            if not response or isinstance(response, dict):
-                continue
+            if column not in columns:
+                columns.append(column)
+        if not columns:
+            return None, None
 
-            # HPA's search matches synonyms too (search=GFAP also returns
-            # HGFAC), so pick the row whose Gene actually equals the query.
-            row = next(
-                (
-                    r
-                    for r in response
-                    if str(r.get("Gene", "")).upper() == gene_name.upper()
-                ),
-                response[0],
-            )
-            for key, value in row.items():
-                # HPA labels the column e.g. "Brain RNA - thalamus [nTPM]".
-                if " RNA - " not in key:
-                    continue
-                if value not in (None, "", "N/A"):
-                    return value, key
+        try:
+            response = self._make_api_request(gene_name, ",".join(["g"] + columns))
+        except Exception:
+            return None, None
+        if not response or isinstance(response, dict):
+            return None, None
+
+        # HPA's search matches synonyms too (search=GFAP also returns HGFAC),
+        # so pick the row whose Gene actually equals the query.
+        row = next(
+            (
+                r
+                for r in response
+                if str(r.get("Gene", "")).upper() == str(gene_name).upper()
+            ),
+            response[0],
+        )
+
+        # HPA labels the columns e.g. "Brain RNA - thalamus [nTPM]" or
+        # "Single Cell Type RNA - Hepatocytes [nCPM]"; match the part after
+        # " RNA - " back to the requested suffix.
+        by_slug = {}
+        for key, value in row.items():
+            if " RNA - " not in key:
+                continue
+            source_label = key.split(" RNA - ", 1)[1]
+            source_label = re.sub(r"\s*\[[^\[\]]*\]\s*$", "", source_label)
+            by_slug.setdefault(hpa_slug(source_label), (value, key))
+
+        for candidate in candidate_names:
+            hit = by_slug.get(hpa_slug(candidate))
+            if hit and hit[0] not in (None, "", "N/A"):
+                return hit
+
+        # Lenient fallback: HPA returned a per-source column we could not tie
+        # back to a candidate name (renamed column). Use it rather than
+        # reporting "no data" for a value HPA clearly published.
+        for value, key in by_slug.values():
+            if value not in (None, "", "N/A"):
+                return value, key
         return None, None
 
     def run(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
@@ -464,9 +879,24 @@ class HPAGetRnaExpressionBySourceTool(HPASearchApiTool):
                 },
             }
 
+        # Names HPA does not publish an RNA column for at all: say so
+        # explicitly instead of returning a permanent, unexplained "N/A".
+        unavailable = self.unavailable_sources.get(source_type, {})
+        if source_name in unavailable:
+            return {
+                "status": "error",
+                "data": {
+                    "error": (
+                        f"HPA has no RNA expression column for source_name "
+                        f"'{source_name}' (source_type '{source_type}'). "
+                        + unavailable[source_name]
+                    )
+                },
+            }
+
         # Enhanced validation with intelligent recommendations
         if source_name not in self.source_name_mappings[source_type]:
-            available_sources = list(self.source_name_mappings[source_type].keys())
+            available_sources = sorted(self.source_name_mappings[source_type].keys())
 
             # Find similar source names (fuzzy matching)
             similar_sources = []
@@ -507,9 +937,15 @@ class HPAGetRnaExpressionBySourceTool(HPASearchApiTool):
             )
             if similar_sources:
                 error_msg += f"Similar options: {similar_sources[:3]}. "
+            # HPA publishes ~160 single cell types; listing every alias makes
+            # the message unusable, so show the canonical names and cap them.
+            canonical = self.source_canonical_names[source_type]
+            shown = canonical[:40]
             error_msg += (
-                f"All available sources for '{source_type}': {available_sources}"
+                f"Valid HPA names for '{source_type}' ({len(canonical)} total): {shown}"
             )
+            if len(canonical) > len(shown):
+                error_msg += f" ... and {len(canonical) - len(shown)} more"
             return {"status": "error", "data": {"error": error_msg}}
 
         try:
@@ -521,18 +957,40 @@ class HPAGetRnaExpressionBySourceTool(HPASearchApiTool):
                 gene_name, source_type, candidates
             )
             if direct_value is not None:
-                return {
-                    "status": "success",
-                    "data": {
-                        "gene_name": gene_name,
-                        "source_type": source_type,
-                        "source_name": source_name,
-                        "expression_value": direct_value,
-                        "expression_level": self._categorize_expression(direct_value),
-                        "column_queried": direct_label,
-                        "status": "ok",
-                    },
+                data = {
+                    "gene_name": gene_name,
+                    "source_type": source_type,
+                    "source_name": source_name,
+                    "expression_value": direct_value,
+                    "expression_level": self._categorize_expression(direct_value),
+                    # Unit comes from HPA's own column header, never a
+                    # hard-coded default: sc_RNA_* columns are [nCPM].
+                    "expression_unit": hpa_unit_from_column_label(
+                        direct_label, self.source_units.get(source_type, "nTPM")
+                    ),
+                    "column_queried": direct_label,
+                    "status": "ok",
                 }
+                # If the request resolved to a differently-named HPA column
+                # (an alias, or a subset standing in for an aggregate HPA does
+                # not publish), say which column the number actually is.
+                matched_label = direct_label.split(" RNA - ", 1)[-1]
+                matched_label = re.sub(r"\s*\[[^\[\]]*\]\s*$", "", matched_label)
+                if hpa_slug(matched_label) != hpa_slug(source_name):
+                    others = [
+                        c
+                        for c in self.source_name_mappings[source_type][source_name]
+                        if hpa_slug(c) != hpa_slug(matched_label)
+                    ]
+                    note = (
+                        f"HPA has no column named '{source_name}' for source_type "
+                        f"'{source_type}'; this value is from its '{matched_label}' "
+                        "column."
+                    )
+                    if others:
+                        note += f" Other columns this name covers: {others}."
+                    data["note"] = note
+                return {"status": "success", "data": data}
 
             # Get the correct API column
             api_column = self.source_column_mappings[source_type]
@@ -605,7 +1063,9 @@ class HPAGetRnaExpressionBySourceTool(HPASearchApiTool):
                 "source_name": source_name,
                 "expression_value": expression_value,
                 "expression_level": expression_level,
-                "expression_unit": "nTPM",
+                # Per-source-family unit, not a blanket "nTPM": HPA's single
+                # cell columns are nCPM.
+                "expression_unit": self.source_units.get(source_type, "nTPM"),
                 "column_queried": api_column,
                 "available_sources": (
                     available_sources[:10]
@@ -619,6 +1079,13 @@ class HPAGetRnaExpressionBySourceTool(HPASearchApiTool):
                     else "no_expression_data_for_source"
                 ),
             }
+            if expression_value == "N/A":
+                result["note"] = (
+                    f"HPA's per-source column for '{source_name}' returned no value "
+                    f"and the '{api_column}' enrichment-summary fallback carried "
+                    "nothing either. 'N/A' here means HPA published no number for "
+                    "this gene/source pair, not that the source name is invalid."
+                )
             return {"status": "success", "data": result}
 
         except Exception as e:
@@ -1241,13 +1708,40 @@ class HPAGetRnaExpressionByTissueTool(HPAJsonApiTool):
 
         expression_results = {}
         for tissue in tissue_names:
-            value = panel.get(tissue)
-            if value is not None:
-                expression_results[tissue] = {
-                    "matched_tissue": tissue,
+            hit = panel.get(tissue)
+            if hit is not None:
+                value, label = hit
+                # HPA's own column header is the source of truth for both the
+                # matched tissue and the unit -- never synthesise it from the
+                # caller's string, which is how 'skin' used to be reported as
+                # "Tissue RNA - skin [nTPM]", a column HPA does not have.
+                matched = label.split(" RNA - ", 1)[-1]
+                matched = re.sub(r"\s*\[[^\[\]]*\]\s*$", "", matched)
+                entry = {
+                    "matched_tissue": matched,
                     "expression_value": value,
                     "expression_level": self._categorize_expression(value),
-                    "source_field": f"Tissue RNA - {tissue} [nTPM]",
+                    "expression_unit": hpa_unit_from_column_label(label, "nTPM"),
+                    "source_field": label,
+                }
+                if hpa_slug(matched) != hpa_slug(tissue):
+                    column = HPA_TISSUE_COLUMN_ALIASES.get(
+                        hpa_slug(tissue), [hpa_slug(matched)]
+                    )[0]
+                    entry["note"] = (
+                        f"HPA publishes this tissue as '{matched}', not "
+                        f"'{tissue}'; the value is from its 't_RNA_{column}' column."
+                    )
+                expression_results[tissue] = entry
+                continue
+
+            unavailable = HPA_UNAVAILABLE_SOURCES["tissue"].get(hpa_slug(tissue))
+            if unavailable:
+                expression_results[tissue] = {
+                    "matched_tissue": "Not found",
+                    "expression_value": "N/A",
+                    "expression_level": "No data",
+                    "note": unavailable,
                 }
                 continue
 
@@ -1283,8 +1777,8 @@ class HPAGetRnaExpressionByTissueTool(HPAJsonApiTool):
                         f"'{tissue}' did not match an HPA tissue column "
                         f"(t_RNA_{self._tissue_column_suffix(tissue)}). This means the "
                         "tissue name is unrecognized, not that the gene lacks "
-                        "expression. Use HPA_get_rna_expression_by_source to list "
-                        "valid source names for source_type='tissue' or 'brain'."
+                        "expression. HPA's consensus tissues: "
+                        f"{sorted(HPA_TISSUE_RNA_COLUMNS)}."
                     ),
                 }
 
@@ -1304,7 +1798,24 @@ class HPAGetRnaExpressionByTissueTool(HPAJsonApiTool):
     @staticmethod
     def _tissue_column_suffix(tissue: str) -> str:
         """Convert a human tissue name to HPA's column suffix form."""
-        return re.sub(r"[^a-z0-9]+", "_", str(tissue).strip().lower()).strip("_")
+        return hpa_slug(tissue)
+
+    @staticmethod
+    def _tissue_column_candidates(tissue: str) -> list[str]:
+        """Resolve a caller's tissue name to real HPA `t_RNA_` column suffixes.
+
+        Fix-R31: the slugified name is NOT always a column. HPA publishes
+        'skin' as `t_RNA_skin_1`, 'stomach' as `t_RNA_stomach_1` and
+        'endometrium' as `t_RNA_endometrium_1`; `t_RNA_skin` etc. are silently
+        dropped, which the tool then misreported as an unrecognized tissue
+        name. Consult the verified catalogue first, and still try the raw slug
+        so a column HPA adds later keeps working without a code change.
+        """
+        slug = hpa_slug(tissue)
+        candidates = list(HPA_TISSUE_COLUMN_ALIASES.get(slug, []))
+        if slug and slug not in candidates:
+            candidates.append(slug)
+        return candidates
 
     def _fetch_tissue_panel(
         self, ensembl_id: str, tissue_names: List[str]
@@ -1313,14 +1824,19 @@ class HPAGetRnaExpressionByTissueTool(HPAJsonApiTool):
 
         HPA drops columns it does not recognize instead of erroring, so a tissue
         missing from the response is an unknown tissue name. Returns a mapping of
-        the caller's original tissue strings to their nTPM values.
+        the caller's original tissue strings to (value, HPA column header).
         """
-        suffixes = {t: self._tissue_column_suffix(t) for t in tissue_names}
-        columns = ",".join(["g", "eg"] + [f"t_RNA_{s}" for s in suffixes.values() if s])
+        candidates = {t: self._tissue_column_candidates(t) for t in tissue_names}
+        columns = ["g", "eg"]
+        for suffixes in candidates.values():
+            for suffix in suffixes:
+                column = f"t_RNA_{suffix}"
+                if column not in columns:
+                    columns.append(column)
         params = {
             "search": ensembl_id,
             "format": "json",
-            "columns": columns,
+            "columns": ",".join(columns),
             "compress": "no",
         }
         try:
@@ -1337,15 +1853,18 @@ class HPAGetRnaExpressionByTissueTool(HPAJsonApiTool):
         # HPA labels the returned columns "Tissue RNA - <tissue> [nTPM]".
         by_suffix = {}
         for key, value in row.items():
-            match = re.match(r"^Tissue RNA - (.+?) \[nTPM\]$", key)
+            match = re.match(r"^Tissue RNA - (.+?) \[[^\[\]]+\]$", key)
             if match:
-                by_suffix[self._tissue_column_suffix(match.group(1))] = value
+                by_suffix[hpa_slug(match.group(1))] = (value, key)
 
-        return {
-            tissue: by_suffix[suffix]
-            for tissue, suffix in suffixes.items()
-            if by_suffix.get(suffix) not in (None, "")
-        }
+        panel = {}
+        for tissue, suffixes in candidates.items():
+            for suffix in suffixes:
+                hit = by_suffix.get(suffix)
+                if hit and hit[0] not in (None, ""):
+                    panel[tissue] = hit
+                    break
+        return panel
 
     def _categorize_expression(self, expr_value) -> str:
         """Categorize expression level"""
@@ -1719,15 +2238,57 @@ class HPAGetGenePageDetailsTool(HPAXmlApiTool):
             result["cell_line_expression"] = self._extract_cell_line_expression(root)
 
         # Extract summary statistics
+        tissue_rows = result.get("tissue_expression", [])
+        detected, assayed = self._count_tissues(tissue_rows)
         result["summary"] = {
             "total_antibodies": len(result.get("antibodies", [])),
             "total_ihc_images": len(result.get("ihc_images", [])),
             "total_if_images": len(result.get("if_images", [])),
-            "tissues_with_expression": len(result.get("tissue_expression", [])),
+            # Fix-R31: this used to be len(tissue_expression), i.e. the number
+            # of assayed ROWS -- 184 for NCSTN, of which 135 carried no level
+            # at all, 9 said "not detected", and the remainder repeated the
+            # same tissue once per antibody ("Skin 1" appeared 4x). HPA
+            # publishes ~44 consensus tissues, so the old number was
+            # impossible on its face. Count distinct tissues whose IHC level
+            # is actually detected.
+            "tissues_with_expression": detected,
+            "distinct_tissues_assayed": assayed,
+            "tissue_expression_rows": len(tissue_rows),
             "cell_lines_with_expression": len(result.get("cell_line_expression", [])),
         }
+        result["summary"]["summary_note"] = (
+            "'tissues_with_expression' counts distinct tissues with a detected "
+            "IHC expression level; rows with no level and rows scored "
+            "'not detected' are excluded. 'tissue_expression_rows' is the raw "
+            "row count of the tissue_expression array (one row per "
+            "tissue x antibody)."
+        )
 
         return result
+
+    @staticmethod
+    def _count_tissues(tissue_rows: list) -> tuple[int, int]:
+        """Return (distinct tissues with detected expression, distinct assayed).
+
+        `tissue_expression` holds one row per tissue x antibody, many of them
+        with a blank or "not detected" level, so its length is neither a
+        tissue count nor an expression count.
+        """
+        not_detected = {"", "not detected", "none", "negative", "n/a", "undetected"}
+        detected, assayed = set(), set()
+        for row in tissue_rows or []:
+            if not isinstance(row, dict):
+                continue
+            name = str(row.get("tissue_name") or "").strip().lower()
+            if not name:
+                continue
+            assayed.add(name)
+            level = str(row.get("expression_level") or "").strip().lower()
+            # Levels arrive as "<type>: <level>", e.g. "expression: medium".
+            level = level.rsplit(":", 1)[-1].strip()
+            if level and level not in not_detected:
+                detected.add(name)
+        return len(detected), len(assayed)
 
     def _extract_ihc_images(self, root: ET.Element) -> List[Dict[str, Any]]:
         """Extract tissue immunohistochemistry (IHC) images based on actual HPA XML structure"""

--- a/src/tooluniverse/interpro_domain_arch_tool.py
+++ b/src/tooluniverse/interpro_domain_arch_tool.py
@@ -19,6 +19,27 @@ from .base_tool import BaseTool
 INTERPRO_BASE_URL = "https://www.ebi.ac.uk/interpro/api"
 
 
+def _json_or_none(response):
+    """Parse a JSON response body, returning None when there is no body.
+
+    The InterPro API reports an empty result set as HTTP 204 No Content with a
+    zero-length body instead of a 200 carrying ``{"count": 0, "results": []}``.
+    ``raise_for_status()`` treats 204 as success, so calling ``.json()`` on it
+    raises a JSONDecodeError that used to escape as an opaque
+    "Unexpected error querying InterPro API" message -- callers could not tell
+    "nothing matched" from "the tool is broken".
+
+    Callers translate a ``None`` return into their own empty-result shape (for
+    list endpoints) or a not-found error (for single-record endpoints).
+    """
+    if response.status_code == 204:
+        return None
+    body = response.content
+    if not body or not body.strip():
+        return None
+    return response.json()
+
+
 class InterProDomainArchTool(BaseTool):
     """
     Tool for InterPro domain architecture analysis via the InterPro API.
@@ -53,8 +74,8 @@ class InterProDomainArchTool(BaseTool):
                     ),
                 )
                 return {"status": "error", "error": f"Not found in InterPro: {param}"}
-            if code == 204:
-                return {"status": "error", "error": "No results found"}
+            # NB: 204 never reaches here -- raise_for_status() only raises for
+            # 4xx/5xx. It is handled as an empty result set by _json_or_none().
             return {"status": "error", "error": f"InterPro API HTTP error: {code}"}
         except Exception as e:
             return {
@@ -88,7 +109,8 @@ class InterProDomainArchTool(BaseTool):
         params = {"page_size": 50, "format": "json"}
         response = requests.get(url, params=params, timeout=self.timeout)
         response.raise_for_status()
-        data = response.json()
+        # HTTP 204 / empty body == "this protein has no Pfam domains".
+        data = _json_or_none(response) or {}
 
         results = data.get("results", [])
         domains = []
@@ -153,7 +175,8 @@ class InterProDomainArchTool(BaseTool):
         params = {"page_size": max_results, "format": "json"}
         response = requests.get(url, params=params, timeout=self.timeout)
         response.raise_for_status()
-        data = response.json()
+        # HTTP 204 / empty body == "no PDB structure contains this domain".
+        data = _json_or_none(response) or {}
 
         total = data.get("count", 0)
         results = data.get("results", [])
@@ -200,7 +223,11 @@ class InterProDomainArchTool(BaseTool):
         params = {"format": "json"}
         response = requests.get(url, params=params, timeout=self.timeout)
         response.raise_for_status()
-        clan_data = response.json()
+        # A single-record endpoint answers an unknown clan with HTTP 204, not
+        # 404. Report it as not-found rather than a success full of blanks.
+        clan_data = _json_or_none(response)
+        if clan_data is None:
+            return {"status": "error", "error": f"Not found in InterPro: {clan_acc}"}
 
         metadata = clan_data.get("metadata", {})
         name_info = metadata.get("name", {})

--- a/src/tooluniverse/interpro_entry_tool.py
+++ b/src/tooluniverse/interpro_entry_tool.py
@@ -18,6 +18,24 @@ from .base_tool import BaseTool
 INTERPRO_BASE_URL = "https://www.ebi.ac.uk/interpro/api"
 
 
+def _json_or_none(response):
+    """Parse a JSON response body, returning None when there is no body.
+
+    The InterPro API reports an empty result set as HTTP 204 No Content with a
+    zero-length body instead of a 200 carrying ``{"count": 0, "results": []}``.
+    ``raise_for_status()`` treats 204 as success, so calling ``.json()`` on it
+    raises a JSONDecodeError that used to escape as an opaque
+    "Unexpected error querying InterPro API" message -- callers could not tell
+    "nothing matched" from "the tool is broken".
+    """
+    if response.status_code == 204:
+        return None
+    body = response.content
+    if not body or not body.strip():
+        return None
+    return response.json()
+
+
 class InterProEntryTool(BaseTool):
     """
     Tool for InterPro entry API providing protein-to-domain mappings
@@ -87,7 +105,8 @@ class InterProEntryTool(BaseTool):
             timeout=self.timeout,
         )
         response.raise_for_status()
-        data = response.json()
+        # HTTP 204 / empty body == "this protein has no InterPro entries".
+        data = _json_or_none(response) or {}
 
         results = data.get("results", [])
         entries = []
@@ -151,7 +170,9 @@ class InterProEntryTool(BaseTool):
             timeout=self.timeout,
         )
         response.raise_for_status()
-        data = response.json()
+        # HTTP 204 / empty body == "no entry matched"; report it as an empty
+        # result set rather than letting .json() raise.
+        data = _json_or_none(response) or {}
 
         results = data.get("results", [])
         entries = []

--- a/src/tooluniverse/interpro_ext_tool.py
+++ b/src/tooluniverse/interpro_ext_tool.py
@@ -17,6 +17,24 @@ from .base_tool import BaseTool
 INTERPRO_API_BASE_URL = "https://www.ebi.ac.uk/interpro/api"
 
 
+def _json_or_none(response):
+    """Parse a JSON response body, returning None when there is no body.
+
+    The InterPro API reports an empty result set as HTTP 204 No Content with a
+    zero-length body instead of a 200 carrying ``{"count": 0, "results": []}``.
+    ``raise_for_status()`` treats 204 as success, so calling ``.json()`` on it
+    raises a JSONDecodeError that used to escape as an opaque
+    "Unexpected error querying InterPro API" message -- callers could not tell
+    "nothing matched" from "the tool is broken".
+    """
+    if response.status_code == 204:
+        return None
+    body = response.content
+    if not body or not body.strip():
+        return None
+    return response.json()
+
+
 class InterProExtTool(BaseTool):
     """
     Extended InterPro API tool for protein-by-domain queries.
@@ -85,7 +103,8 @@ class InterProExtTool(BaseTool):
 
         response = requests.get(url, params=params, timeout=self.timeout)
         response.raise_for_status()
-        data = response.json()
+        # HTTP 204 / empty body == "no protein carries this domain".
+        data = _json_or_none(response) or {}
 
         total_count = data.get("count", 0)
         results = data.get("results", [])

--- a/src/tooluniverse/interpro_tool.py
+++ b/src/tooluniverse/interpro_tool.py
@@ -4,6 +4,24 @@ from .base_tool import BaseTool
 from .tool_registry import register_tool
 
 
+def _json_or_none(response):
+    """Parse a JSON response body, returning None when there is no body.
+
+    The InterPro API reports an empty result set as HTTP 204 No Content with a
+    zero-length body instead of a 200 carrying ``{"count": 0, "results": []}``.
+    ``raise_for_status()`` treats 204 as success, so calling ``.json()`` on it
+    raises a JSONDecodeError that used to surface as an opaque
+    "InterPro API error: Expecting value: line 1 column 1 (char 0)" -- callers
+    could not tell "nothing matched" from "the tool is broken".
+    """
+    if response.status_code == 204:
+        return None
+    body = response.content
+    if not body or not body.strip():
+        return None
+    return response.json()
+
+
 @register_tool("InterProRESTTool")
 class InterProRESTTool(BaseTool):
     def __init__(self, tool_config: Dict):
@@ -53,18 +71,29 @@ class InterProRESTTool(BaseTool):
             url = self._build_url(arguments)
             response = self.session.get(url, timeout=self.timeout)
             response.raise_for_status()
-            data = response.json()
+            # HTTP 204 / empty body == "nothing matched". Fall through with an
+            # empty payload so extraction yields the normal empty shape
+            # ([] for extract_path "results", 0 for "count") instead of
+            # letting .json() raise.
+            payload = _json_or_none(response)
+            empty = payload is None
+            data = {} if empty else payload
             extract_path = self.tool_config["fields"].get("extract_path")
             if extract_path:
                 result = self._extract_data(data, extract_path)
             else:
                 result = data
 
+            if empty:
+                count = 0
+            else:
+                count = len(result) if isinstance(result, list) else 1
+
             return {
                 "status": "success",
                 "data": result,
                 "url": url,
-                "count": len(result) if isinstance(result, list) else 1,
+                "count": count,
             }
 
         except Exception as e:

--- a/src/tooluniverse/medlineplus_tool.py
+++ b/src/tooluniverse/medlineplus_tool.py
@@ -1,15 +1,34 @@
 # medlineplus_tool.py
 
+import re
+from typing import Any, Dict, Optional
+
 import requests
 import xmltodict
-from typing import Optional, Dict, Any
-import re
-import json
 
 from .base_tool import BaseTool
+from .logging_config import get_logger
 from .tool_registry import register_tool
 
+logger = get_logger("MedlinePlusRESTTool")
+
 _HTML_TAG_RE = re.compile(r"<[^>]+>")
+
+# The wsearch service wraps every term match in <span class="qt0">...</span>
+# highlight markup in the flat `brief`/`all` content nodes. The same text in
+# the `topic` <health-topic> record carries no such markup, so stripping the
+# spans (keeping their inner text) makes the three rettypes agree.
+_HIGHLIGHT_SPAN_RE = re.compile(r"</?span[^>]*>")
+
+# NLM's wsearch endpoint accepts any `db` value but only actually serves the
+# two health-topic databases; every query against the other historically
+# documented databases returns <count>0</count>. Verified live (2026-08) for
+# drugs / drugsSpanish / genetics / medicalTests / medicalEncyclopedia across
+# the terms aspirin, cancer, heart, BRCA1, diabetes and vitamin -- all zero,
+# while healthTopics/healthTopicsSpanish return hundreds of hits for the same
+# terms. The values stay accepted so existing callers keep working; they just
+# now get an explanation instead of a generic "no results".
+_SERVED_SEARCH_DBS = ("healthTopics", "healthTopicsSpanish")
 
 
 @register_tool("MedlinePlusRESTTool")
@@ -95,7 +114,156 @@ class MedlinePlusRESTTool(BaseTool):
             return _HTML_TAG_RE.sub("", html.replace("</p>", "\n")).strip()
         return ""
 
-    def _format_response(self, response: Any, tool_name: str) -> Dict[str, Any]:
+    @staticmethod
+    def _strip_highlight(value: Any) -> str:
+        """Drop the wsearch term-highlight <span> wrappers, keeping their text."""
+        if not isinstance(value, str):
+            return ""
+        return _HIGHLIGHT_SPAN_RE.sub("", value).strip()
+
+    @staticmethod
+    def _truncate_summary(summary: Any) -> Any:
+        text = summary if isinstance(summary, str) else str(summary)
+        return text[:500] + "..." if len(text) > 500 else summary
+
+    @staticmethod
+    def _split_document_content(doc: dict):
+        """Split a <document>'s <content> nodes into the structured
+        <health-topic> record (rettype=topic / all) and a name -> [text] map
+        of the flat content nodes (rettype=brief / all).
+
+        rettype=topic yields exactly one <content name="healthTopic"> node,
+        which xmltodict collapses to a bare dict; brief yields several flat
+        <content name="..."> nodes (a list); all yields both in one list.
+        The old code only ever looked at the dict shape, so every brief/all
+        document was silently discarded.
+        """
+        content = doc.get("content", {})
+        if isinstance(content, dict):
+            entries = [content]
+        elif isinstance(content, list):
+            entries = [c for c in content if isinstance(c, dict)]
+        else:
+            entries = []
+
+        health_topic = {}
+        flat: dict[str, list] = {}
+        for entry in entries:
+            nested = entry.get("health-topic")
+            if isinstance(nested, dict):
+                health_topic = nested
+                continue
+            text = entry.get("#text")
+            if isinstance(text, str):
+                flat.setdefault(entry.get("@name", ""), []).append(text)
+        return health_topic, flat
+
+    def _format_health_topic(self, health_topic: dict, doc_url: str, doc_rank: str):
+        """Format the structured <health-topic> record (rettype=topic/all)."""
+        title = health_topic.get("@title", "")
+        meta_desc = health_topic.get("@meta-desc", "")
+        topic_url = health_topic.get("@url", doc_url)
+        language = health_topic.get("@language", "")
+
+        # Extract aliases
+        also_called = health_topic.get("also-called", [])
+        if isinstance(also_called, str):
+            also_called = [also_called]
+        elif isinstance(also_called, dict):
+            also_called = [also_called.get("#text", str(also_called))]
+        elif not isinstance(also_called, list):
+            also_called = []
+
+        # Extract summary
+        full_summary = health_topic.get("full-summary", "")
+        if isinstance(full_summary, dict):
+            full_summary = str(full_summary)
+
+        # Extract group information
+        groups = health_topic.get("group", [])
+        if isinstance(groups, str):
+            groups = [groups]
+        elif isinstance(groups, dict):
+            groups = [groups.get("#text", str(groups))]
+        elif not isinstance(groups, list):
+            groups = []
+
+        return {
+            "title": title,
+            "meta_desc": meta_desc,
+            "url": topic_url,
+            "language": language,
+            "rank": doc_rank,
+            "also_called": also_called,
+            "summary": self._truncate_summary(full_summary),
+            "groups": groups,
+        }
+
+    def _format_brief_document(
+        self, flat: dict[str, list], doc_url: str, doc_rank: str, db: str
+    ):
+        """Format a rettype=brief document, whose fields arrive as flat
+        <content name="title|altTitle|FullSummary|groupName|snippet"> nodes
+        instead of a nested <health-topic> record."""
+
+        def first(name: str) -> str:
+            values = flat.get(name) or [""]
+            return self._strip_highlight(values[0])
+
+        # brief carries no meta-desc; the search snippet is the equivalent
+        # short description the service offers for this rettype.
+        snippet = first("snippet")
+        # brief carries no language attribute either; it is fixed by the db.
+        if db.lower().endswith("spanish"):
+            language = "Spanish"
+        elif db:
+            language = "English"
+        else:
+            language = ""
+
+        return {
+            "title": first("title"),
+            "meta_desc": snippet,
+            "url": doc_url,
+            "language": language,
+            "rank": doc_rank,
+            "also_called": [
+                self._strip_highlight(v)
+                for v in flat.get("altTitle", [])
+                if self._strip_highlight(v)
+            ],
+            "summary": self._truncate_summary(first("FullSummary")),
+            "groups": [
+                self._strip_highlight(v)
+                for v in flat.get("groupName", [])
+                if self._strip_highlight(v)
+            ],
+        }
+
+    @staticmethod
+    def _no_documents_error(arguments: dict[str, Any]) -> str:
+        """Explain an empty result set, naming the real cause when the caller
+        targeted a `db` that wsearch accepts but never serves."""
+        db = str(arguments.get("db", "") or "")
+        term = str(arguments.get("term", "") or "")
+        if db and db not in _SERVED_SEARCH_DBS:
+            return (
+                f"MedlinePlus wsearch does not serve `db={db}`; only "
+                f"{' and '.join(_SERVED_SEARCH_DBS)} return results. The service "
+                f"accepts the request but always answers with count=0, so this is "
+                f"not a 'no match for your term' result. Retry with "
+                f"db=healthTopics (or db=healthTopicsSpanish)."
+            )
+        where = f" in db={db}" if db else ""
+        for_term = f" for term '{term}'" if term else ""
+        return f"MedlinePlus returned no matching documents{for_term}{where} (count=0)."
+
+    def _format_response(
+        self,
+        response: Any,
+        tool_name: str,
+        arguments: dict[str, Any] | None = None,
+    ) -> Dict[str, Any]:
         """Format response content"""
         if not isinstance(response, dict):
             return {"raw_response": response}
@@ -147,13 +315,8 @@ class MedlinePlusRESTTool(BaseTool):
 
         # Format response based on tool type
         if tool_name == "MedlinePlus_search_topics_by_keyword":
-            # First print raw response for debugging
-            print("\n🔍 Raw response structure:")
-            print(
-                json.dumps(response, indent=2, ensure_ascii=False)[:2000] + "..."
-                if len(json.dumps(response, indent=2, ensure_ascii=False)) > 2000
-                else json.dumps(response, indent=2, ensure_ascii=False)
-            )
+            arguments = arguments or {}
+            logger.debug("MedlinePlus raw search response: %s", response)
 
             # Extract topic information from XML structure
             nlm_result = response.get("nlmSearchResult", {})
@@ -163,68 +326,36 @@ class MedlinePlusRESTTool(BaseTool):
             # Get document list
             document_list = nlm_result.get("list", {}).get("document", [])
             if not document_list:
-                return {"status": "error", "error": "document list not found"}
+                return {
+                    "status": "error",
+                    "error": self._no_documents_error(arguments),
+                }
 
             # Ensure document_list is a list
             if isinstance(document_list, dict):
                 document_list = [document_list]
 
+            db = str(arguments.get("db", "") or "")
             formatted_topics = []
             for doc in document_list:
+                if not isinstance(doc, dict):
+                    continue
                 # Get document basic info
                 doc_url = doc.get("@url", "")
                 doc_rank = doc.get("@rank", "")
 
-                # Get content node
-                content = doc.get("content", {})
-                if isinstance(content, dict):
-                    health_topic = content.get("health-topic", {})
-                    if health_topic:
-                        # Extract health topic information
-                        title = health_topic.get("@title", "")
-                        meta_desc = health_topic.get("@meta-desc", "")
-                        topic_url = health_topic.get("@url", doc_url)
-                        language = health_topic.get("@language", "")
-
-                        # Extract aliases
-                        also_called = health_topic.get("also-called", [])
-                        if isinstance(also_called, str):
-                            also_called = [also_called]
-                        elif isinstance(also_called, dict):
-                            also_called = [also_called.get("#text", str(also_called))]
-                        elif not isinstance(also_called, list):
-                            also_called = []
-
-                        # Extract summary
-                        full_summary = health_topic.get("full-summary", "")
-                        if isinstance(full_summary, dict):
-                            full_summary = str(full_summary)
-
-                        # Extract group information
-                        groups = health_topic.get("group", [])
-                        if isinstance(groups, str):
-                            groups = [groups]
-                        elif isinstance(groups, dict):
-                            groups = [groups.get("#text", str(groups))]
-                        elif not isinstance(groups, list):
-                            groups = []
-
-                        formatted_topics.append(
-                            {
-                                "title": title,
-                                "meta_desc": meta_desc,
-                                "url": topic_url,
-                                "language": language,
-                                "rank": doc_rank,
-                                "also_called": also_called,
-                                "summary": (
-                                    full_summary[:500] + "..."
-                                    if len(str(full_summary)) > 500
-                                    else full_summary
-                                ),
-                                "groups": groups,
-                            }
-                        )
+                health_topic, flat = self._split_document_content(doc)
+                if health_topic:
+                    # rettype=topic, and rettype=all (which ships the same
+                    # structured record alongside the flat fields).
+                    formatted_topics.append(
+                        self._format_health_topic(health_topic, doc_url, doc_rank)
+                    )
+                elif flat:
+                    # rettype=brief: only the flat content nodes are present.
+                    formatted_topics.append(
+                        self._format_brief_document(flat, doc_url, doc_rank, db)
+                    )
 
             return (
                 {"topics": formatted_topics}
@@ -357,8 +488,11 @@ class MedlinePlusRESTTool(BaseTool):
         if isinstance(url, dict) and "error" in url:
             return url
 
-        # Print complete URL
-        print(f"\n🔗 Request URL: {url}")
+        # Diagnostics go to the shared ToolUniverse logger at DEBUG level
+        # (enable with TOOLUNIVERSE_LOG_LEVEL=DEBUG). They used to be bare
+        # print() calls, which polluted stdout on every single call and
+        # corrupted any consumer parsing the tool's JSON payload from there.
+        logger.debug("Request URL: %s", url)
 
         # Make request
         try:
@@ -370,9 +504,12 @@ class MedlinePlusRESTTool(BaseTool):
                     "detail": resp.text,
                 }
 
-            print(f"\n📊 Response status: {resp.status_code}")
-            print(f"📏 Response length: {len(resp.text)} characters")
-            print(f"🔤 First 500 characters of response: {resp.text[:500]}...")
+            logger.debug(
+                "Response status: %s, length: %s characters",
+                resp.status_code,
+                len(resp.text),
+            )
+            logger.debug("First 500 characters of response: %s", resp.text[:500])
 
             # Improved parsing logic
             tool_name = self.tool_config["name"]
@@ -384,11 +521,11 @@ class MedlinePlusRESTTool(BaseTool):
                 # JSON format
                 try:
                     response = resp.json()
-                    print("📋 Parsed as: JSON")
+                    logger.debug("Parsed as: JSON")
                 except Exception:
                     # If JSON parsing fails, fall back to XML
                     response = xmltodict.parse(resp.text)
-                    print("📋 Parsed as: XML -> Dictionary (fallback)")
+                    logger.debug("Parsed as: XML -> Dictionary (fallback)")
             elif (
                 url.endswith(".xml")
                 or response_text.startswith("<?xml")
@@ -396,25 +533,24 @@ class MedlinePlusRESTTool(BaseTool):
             ):
                 # XML format
                 response = xmltodict.parse(resp.text)
-                print("📋 Parsed as: XML -> Dictionary")
+                logger.debug("Parsed as: XML -> Dictionary")
             elif tool_name == "MedlinePlus_search_topics_by_keyword":
                 # Search tool defaults to XML
                 response = xmltodict.parse(resp.text)
-                print("📋 Parsed as: XML -> Dictionary (Search tool)")
+                logger.debug("Parsed as: XML -> Dictionary (Search tool)")
             elif tool_name == "MedlinePlus_get_genetics_index":
                 # Genetics index defaults to XML
                 response = xmltodict.parse(resp.text)
-                print("📋 Parsed as: XML -> Dictionary (Genetics index)")
+                logger.debug("Parsed as: XML -> Dictionary (Genetics index)")
             else:
                 # Other cases keep original text
                 response = resp.text
-                print("📋 Parsed as: Plain text")
+                logger.debug("Parsed as: Plain text")
 
-            print(f"🔍 Parsed data type: {type(response)}")
             if isinstance(response, dict):
-                print(f"🗝️ Top-level dictionary keys: {list(response.keys())}")
+                logger.debug("Top-level dictionary keys: %s", list(response.keys()))
 
-            return self._format_response(response, tool_name)
+            return self._format_response(response, tool_name, arguments)
 
         except requests.RequestException as e:
             return {
@@ -424,7 +560,7 @@ class MedlinePlusRESTTool(BaseTool):
 
     # Tool methods
     def search_topics_by_keyword(
-        self, term: str, db: str, rettype: str = "brief"
+        self, term: str, db: str, rettype: str = "topic"
     ) -> Dict[str, Any]:
         return self.run({"term": term, "db": db, "rettype": rettype})
 

--- a/src/tooluniverse/monarch_v3_tool.py
+++ b/src/tooluniverse/monarch_v3_tool.py
@@ -23,6 +23,69 @@ MONARCH_BASE_URL = "https://api.monarchinitiative.org/v3/api"
 
 _UNDERSCORE_CURIE_RE = re.compile(r"^([A-Za-z]+)_(\d+)$")
 
+# Biolink association categories are directed: the category name reads
+# "<subject>To<object>Association". Anchoring an entity on the wrong side is
+# silently valid at the API (it just matches nothing), so a caller asking
+# "which genes cause MONDO:0006559?" as subject=MONDO:0006559 gets a confident
+# empty list rather than the three causal genes the object side would return.
+# Map each category to the kind of entity that belongs on each side so an empty
+# result can say which side the caller's CURIE actually belongs on.
+_ASSOCIATION_SIDES = {
+    "biolink:CausalGeneToDiseaseAssociation": ("gene", "disease"),
+    "biolink:CorrelatedGeneToDiseaseAssociation": ("gene", "disease"),
+    "biolink:GeneToPhenotypicFeatureAssociation": ("gene", "phenotype"),
+    "biolink:DiseaseToPhenotypicFeatureAssociation": ("disease", "phenotype"),
+    "biolink:GeneToPathwayAssociation": ("gene", "pathway"),
+    "biolink:GeneToExpressionSiteAssociation": ("gene", "expression site"),
+}
+
+# Only unambiguous CURIE prefixes -- enough to recognise a disease passed where
+# a gene belongs (and vice versa) without guessing about multi-purpose
+# namespaces such as MGI/ZFIN, which identify both genes and genotypes.
+_CURIE_PREFIX_KIND = {
+    "HGNC": "gene",
+    "NCBIGENE": "gene",
+    "ENSEMBL": "gene",
+    "MONDO": "disease",
+    "OMIM": "disease",
+    "DOID": "disease",
+    "ORPHANET": "disease",
+    "HP": "phenotype",
+}
+
+
+def _curie_kind(curie: str) -> str:
+    """Best-effort entity kind for a CURIE, or '' when the prefix is ambiguous."""
+    if not isinstance(curie, str) or ":" not in curie:
+        return ""
+    return _CURIE_PREFIX_KIND.get(curie.split(":", 1)[0].strip().upper(), "")
+
+
+def _direction_hint(category: str, subject: str, obj: str) -> str:
+    """Explain the subject/object direction when a query returned nothing and
+    the supplied CURIE looks like it belongs on the other side."""
+    sides = _ASSOCIATION_SIDES.get(category)
+    if not sides:
+        return ""
+    subject_kind, object_kind = sides
+    if subject_kind == object_kind:
+        return ""
+    preamble = (
+        f"{category} is directed: the {subject_kind} is the 'subject' "
+        f"and the {object_kind} is the 'object'."
+    )
+    if subject and not obj and _curie_kind(subject) == object_kind:
+        return (
+            f"{preamble} You passed {subject} (a {object_kind}) as 'subject'; "
+            f"retry with object='{subject}' to get its {subject_kind}s."
+        )
+    if obj and not subject and _curie_kind(obj) == subject_kind:
+        return (
+            f"{preamble} You passed {obj} (a {subject_kind}) as 'object'; "
+            f"retry with subject='{obj}' to get its {object_kind}s."
+        )
+    return ""
+
 
 def _normalize_curie(entity_id: str) -> str:
     """Convert an underscore-delimited ontology CURIE to the colon form Monarch
@@ -145,7 +208,15 @@ class MonarchV3Tool(BaseTool):
         if not subject and not obj:
             return {
                 "status": "error",
-                "error": "Either subject or object CURIE is required (e.g., HGNC:11998 or MONDO:0005148)",
+                "error": (
+                    "At least one of 'subject' or 'object' is required (a CURIE). "
+                    "Associations are directed: use 'subject' for the entity on the "
+                    "left of the category (e.g. subject='HGNC:11998' with "
+                    "biolink:CausalGeneToDiseaseAssociation for a gene's diseases) "
+                    "and 'object' for the entity on the right (e.g. "
+                    "object='MONDO:0005148' with the same category for a disease's "
+                    "causal genes)."
+                ),
             }
 
         category = arguments.get("category", "")
@@ -180,15 +251,22 @@ class MonarchV3Tool(BaseTool):
                 }
             )
 
+        metadata = {
+            "source": "Monarch Initiative V3",
+            "subject": subject,
+            "object": obj,
+            "category": category,
+            "total_results": data.get("total", len(associations)),
+        }
+        if not associations:
+            hint = _direction_hint(category, subject, obj)
+            if hint:
+                metadata["note"] = hint
+
         return {
             "status": "success",
             "data": associations,
-            "metadata": {
-                "source": "Monarch Initiative V3",
-                "subject": subject,
-                "category": category,
-                "total_results": data.get("total", len(associations)),
-            },
+            "metadata": metadata,
         }
 
     def _search(self, arguments: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/tooluniverse/orphanet_tool.py
+++ b/src/tooluniverse/orphanet_tool.py
@@ -324,6 +324,38 @@ class OrphanetTool(BaseTool):
             },
         }
 
+    def _lookup_orpha_name(self, orpha_code: str) -> "tuple[bool, str | None]":
+        """Resolve an ORPHA code against the RDcode Name endpoint.
+
+        Returns ``(code_exists, preferred_term)``. A 404 from this endpoint
+        is the only signal that definitively means the ORPHA code itself is
+        unknown -- every dataset-specific Orphadata endpoint 404s both for
+        an unknown code AND for a real disease that simply has no record in
+        that particular dataset. Anything other than a clean 200 leaves the
+        preferred term as None; network errors and non-404 failures report
+        ``(True, None)`` -- "can't tell, proceed" -- so a transient lookup
+        failure never manufactures a false "disease not found".
+        """
+        try:
+            response = requests.get(
+                f"{RDCODE_API_URL}/EN/ClinicalEntity/orphacode/{orpha_code}/Name",
+                timeout=self.timeout,
+                headers=get_rdcode_headers(),
+            )
+        except requests.exceptions.RequestException:
+            return True, None
+        if response.status_code == 404:
+            return False, None
+        if response.status_code != 200:
+            return True, None
+        try:
+            payload = response.json()
+        except ValueError:
+            return True, None
+        if isinstance(payload, dict):
+            return True, payload.get("Preferred term") or payload.get("Name") or None
+        return True, None
+
     def _orpha_code_exists(self, orpha_code: str) -> bool:
         """True unless the RDcode Name endpoint definitively 404s for this
         ORPHA code -- i.e. the code itself doesn't exist, as opposed to a
@@ -333,15 +365,7 @@ class OrphanetTool(BaseTool):
         they're treated as "can't tell, proceed" so a transient
         existence-check failure doesn't mask an otherwise-working request.
         """
-        try:
-            response = requests.get(
-                f"{RDCODE_API_URL}/EN/ClinicalEntity/orphacode/{orpha_code}/Name",
-                timeout=self.timeout,
-                headers=get_rdcode_headers(),
-            )
-        except requests.exceptions.RequestException:
-            return True
-        return response.status_code != 404
+        return self._lookup_orpha_name(orpha_code)[0]
 
     def _orpha_not_found_error(self, orpha_code: str) -> Optional[Dict[str, Any]]:
         """Standard "Disease not found" error payload if `orpha_code`
@@ -844,9 +868,40 @@ class OrphanetTool(BaseTool):
 
         except requests.exceptions.HTTPError as e:
             if e.response.status_code == 404:
+                # Orphadata answers with a byte-identical 404 body
+                # ({"error":{"code":404,"type":"Query not found"}}) for a
+                # genuinely unknown ORPHA code AND for a real, current
+                # disease that simply has no record in the rd-phenotypes
+                # dataset. Confirmed live: ORPHA:1247 (Schistosomiasis)
+                # 404s here, yet resolves fine on RDcode and on the
+                # natural-history and ICD-mapping datasets. Blanket-
+                # reporting "disease not found" was therefore a false
+                # statement, and its advice to run Orphanet_search_diseases
+                # sent the caller into a loop -- that search hands ORPHA:1247
+                # straight back. Discriminate with the RDcode Name endpoint,
+                # the same existence check the sibling operations already
+                # use (Fix-R20D-1): it 200s for 1247 and 404s only for a
+                # truly unknown code.
+                code_exists, preferred_term = self._lookup_orpha_name(orpha_code)
+                if not code_exists:
+                    return {
+                        "status": "error",
+                        "error": f"Disease ORPHA:{orpha_code} not found. Use Orphanet_search_diseases to find a valid ORPHA code.",
+                    }
+                named = f" ({preferred_term})" if preferred_term else ""
                 return {
                     "status": "error",
-                    "error": f"Disease ORPHA:{orpha_code} not found. Use Orphanet_search_diseases to find a valid ORPHA code.",
+                    "error": (
+                        f"No HPO phenotype annotations available for "
+                        f"ORPHA:{orpha_code}{named}: Orphanet's rd-phenotypes "
+                        "dataset holds no record for this code. The ORPHA code "
+                        "itself is valid and current, so re-searching for it "
+                        "will not help -- Orphanet curates phenotype "
+                        "annotations for only a subset of its diseases. Other "
+                        "Orphanet datasets may still cover this code: try "
+                        "Orphanet_get_disease, Orphanet_get_natural_history, "
+                        "Orphanet_get_epidemiology or Orphanet_get_icd_mapping."
+                    ),
                 }
             return {"status": "error", "error": f"HTTP error: {e.response.status_code}"}
         except requests.exceptions.RequestException as e:

--- a/src/tooluniverse/pfam_tool.py
+++ b/src/tooluniverse/pfam_tool.py
@@ -23,6 +23,27 @@ from .base_tool import BaseTool
 INTERPRO_BASE_URL = "https://www.ebi.ac.uk/interpro/api"
 
 
+def _json_or_none(response):
+    """Parse a JSON response body, returning None when there is no body.
+
+    The InterPro API reports an empty result set as HTTP 204 No Content with a
+    zero-length body instead of a 200 carrying ``{"count": 0, "results": []}``.
+    ``raise_for_status()`` treats 204 as success, so calling ``.json()`` on it
+    raises a JSONDecodeError that used to escape as an opaque
+    "Unexpected error querying Pfam API" message -- callers could not tell
+    "no such family" from "the tool is broken".
+
+    Callers translate a ``None`` return into their own empty-result shape (for
+    search/list endpoints) or a not-found error (for single-record endpoints).
+    """
+    if response.status_code == 204:
+        return None
+    body = response.content
+    if not body or not body.strip():
+        return None
+    return response.json()
+
+
 class PfamTool(BaseTool):
     """
     Tool for Pfam protein family queries via the InterPro API.
@@ -61,8 +82,8 @@ class PfamTool(BaseTool):
                     "status": "error",
                     "error": f"Not found in Pfam/InterPro: {param}",
                 }
-            if code == 204:
-                return {"status": "error", "error": "No results found"}
+            # NB: 204 never reaches here -- raise_for_status() only raises for
+            # 4xx/5xx. It is handled as an empty result set by _json_or_none().
             return {"status": "error", "error": f"InterPro/Pfam API HTTP error: {code}"}
         except Exception as e:
             return {
@@ -108,7 +129,9 @@ class PfamTool(BaseTool):
         params = {"search": query, "page_size": max_results}
         response = requests.get(url, params=params, timeout=self.timeout)
         response.raise_for_status()
-        data = response.json()
+        # HTTP 204 / empty body == "no family matched"; report it as an empty
+        # result set rather than letting .json() raise.
+        data = _json_or_none(response) or {}
 
         total = data.get("count", 0)
         results = data.get("results", [])
@@ -151,7 +174,14 @@ class PfamTool(BaseTool):
         url = f"{INTERPRO_BASE_URL}/entry/pfam/{pfam_acc}"
         response = requests.get(url, timeout=self.timeout)
         response.raise_for_status()
-        data = response.json()
+        # A single-record endpoint answers an unknown accession with HTTP 204,
+        # not 404. Report it as not-found rather than a success full of blanks.
+        data = _json_or_none(response)
+        if data is None:
+            return {
+                "status": "error",
+                "error": f"Not found in Pfam/InterPro: {pfam_acc}",
+            }
 
         meta = data.get("metadata", {})
         name_info = meta.get("name", {})
@@ -249,7 +279,8 @@ class PfamTool(BaseTool):
         params = {"page_size": max_results}
         response = requests.get(url, params=params, timeout=self.timeout)
         response.raise_for_status()
-        data = response.json()
+        # HTTP 204 / empty body == "no protein matched this family (+ filter)".
+        data = _json_or_none(response) or {}
 
         total = data.get("count", 0)
         results = data.get("results", [])
@@ -315,7 +346,8 @@ class PfamTool(BaseTool):
         params = {"page_size": 50}
         response = requests.get(url, params=params, timeout=self.timeout)
         response.raise_for_status()
-        data = response.json()
+        # HTTP 204 / empty body == "this protein has no Pfam annotations".
+        data = _json_or_none(response) or {}
 
         results = data.get("results", [])
 
@@ -380,7 +412,8 @@ class PfamTool(BaseTool):
 
         response = requests.get(url, params=params, timeout=self.timeout)
         response.raise_for_status()
-        data = response.json()
+        # HTTP 204 / empty body == "no clan matched".
+        data = _json_or_none(response) or {}
 
         total = data.get("count", 0)
         results = data.get("results", [])
@@ -425,7 +458,8 @@ class PfamTool(BaseTool):
         params = {"page_size": max_results}
         response = requests.get(url, params=params, timeout=self.timeout)
         response.raise_for_status()
-        data = response.json()
+        # HTTP 204 / empty body == "no proteome carries this family".
+        data = _json_or_none(response) or {}
 
         total = data.get("count", 0)
         results = data.get("results", [])

--- a/src/tooluniverse/sider_tool.py
+++ b/src/tooluniverse/sider_tool.py
@@ -17,12 +17,63 @@ Reference: Kuhn et al., Nucleic Acids Res. 2016; 44(D1): D1075-D1079
 
 import re
 import requests
+from html import unescape
 from typing import Dict, Any, Optional, List
 from .base_tool import BaseTool
 from .tool_registry import register_tool
 
 
 SIDER_BASE_URL = "http://sideeffects.embl.de"
+
+# Column layout of the side-effect table on a SIDER drug page
+# (http://sideeffects.embl.de/drugs/<id>/). Verified against the live page:
+# the header row is
+#   <th>Side effect</th> <th>Data for drug</th> <th>Placebo</th>
+#   <th colspan="N">Labels</th>
+# so every data row starts with these three fixed cells, followed by one cell
+# per source label. The trailing label cells carry per-label tooltips such as
+# title="<b>Acitretin</b> : 65%", so percentages MUST be read from their own
+# <td> and never by scanning the whole <tr>.
+SE_NAME_COL = 0
+DRUG_FREQUENCY_COL = 1
+PLACEBO_FREQUENCY_COL = 2
+
+_TD_RE = re.compile(r"<td\b[^>]*>(.*?)</td>", re.DOTALL | re.IGNORECASE)
+_TAG_RE = re.compile(r"<[^>]+>")
+
+
+def _split_row_cells(row_html: str) -> List[str]:
+    """Split a table row's inner HTML into the inner HTML of its <td> cells."""
+    return _TD_RE.findall(row_html)
+
+
+def _cell_text(cell_html: str) -> Optional[str]:
+    """
+    Return the visible text of a single <td>, or None when the cell is empty.
+
+    SIDER renders "no data" as a physically empty cell (e.g. no placebo arm in
+    the label), so an empty cell must map to None rather than being back-filled
+    from anywhere else in the row.
+    """
+    text = unescape(_TAG_RE.sub(" ", cell_html))
+    text = re.sub(r"\s+", " ", text).strip()
+    return text or None
+
+
+class SiderUpstreamError(Exception):
+    """
+    SIDER answered with an unexpected HTTP status that is not a genuine 404.
+
+    Kept distinct from "the record does not exist" so that a temporary outage of
+    the SIDER website (which answers 5xx with a "Page unavailable" body) is not
+    reported to callers as a stable absence of the drug.
+    """
+
+    def __init__(self, url: str, status_code: int, message: str):
+        self.url = url
+        self.status_code = status_code
+        self.retryable = status_code >= 500
+        super().__init__(message)
 
 
 @register_tool("SiderTool")
@@ -76,6 +127,13 @@ class SiderTool(BaseTool):
 
         try:
             return handler(arguments)
+        except SiderUpstreamError as e:
+            return {
+                "status": "error",
+                "error": str(e),
+                "http_status": e.status_code,
+                "retryable": e.retryable,
+            }
         except requests.exceptions.Timeout:
             return {"status": "error", "error": "SIDER request timed out"}
         except requests.exceptions.ConnectionError:
@@ -87,12 +145,35 @@ class SiderTool(BaseTool):
             }
 
     def _fetch_page(self, path: str) -> Optional[str]:
-        """Fetch an HTML page from SIDER."""
+        """
+        Fetch an HTML page from SIDER.
+
+        Returns the page body on HTTP 200 and None on a genuine HTTP 404 (the
+        record really is absent). Any other status raises SiderUpstreamError so
+        that a server-side failure is never mistaken for a missing record.
+        """
         url = "{}/{}".format(SIDER_BASE_URL, path.lstrip("/"))
         response = self.session.get(url, timeout=self.timeout)
-        if response.status_code == 200:
+        status = response.status_code
+        if status == 200:
             return response.text
-        return None
+        if status == 404:
+            return None
+        if status >= 500:
+            raise SiderUpstreamError(
+                url,
+                status,
+                (
+                    "SIDER server error (HTTP {}) from {}. The SIDER website is "
+                    "temporarily unavailable; this is a transient upstream "
+                    "failure and the request should be retried later."
+                ).format(status, url),
+            )
+        raise SiderUpstreamError(
+            url,
+            status,
+            "SIDER returned unexpected HTTP {} from {}".format(status, url),
+        )
 
     def _search_drug(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Search for a drug by name using SIDER's search endpoint."""
@@ -193,12 +274,22 @@ class SiderTool(BaseTool):
 
         side_effects = []
         for row in se_rows:
-            # Extract MedDRA code and name
+            # Parse the row into its cells. Every value below is read from the
+            # cell that actually holds it: a row-wide regex would also match the
+            # per-label tooltips ("<b>Acitretin</b> : 65%") and percentages that
+            # occur inside the MedDRA concept description prose, and would
+            # attribute those numbers to the drug or to placebo.
+            cells = _split_row_cells(row)
+            name_cell = cells[SE_NAME_COL] if cells else row
+
+            # Extract MedDRA code and name from the "Side effect" cell
             se_match = re.search(
-                r'href="/se/(C\d+)/"[^>]*title="([^"]*)"[^>]*>([^<]+)', row
+                r'href="/se/(C\d+)/"[^>]*title="([^"]*)"[^>]*>([^<]+)', name_cell
             )
             if not se_match:
-                se_match_simple = re.search(r'href="/se/(C\d+)/"[^>]*>([^<]+)', row)
+                se_match_simple = re.search(
+                    r'href="/se/(C\d+)/"[^>]*>([^<]+)', name_cell
+                )
                 if not se_match_simple:
                     continue
                 code = se_match_simple.group(1)
@@ -209,10 +300,20 @@ class SiderTool(BaseTool):
                 description = se_match.group(2)
                 name = se_match.group(3).strip()
 
-            # Extract frequency percentages
-            pct_matches = re.findall(r"([\d.]+%\s*-\s*[\d.]+%|[\d.]+%)", row)
-            frequency = pct_matches[0] if pct_matches else None
-            placebo_frequency = pct_matches[1] if len(pct_matches) > 1 else None
+            # Read each frequency from its own column. SIDER leaves the placebo
+            # cell physically empty whenever the label reports no placebo arm,
+            # which is the common case; that must surface as null and never as a
+            # copy of the drug's own rate.
+            frequency = (
+                _cell_text(cells[DRUG_FREQUENCY_COL])
+                if len(cells) > DRUG_FREQUENCY_COL
+                else None
+            )
+            placebo_frequency = (
+                _cell_text(cells[PLACEBO_FREQUENCY_COL])
+                if len(cells) > PLACEBO_FREQUENCY_COL
+                else None
+            )
 
             entry = {
                 "meddra_code": code,

--- a/src/tooluniverse/togoid_tool.py
+++ b/src/tooluniverse/togoid_tool.py
@@ -22,8 +22,36 @@ from .tool_registry import register_tool
 
 TOGOID_BASE = "https://api.togoid.dbcls.jp"
 
+# Guidance appended to TogoID's own explanation of an unroutable conversion.
+ROUTE_GUIDANCE = (
+    "source and target must be directly related; pick adjacent dataset types "
+    "or convert via an intermediate. TogoID itself supports multi-hop routes, "
+    "but this tool issues a direct 2-step route."
+)
 
-def _togoid_get(path: str, timeout: int, params: Dict[str, Any] | None = None):
+
+def _upstream_message(resp) -> str | None:
+    """Best-effort extraction of TogoID's explanatory {"message": ...} body.
+
+    TogoID reports actionable failures (notably ``no route: a <> b``) as a JSON
+    message served with HTTP 400, so the body is the only useful part of the
+    response. Returns None when the body is missing, non-JSON, or unhelpful.
+    """
+    try:
+        body = resp.json()
+    except (ValueError, requests.exceptions.RequestException):
+        return None
+    if isinstance(body, dict) and body.get("message"):
+        return str(body["message"]).strip()
+    return None
+
+
+def _togoid_get(
+    path: str,
+    timeout: int,
+    params: Dict[str, Any] | None = None,
+    error_hint: str = "",
+):
     """GET a TogoID endpoint and return (payload, None) or (None, error_dict)."""
     try:
         resp = requests.get(
@@ -32,6 +60,15 @@ def _togoid_get(path: str, timeout: int, params: Dict[str, Any] | None = None):
             headers={"Accept": "application/json"},
             timeout=timeout,
         )
+        if resp.status_code >= 400:
+            # Surface the server's own explanation before raise_for_status()
+            # collapses it into an opaque "400 Client Error for url: ..." dump.
+            message = _upstream_message(resp)
+            if message:
+                error = f"TogoID: {message}."
+                if error_hint:
+                    error = f"{error} {error_hint}"
+                return None, {"status": "error", "error": error}
         resp.raise_for_status()
         return resp.json(), None
     except requests.exceptions.Timeout:
@@ -65,7 +102,9 @@ class TogoIDConvertTool(BaseTool):
             }
 
         params = {"ids": ids, "route": f"{source},{target}", "format": "json"}
-        payload, error = _togoid_get("/convert", self.timeout, params=params)
+        payload, error = _togoid_get(
+            "/convert", self.timeout, params=params, error_hint=ROUTE_GUIDANCE
+        )
         if error:
             return error
 
@@ -73,8 +112,7 @@ class TogoIDConvertTool(BaseTool):
         if isinstance(payload, dict) and payload.get("message"):
             return {
                 "status": "error",
-                "error": f"TogoID: {payload['message']}. source and target must be directly "
-                "related; pick adjacent dataset types or convert via an intermediate.",
+                "error": f"TogoID: {payload['message']}. {ROUTE_GUIDANCE}",
             }
 
         results = payload.get("results", []) if isinstance(payload, dict) else []

--- a/src/tooluniverse/unichem_tool.py
+++ b/src/tooluniverse/unichem_tool.py
@@ -115,6 +115,7 @@ class UniChemTool(BaseTool):
                     "inchi": None,
                     "inchikey": None,
                     "formula": None,
+                    "uci": None,
                     "source_count": 0,
                     "sources": [],
                 },
@@ -146,16 +147,19 @@ class UniChemTool(BaseTool):
                 }
             )
 
-        # Derive InChIKey from InChI if not directly available
-        if inchi_str:
-            # Try to find it from sources or connectivity info
-            for s in sources_raw:
-                pass  # InChIKey might not be directly in compound response
+        # The /compounds response carries the standard InChIKey at the top
+        # level (same field ``_connectivity_search`` reads). Fall back to
+        # echoing the query only when the API omits it, so callers that
+        # searched by InChIKey never lose the value they had before.
+        inchikey = first.get("standardInchiKey")
+        if not inchikey:
+            inchikey = compound if search_type == "inchikey" else None
 
         result = {
             "inchi": inchi_str,
-            "inchikey": compound if search_type == "inchikey" else None,
+            "inchikey": inchikey,
             "formula": formula,
+            "uci": first.get("uci"),
             "source_count": len(sources),
             "sources": sources,
         }

--- a/src/tooluniverse/worms_tool.py
+++ b/src/tooluniverse/worms_tool.py
@@ -70,10 +70,31 @@ class WoRMSRESTTool(BaseTool):
             result["count"] = len(data)
         return result
 
+    @staticmethod
+    def _parse_marine_only(arguments: Dict[str, Any]):
+        """Read the optional `marine_only` argument.
+
+        Returns ``(value, error)`` where ``value`` is ``None`` when the caller
+        did not set the parameter, so the request can be sent exactly as it was
+        before this parameter existed.
+        """
+        raw = arguments.get("marine_only")
+        if "marine_only" not in arguments or raw is None:
+            return None, None
+        if isinstance(raw, bool):
+            return raw, None
+        if isinstance(raw, str) and raw.strip().lower() in ("true", "false"):
+            return raw.strip().lower() == "true", None
+        return None, f"marine_only must be a boolean, got: {raw!r}"
+
     def _run_search_by_name(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         query = arguments.get("query", "")
         if not query:
             return {"status": "error", "error": "Query parameter is required"}
+
+        marine_only, marine_error = self._parse_marine_only(arguments)
+        if marine_error:
+            return {"status": "error", "error": marine_error}
 
         try:
             limit = int(arguments.get("limit", 20))
@@ -91,9 +112,19 @@ class WoRMSRESTTool(BaseTool):
             return {"status": "error", "error": f"limit must be >= 1, got {limit}"}
         offset = max(offset, 1)
 
+        # WoRMS applies `marine_only=true` on AphiaRecordsByName unless told
+        # otherwise, so records flagged only freshwater/terrestrial (e.g. the
+        # parasite Schistosoma mansoni, AphiaID 1599676) are filtered out
+        # upstream. Send the parameter only when the caller set it explicitly:
+        # callers who omit it keep byte-identical requests and result sets.
+        marine_suffix = (
+            "" if marine_only is None else f"&marine_only={str(marine_only).lower()}"
+        )
+        effective_marine_only = True if marine_only is None else marine_only
+
         encoded_query = urllib.parse.quote(query)
         base_url = f"{self.base_url}/AphiaRecordsByName/{encoded_query}"
-        first_url = f"{base_url}?offset={offset}"
+        first_url = f"{base_url}?offset={offset}{marine_suffix}"
 
         # WoRMS caps every AphiaRecordsByName response at _PAGE_SIZE records and
         # pages with a 1-based `offset`. Walk pages until the caller's `limit` is
@@ -102,7 +133,7 @@ class WoRMSRESTTool(BaseTool):
         records: list = []
         page_offset = offset
         while len(records) <= limit:
-            url = f"{base_url}?offset={page_offset}"
+            url = f"{base_url}?offset={page_offset}{marine_suffix}"
             try:
                 response = self.session.get(url, timeout=self.timeout)
                 # 204 / empty body = no (further) records for this query.
@@ -120,6 +151,18 @@ class WoRMSRESTTool(BaseTool):
             page_offset += self._PAGE_SIZE
 
         if not records:
+            message = "No results found for this query"
+            if effective_marine_only:
+                # An empty page under the upstream marine filter is ambiguous:
+                # the name may be unknown to WoRMS, or known but non-marine.
+                # Say so instead of reporting a confident "not found".
+                message += (
+                    ". Note that WoRMS restricted this search to marine taxa "
+                    "(marine_only defaults to true), so species recorded only "
+                    "as freshwater or terrestrial are excluded. Retry with "
+                    "marine_only=false to include freshwater/terrestrial "
+                    "species."
+                )
             return {
                 "status": "success",
                 "data": [],
@@ -127,8 +170,9 @@ class WoRMSRESTTool(BaseTool):
                 "count": 0,
                 "offset": offset,
                 "limit": limit,
+                "marine_only": effective_marine_only,
                 "has_more": False,
-                "message": "No results found for this query",
+                "message": message,
             }
 
         has_more = len(records) > limit
@@ -140,6 +184,7 @@ class WoRMSRESTTool(BaseTool):
             "count": len(page),
             "offset": offset,
             "limit": limit,
+            "marine_only": effective_marine_only,
             "has_more": has_more,
         }
 

--- a/tests/unit/test_drugcentral_activity_scale_disclosed.py
+++ b/tests/unit/test_drugcentral_activity_scale_disclosed.py
@@ -1,0 +1,190 @@
+"""Round 31: DrugCentral_get_targets emitted a p-scale potency under a bare
+"IC50" label with no units.
+
+DrugCentral (via MyChem.info) stores bioactivity potency in ``act_value`` on
+the pChEMBL scale -- ``-log10`` of the molar potency -- not as a nM/uM
+concentration. The tool renamed that field to ``activity_value`` and paired it
+with ``activity_type: "IC50"``, so a caller reading
+``{"activity_type": "IC50", "activity_value": "4.01"}`` naturally reads it as
+an IC50 of 4.01 nM (or uM). The real IC50 is 10^-4.01 M = ~96800 nM (96.8 uM)
+-- verified against ChEMBL for praziquantel/ABCB11 (CHEMBL976/CHEMBL6020:
+IC50 96800 nM, pchembl 4.01) and for miltefosine/AKT1 (IC50 9600 nM,
+pchembl 5.02). That is a ~5-order-of-magnitude misstatement.
+
+The fix is purely additive: ``activity_value`` and ``activity_type`` keep
+their exact upstream values, and new sibling keys
+(``activity_type_reported``, ``activity_value_scale``, ``activity_value_nM``)
+make the scale unambiguous.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.drugcentral_tool import DrugCentralTool
+
+pytestmark = pytest.mark.unit
+
+
+# Shape copied from the live response for
+# https://mychem.info/v1/query?q=drugcentral.xrefs.chembl_id:CHEMBL976&fields=drugcentral.bioactivity
+_PRAZIQUANTEL_TARGETS_RESPONSE = {
+    "_id": "FSVJFNAIGNNGKK-UHFFFAOYSA-N",
+    "drugcentral": {
+        "_license": "http://bit.ly/2SeEhUy",
+        "structures": {"inn": "praziquantel"},
+        "bioactivity": {
+            "act_source": "CHEMBL",
+            "act_type": "IC50",
+            "act_value": "4.01",
+            "organism": "Homo sapiens",
+            "target_class": "Transporter",
+            "target_name": "Bile salt export pump",
+            "uniprot": [
+                {
+                    "gene_symbol": "ABCB11",
+                    "swissprot_entry": "ABCBB_HUMAN",
+                    "uniprot_id": "O95342",
+                }
+            ],
+        },
+    },
+}
+
+# Upstream legitimately omits act_type/act_value for many rows (34 of 143 in a
+# live sample), and MoA-only rows carry an action_type but no potency at all.
+_MISSING_AND_JUNK_VALUES_RESPONSE = {
+    "_id": "XZWYZXLIPXDOLR-UHFFFAOYSA-N",
+    "drugcentral": {
+        "structures": {"inn": "metformin"},
+        "bioactivity": [
+            {
+                "act_source": "DRUG LABEL",
+                "action_type": "INHIBITOR",
+                "moa": "1",
+                "organism": "Homo sapiens",
+                "target_name": "Solute carrier family 22 member 1",
+                "uniprot": [{"gene_symbol": "SLC22A1", "uniprot_id": "O15245"}],
+            },
+            {
+                "act_source": "WOMBAT-PK",
+                "act_type": "Ki",
+                "act_value": "",
+                "target_name": "Empty string value",
+            },
+            {
+                "act_source": "CHEMBL",
+                "act_type": "IC50",
+                "act_value": "not-a-number",
+                "target_name": "Unparseable value",
+            },
+            {
+                "act_source": "CHEMBL",
+                "act_type": "Kd",
+                "act_value": None,
+                "target_name": "Explicit null value",
+            },
+        ],
+    },
+}
+
+
+def _tool(operation="get_targets"):
+    return DrugCentralTool(
+        {"name": "drugcentral_test", "fields": {"operation": operation}}
+    )
+
+
+def _resp(json_body):
+    r = MagicMock()
+    r.status_code = 200
+    r.json.return_value = json_body
+    r.raise_for_status = MagicMock()
+    return r
+
+
+def _run(payload, arguments):
+    tool = _tool()
+    with patch("tooluniverse.drugcentral_tool.requests.get", return_value=_resp(payload)):
+        return tool.run(arguments)
+
+
+class TestPScaleDisclosed:
+    def test_activity_value_is_unchanged(self):
+        """Additive fix: existing callers must still see the exact old value."""
+        result = _run(_PRAZIQUANTEL_TARGETS_RESPONSE, {"chem_id": "CHEMBL976"})
+
+        assert result["status"] == "success"
+        target = result["data"]["targets"][0]
+        assert target["activity_value"] == "4.01"
+        assert target["activity_type"] == "IC50"
+
+    def test_scale_and_units_keys_present(self):
+        result = _run(_PRAZIQUANTEL_TARGETS_RESPONSE, {"chem_id": "CHEMBL976"})
+        target = result["data"]["targets"][0]
+
+        assert target["activity_type_reported"] == "pIC50"
+
+        scale = target["activity_value_scale"]
+        assert isinstance(scale, str) and scale
+        # Must say -log10 / molar and must say it is not a concentration.
+        assert "-log10" in scale
+        assert "not a concentration" in scale.lower()
+
+    def test_derived_nanomolar_matches_chembl(self):
+        """pIC50 4.01 -> ~96800 nM, per ChEMBL activity CHEMBL976/CHEMBL6020."""
+        result = _run(_PRAZIQUANTEL_TARGETS_RESPONSE, {"chem_id": "CHEMBL976"})
+        nanomolar = result["data"]["targets"][0]["activity_value_nM"]
+
+        assert nanomolar == pytest.approx(96800, rel=0.05)
+        # Sanity: the old bare number would have been read as ~4 nM.
+        assert nanomolar > 10000
+
+    def test_derived_nanomolar_for_miltefosine_akt1(self):
+        """Second verified point: pIC50 5.02 -> ~9600 nM (ChEMBL AKT1)."""
+        payload = {
+            "drugcentral": {
+                "structures": {"inn": "miltefosine"},
+                "bioactivity": {
+                    "act_source": "CHEMBL",
+                    "act_type": "IC50",
+                    "act_value": "5.02",
+                    "target_name": "Serine/threonine-protein kinase AKT",
+                    "uniprot": [{"gene_symbol": "AKT1", "uniprot_id": "P31749"}],
+                },
+            }
+        }
+        result = _run(payload, {"chem_id": "CHEMBL1200365"})
+        target = result["data"]["targets"][0]
+
+        assert target["activity_value"] == "5.02"
+        assert target["activity_type_reported"] == "pIC50"
+        assert target["activity_value_nM"] == pytest.approx(9600, rel=0.05)
+
+
+class TestNonNumericAndMissingValues:
+    def test_no_crash_and_no_fabricated_concentration(self):
+        result = _run(_MISSING_AND_JUNK_VALUES_RESPONSE, {"chem_id": "CHEMBL1431"})
+
+        assert result["status"] == "success"
+        targets = result["data"]["targets"]
+        assert len(targets) == 4
+
+        for target in targets:
+            # Key may be absent or null, but must never be a made-up number.
+            assert target.get("activity_value_nM") is None
+
+    def test_missing_activity_type_yields_null_reported_type(self):
+        result = _run(_MISSING_AND_JUNK_VALUES_RESPONSE, {"chem_id": "CHEMBL1431"})
+        moa_only = result["data"]["targets"][0]
+
+        assert moa_only["activity_type"] is None
+        assert moa_only.get("activity_type_reported") is None
+        assert moa_only["is_moa"] is True
+
+    def test_present_activity_type_still_gets_p_prefix(self):
+        result = _run(_MISSING_AND_JUNK_VALUES_RESPONSE, {"chem_id": "CHEMBL1431"})
+        by_name = {t["target_name"]: t for t in result["data"]["targets"]}
+
+        assert by_name["Empty string value"]["activity_type_reported"] == "pKi"
+        assert by_name["Explicit null value"]["activity_type_reported"] == "pKd"

--- a/tests/unit/test_gwas_filter_not_blamed_on_trait.py
+++ b/tests/unit/test_gwas_filter_not_blamed_on_trait.py
@@ -1,0 +1,383 @@
+"""Round-31 regression guards for src/tooluniverse/gwas_tool.py.
+
+Issue 1 -- a client-side filter's zero result was blamed on the trait.
+    gwas_search_associations '{"efo_id":"EFO_0004340","p_value":5e-08,
+    "sort":"p_value","direction":"desc","size":10}' returned data=[] with a
+    note telling the caller their EFO term was probably wrong -- in the same
+    payload that reported pagination.totalElements=23608 for BMI, one of the
+    best-populated traits in GWAS Catalog. The p_value threshold was never
+    sent upstream; it was applied client-side to a page fetched
+    direction=desc, i.e. the LEAST significant rows, so every row failed.
+
+    The GWAS Catalog REST API v2 genuinely has no server-side p-value filter.
+    Verified against its OpenAPI document
+    (https://www.ebi.ac.uk/gwas/rest/api/v2/rest-api-doc.yaml): GET
+    /v2/associations declares only pubmed_id, rs_id, full_pvalue_set,
+    accession_id, efo_trait, efo_id, show_child_trait, mapped_gene,
+    extended_geneset, sort, direction, page, size. `p_upper` merely gets
+    echoed back inside the HAL _links hrefs -- confirmed live that
+    ...&sort=p_value&direction=asc&p_upper=1e-300 still returns all 68
+    associations for EFO_0009184. So the threshold stays client-side, and the
+    fix is (i) fetch the page most-significant-first so the threshold can
+    actually pass rows, (ii) attribute an empty result to the filter rather
+    than to the trait, and (iii) disclose that pagination totals are
+    pre-filter.
+
+Issue 2 -- a trait name was silently resolved to a different phenotype.
+    disease_trait="cardiorespiratory fitness" resolves to EFO_0009184
+    ("heart rate response to exercise"), not EFO_0004887 ("maximal oxygen
+    uptake measurement"). The resolution is unchanged (re-tuning the matcher
+    is out of scope); it is now disclosed: the resolved label and the
+    original query string travel back with the id.
+
+Offline only: every HTTP call is patched.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from tooluniverse.gwas_tool import (
+    GWASAssociationSearch,
+    GWASAssociationsForTrait,
+)
+
+pytestmark = pytest.mark.unit
+
+# Query parameters GET /v2/associations actually declares in the v2 OpenAPI doc.
+_SPEC_PARAMS = {
+    "pubmed_id",
+    "rs_id",
+    "full_pvalue_set",
+    "accession_id",
+    "efo_trait",
+    "efo_id",
+    "show_child_trait",
+    "mapped_gene",
+    "extended_geneset",
+    "sort",
+    "direction",
+    "page",
+    "size",
+}
+
+
+def _assoc(p_value):
+    return {"association_id": int(-1 / p_value) if p_value else 0, "p_value": p_value}
+
+
+def _run(arguments, associations, page=None):
+    """Run gwas_search_associations offline; return (result, captured params)."""
+    captured = {}
+
+    def fake_request(endpoint, params=None):
+        captured["endpoint"] = endpoint
+        captured["params"] = params or {}
+        return {
+            "_embedded": {"associations": list(associations)},
+            "page": page
+            if page is not None
+            else {"size": 10, "totalElements": 23608, "totalPages": 2361, "number": 0},
+        }
+
+    tool = GWASAssociationSearch({"name": "gwas_search_associations"})
+    with patch.object(GWASAssociationSearch, "_make_request", side_effect=fake_request):
+        result = tool.run(arguments)
+    return result, captured["params"]
+
+
+# --------------------------------------------------------------------------
+# (a) the request carries the ordering that makes the threshold real, and
+#     nothing the API does not understand
+# --------------------------------------------------------------------------
+
+
+def test_pvalue_filtered_request_is_fetched_most_significant_first():
+    """direction=desc + p_value used to guarantee an empty page.
+
+    The threshold cannot be pushed upstream (the v2 spec has no p-value
+    parameter), so the request must instead be ordered p_value-ascending --
+    otherwise the client-side filter is applied to exactly the rows that
+    cannot pass it.
+    """
+    _, params = _run(
+        {
+            "efo_id": "EFO_0004340",
+            "p_value": 5e-08,
+            "sort": "p_value",
+            "direction": "desc",
+            "size": 10,
+        },
+        [_assoc(1e-300), _assoc(1e-100), _assoc(5e-09), _assoc(1e-03)],
+    )
+    assert params["sort"] == "p_value"
+    assert params["direction"] == "asc", (
+        "a p-value threshold must be evaluated against the most-significant "
+        "end of the result set"
+    )
+
+
+def test_request_sends_only_parameters_the_v2_api_declares():
+    """No made-up threshold parameter is smuggled upstream.
+
+    `p_upper` and friends are silently ignored by GWAS Catalog (they are only
+    echoed into _links), so sending one would fake a server-side filter.
+    """
+    _, params = _run(
+        {"efo_id": "EFO_0004340", "p_value": 5e-08, "size": 10},
+        [_assoc(1e-300)],
+    )
+    assert set(params) <= _SPEC_PARAMS, (
+        f"undeclared params sent: {set(params) - _SPEC_PARAMS}"
+    )
+    for bogus in ("p_upper", "p_value", "p_value_threshold", "pvalue_upper"):
+        assert bogus not in params
+
+
+def test_desc_request_still_returns_the_significant_rows():
+    """The BMI repro: data must no longer be empty."""
+    result, _ = _run(
+        {
+            "efo_id": "EFO_0004340",
+            "p_value": 5e-08,
+            "sort": "p_value",
+            "direction": "desc",
+            "size": 10,
+        },
+        [_assoc(1e-300), _assoc(1e-100), _assoc(5e-09), _assoc(1e-03)],
+    )
+    assert [a["p_value"] for a in result["data"]] == [5e-09, 1e-100, 1e-300]
+    assert "note" not in result
+    assert result["metadata"]["sort_override"]["fetched_direction"] == "asc"
+    assert result["metadata"]["sort_override"]["requested_direction"] == "desc"
+
+
+# --------------------------------------------------------------------------
+# (b) an empty page caused by the filter blames the filter, not the trait
+# --------------------------------------------------------------------------
+
+
+def test_filter_emptied_page_note_names_the_filter():
+    result, _ = _run(
+        {"efo_id": "EFO_0004340", "p_value": 1e-320, "size": 10},
+        [_assoc(1e-300), _assoc(1e-100), _assoc(5e-09)],
+        page={"size": 10, "totalElements": 23608, "totalPages": 2361, "number": 0},
+    )
+    assert result["data"] == []
+    note = result["note"]
+    assert "filter" in note.lower()
+    assert "1e-320" in note
+    assert "23608" in note, "the note should show how much data the trait really has"
+    assert "removed" in note.lower()
+
+
+def test_filter_emptied_page_note_does_not_blame_the_efo_term():
+    result, _ = _run(
+        {"efo_id": "EFO_0004340", "p_value": 1e-320, "size": 10},
+        [_assoc(1e-300), _assoc(1e-100)],
+    )
+    note = result["note"]
+    assert "synonym" not in note.lower()
+    assert "different" not in note.lower() or "EFO/MONDO term" not in note
+    assert "GWAS_search_associations_by_gene" not in note
+    assert "gwas_get_snps_for_gene" not in note
+    assert "No associations found for EFO ID" not in note
+
+
+# --------------------------------------------------------------------------
+# (c) a genuinely empty UNFILTERED result set keeps the original advice
+# --------------------------------------------------------------------------
+
+
+def test_genuinely_empty_result_still_gets_trait_advice():
+    result, _ = _run(
+        {"efo_id": "EFO_0004340", "size": 10},
+        [],
+        page={"size": 10, "totalElements": 0, "totalPages": 0, "number": 0},
+    )
+    note = result["note"]
+    assert "No associations found for EFO ID 'EFO_0004340'" in note
+    assert "synonym" in note
+    assert "GWAS_search_associations_by_gene" in note
+    assert "gwas_get_snps_for_gene" in note
+
+
+def test_genuinely_empty_result_with_threshold_also_gets_trait_advice():
+    """A threshold that removed nothing must not hijack the trait advice."""
+    result, _ = _run(
+        {"efo_id": "EFO_0004340", "p_value": 5e-08, "size": 10},
+        [],
+        page={"size": 10, "totalElements": 0, "totalPages": 0, "number": 0},
+    )
+    assert "No associations found for EFO ID 'EFO_0004340'" in result["note"]
+
+
+# --------------------------------------------------------------------------
+# (d) pagination totals are disclosed as pre-filter
+# --------------------------------------------------------------------------
+
+
+def test_pagination_totals_are_disclosed_as_prefilter():
+    """EFO_0009184: 63 of 68 rows pass 5e-08, but totalElements stays 68."""
+    associations = [_assoc(1e-30)] * 63 + [_assoc(1e-03)] * 5
+    result, _ = _run(
+        {"efo_id": "EFO_0009184", "p_value": 5e-08, "size": 100},
+        associations,
+        page={"size": 100, "totalElements": 68, "totalPages": 1, "number": 0},
+    )
+    metadata = result["metadata"]
+    # totalElements keeps its established (unfiltered) meaning ...
+    assert metadata["pagination"]["totalElements"] == 68
+    # ... and the pre-filter nature is stated explicitly.
+    assert metadata["pagination_totals_are_prefilter"] is True
+    assert metadata["p_value_filter_scope"].startswith("client-side")
+    assert "client-side" in metadata["p_value_filter_note"].lower()
+    assert "UNFILTERED" in metadata["filtered_total_note"]
+    # ... alongside a separately named, correct filtered denominator.
+    assert metadata["filtered_total"] == 63
+    assert metadata["filtered_total_is_exact"] is True
+    assert metadata["filtered_count"] == 63
+    assert len(result["data"]) == 63
+
+
+def test_filtered_total_is_not_faked_when_a_page_cannot_determine_it():
+    """Every fetched row passed, so the true filtered total is unknown."""
+    result, _ = _run(
+        {"efo_id": "EFO_0004340", "p_value": 5e-08, "size": 3},
+        [_assoc(1e-300), _assoc(1e-100), _assoc(1e-30)],
+        page={"size": 3, "totalElements": 23608, "totalPages": 7870, "number": 0},
+    )
+    metadata = result["metadata"]
+    assert metadata["filtered_total"] is None
+    assert metadata["filtered_total_is_exact"] is False
+    assert metadata["filtered_total_at_least"] == 3
+    assert metadata["pagination_totals_are_prefilter"] is True
+
+
+# --------------------------------------------------------------------------
+# (e) a resolved trait discloses the EFO id, its label and the original query
+# --------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    def __init__(self, payload, status_code=200):
+        self._payload = payload
+        self.status_code = status_code
+
+    def json(self):
+        return self._payload
+
+
+def _fake_gwas_get(url, params=None, timeout=None, **kwargs):
+    """Reproduces the live resolver traffic for 'cardiorespiratory fitness'."""
+    if "efoTraits/search/findByEfoTrait" in url:
+        return _FakeResponse({"_embedded": {"efoTraits": []}})
+    if url.endswith("/v2/studies"):
+        return _FakeResponse(
+            {
+                "_embedded": {
+                    "studies": [
+                        {
+                            "accession_id": "GCST90310239",
+                            "disease_trait": "Cardiorespiratory fitness",
+                            "efo_traits": [
+                                {
+                                    "efo_id": "EFO_0009184",
+                                    "efo_trait": "heart rate response to exercise",
+                                }
+                            ],
+                        }
+                    ]
+                }
+            }
+        )
+    raise AssertionError(f"unexpected HTTP call in offline test: {url}")
+
+
+def _run_trait_tool(arguments, associations):
+    def fake_request(endpoint, params=None):
+        return {
+            "_embedded": {"associations": list(associations)},
+            "page": {"size": 3, "totalElements": 68, "totalPages": 23, "number": 0},
+        }
+
+    tool = GWASAssociationsForTrait({"name": "gwas_get_associations_for_trait"})
+    with patch("tooluniverse.gwas_tool.requests.get", side_effect=_fake_gwas_get):
+        with patch.object(
+            GWASAssociationsForTrait, "_make_request", side_effect=fake_request
+        ):
+            return tool.run(arguments)
+
+
+def test_resolved_trait_returns_id_label_and_original_query():
+    result = _run_trait_tool(
+        {"disease_trait": "cardiorespiratory fitness", "size": 3},
+        [_assoc(3e-30)],
+    )
+    assert result["resolved_efo_id"] == "EFO_0009184"
+    assert result["resolved_efo_label"] == "heart rate response to exercise"
+    assert result["query_trait"] == "cardiorespiratory fitness"
+    assert "GCST90310239" in result["trait_resolution_source"]
+
+
+def test_inexact_trait_resolution_is_flagged():
+    result = _run_trait_tool(
+        {"disease_trait": "cardiorespiratory fitness", "size": 3},
+        [_assoc(3e-30)],
+    )
+    note = result["trait_resolution_note"]
+    assert "cardiorespiratory fitness" in note
+    assert "heart rate response to exercise" in note
+    assert "EFO_0009184" in note
+    assert "not an exact match" in note.lower() or "SUBSTITUTION" in note
+
+
+def test_exact_trait_resolution_is_not_flagged_as_a_substitution():
+    def exact_get(url, params=None, timeout=None, **kwargs):
+        if "efoTraits/search/findByEfoTrait" in url:
+            return _FakeResponse(
+                {
+                    "_embedded": {
+                        "efoTraits": [{"trait": "asthma", "shortForm": "MONDO_0004979"}]
+                    }
+                }
+            )
+        raise AssertionError(f"unexpected HTTP call: {url}")
+
+    def fake_request(endpoint, params=None):
+        return {
+            "_embedded": {"associations": [_assoc(7e-288)]},
+            "page": {"size": 3, "totalElements": 3219, "totalPages": 1073, "number": 0},
+        }
+
+    tool = GWASAssociationsForTrait({"name": "gwas_get_associations_for_trait"})
+    with patch("tooluniverse.gwas_tool.requests.get", side_effect=exact_get):
+        with patch.object(
+            GWASAssociationsForTrait, "_make_request", side_effect=fake_request
+        ):
+            result = tool.run({"disease_trait": "asthma", "size": 3})
+
+    assert result["resolved_efo_id"] == "MONDO_0004979"
+    assert result["resolved_efo_label"] == "asthma"
+    assert result["query_trait"] == "asthma"
+    assert "trait_resolution_note" not in result
+
+
+def test_search_tool_also_discloses_the_resolved_label():
+    def fake_request(endpoint, params=None):
+        return {
+            "_embedded": {"associations": [_assoc(3e-30)]},
+            "page": {"size": 3, "totalElements": 68, "totalPages": 23, "number": 0},
+        }
+
+    tool = GWASAssociationSearch({"name": "gwas_search_associations"})
+    with patch("tooluniverse.gwas_tool.requests.get", side_effect=_fake_gwas_get):
+        with patch.object(
+            GWASAssociationSearch, "_make_request", side_effect=fake_request
+        ):
+            result = tool.run({"disease_trait": "cardiorespiratory fitness", "size": 3})
+
+    assert result["resolved_efo_id"] == "EFO_0009184"
+    assert result["resolved_efo_label"] == "heart rate response to exercise"
+    assert result["query_trait"] == "cardiorespiratory fitness"
+    assert "trait_resolution_note" in result

--- a/tests/unit/test_gwas_sumstats_sentinel_not_significant.py
+++ b/tests/unit/test_gwas_sumstats_sentinel_not_significant.py
@@ -1,0 +1,218 @@
+"""Regression guard: GWASSumStats_get_region_associations reported the GWAS
+Catalog missing-value sentinel (-99) as a genome-wide-significant hit.
+
+Confirmed live against
+chr2:179000000-179600000 with p_upper=5e-8: the upstream API itself returns
+rows whose ``p_value`` is ``-99.0`` (and whose ``odds_ratio`` is also
+``-99.0``), because the server-side threshold test ``-99 <= 5e-8`` is
+numerically true. The tool then re-sorted ascending by p-value, which lifted
+every ``-99`` row *above* the two genuinely significant variants
+(rs10174774 p=5.31e-24, rs10170520 p=5.71e-23), so a size=10 query answered
+with 8 sentinels on top and the real hits at the bottom.
+
+Note the upstream ``code`` field cannot be used as the discriminator: it is
+the harmonisation code, and code 10 ("forward strand, alleles already in the
+correct orientation") is a *success* code that the sentinel rows happen to
+carry, while the two real hits carry code 14 ("invalid for harmonisation",
+their alleles are null). The payloads below mirror that real shape.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.gwas_sumstats_tool import GWASSumStatsTool
+
+pytestmark = pytest.mark.unit
+
+
+REGION_ARGS = {
+    "chromosome": 2,
+    "bp_lower": 179000000,
+    "bp_upper": 179600000,
+    "p_upper": 5e-8,
+    "size": 5,
+}
+
+
+def _tool():
+    return GWASSumStatsTool(
+        {
+            "name": "gwas_sumstats_test",
+            "fields": {"endpoint_type": "get_region_associations"},
+        }
+    )
+
+
+def _resp(status_code, json_body=None):
+    r = MagicMock()
+    r.status_code = status_code
+    r.raise_for_status = MagicMock()
+    r.json.return_value = json_body or {}
+    return r
+
+
+def _real_hit(variant_id, position, p_value):
+    """Mirrors a GCST001255 row: real p-value, no alleles, harmonisation code 14."""
+    return {
+        "variant_id": variant_id,
+        "chromosome": 2,
+        "base_pair_location": position,
+        "p_value": p_value,
+        "beta": None,
+        "odds_ratio": None,
+        "effect_allele": None,
+        "other_allele": None,
+        "effect_allele_frequency": None,
+        "code": 14,
+        "study_accession": "GCST001255",
+        "trait": ["EFO_0001359"],
+        "ci_lower": None,
+        "ci_upper": None,
+    }
+
+
+def _sentinel_row(variant_id, position, eaf):
+    """Mirrors a GCST004415 row: -99 sentinel p-value/OR, harmonisation code 10."""
+    return {
+        "variant_id": variant_id,
+        "chromosome": 2,
+        "base_pair_location": position,
+        "p_value": -99.0,
+        "beta": None,
+        "odds_ratio": -99.0,
+        "effect_allele": "C",
+        "other_allele": "T",
+        "effect_allele_frequency": eaf,
+        "code": 10,
+        "study_accession": "GCST004415",
+        "trait": ["EFO_0001075"],
+        "ci_lower": None,
+        "ci_upper": None,
+    }
+
+
+def _payload(rows):
+    return {"_embedded": {"associations": {str(i): r for i, r in enumerate(rows)}}}
+
+
+MIXED_PAYLOAD = _payload(
+    [
+        _real_hit("rs10170520", 179229886, 5.708e-23),
+        _real_hit("rs10174774", 179231834, 5.3109999999999995e-24),
+        _sentinel_row("rs571763084", 179002622, 1.414e-05),
+        _sentinel_row("rs181634435", 179003529, 0.0006703999999999999),
+        _sentinel_row("rs531141128", 179004593, 0.0006997),
+    ]
+)
+
+CLEAN_PAYLOAD = _payload(
+    [
+        _real_hit("rs10170520", 179229886, 5.708e-23),
+        _real_hit("rs10174774", 179231834, 5.3109999999999995e-24),
+    ]
+)
+
+
+def _run(payload, args=None):
+    tool = _tool()
+    with patch(
+        "tooluniverse.gwas_sumstats_tool.requests.get",
+        return_value=_resp(200, payload),
+    ):
+        return tool.run(dict(args if args is not None else REGION_ARGS))
+
+
+def test_sentinel_rows_do_not_satisfy_p_upper():
+    result = _run(MIXED_PAYLOAD)
+
+    assert result["status"] == "success"
+    returned = result["data"]
+    assert [row["p_value"] for row in returned] == pytest.approx(
+        [5.3109999999999995e-24, 5.708e-23]
+    )
+    # No -99 sentinel survived the genome-wide-significance filter.
+    assert all(row["p_value"] > 0 for row in returned)
+    assert not any(row["variant_id"].startswith("rs5717") for row in returned)
+
+
+def test_real_hits_are_returned_most_significant_first():
+    returned = _run(MIXED_PAYLOAD)["data"]
+
+    ids = [row["variant_id"] for row in returned]
+    assert ids == ["rs10174774", "rs10170520"]
+    assert returned[0]["p_value"] == pytest.approx(5.3109999999999995e-24)
+
+
+def test_excluded_sentinel_count_is_disclosed():
+    metadata = _run(MIXED_PAYLOAD)["metadata"]
+
+    assert metadata["sentinel_rows_excluded"] == 3
+    assert metadata["num_associations"] == 2
+    assert "-99" in metadata["sentinel_note"]
+
+
+def test_rows_expose_code_and_reported_flag():
+    returned = _run(MIXED_PAYLOAD)["data"]
+
+    for row in returned:
+        assert row["p_value_reported"] is True
+        assert row["code"] == 14  # upstream harmonisation code is passed through
+
+
+def test_sentinels_kept_but_flagged_and_sorted_last_when_no_threshold():
+    """Without a p_upper threshold the caller asked for the whole region, so
+    sentinel rows are retained -- but flagged, and never above a real hit."""
+    args = dict(REGION_ARGS, p_upper=None)
+    result = _run(MIXED_PAYLOAD, args)
+
+    returned = result["data"]
+    assert len(returned) == 5
+    assert result["metadata"]["sentinel_rows_excluded"] == 0
+    assert [row["p_value_reported"] for row in returned] == [
+        True,
+        True,
+        False,
+        False,
+        False,
+    ]
+    assert [row["variant_id"] for row in returned[:2]] == [
+        "rs10174774",
+        "rs10170520",
+    ]
+
+
+def test_all_valid_response_is_unchanged_apart_from_added_keys():
+    result = _run(CLEAN_PAYLOAD)
+
+    assert result["status"] == "success"
+    assert result["metadata"]["sentinel_rows_excluded"] == 0
+    assert "sentinel_note" not in result["metadata"]
+    assert result["metadata"]["num_associations"] == 2
+
+    returned = result["data"]
+    assert [row["variant_id"] for row in returned] == ["rs10174774", "rs10170520"]
+    assert set(returned[0]) == {
+        "variant_id",
+        "chromosome",
+        "position",
+        "p_value",
+        "p_value_reported",
+        "code",
+        "beta",
+        "odds_ratio",
+        "effect_allele",
+        "other_allele",
+        "effect_allele_frequency",
+        "study_accession",
+        "trait",
+        "ci_lower",
+        "ci_upper",
+    }
+    assert returned[0]["position"] == 179231834
+    assert returned[0]["study_accession"] == "GCST001255"
+    assert returned[0]["trait"] == ["EFO_0001359"]

--- a/tests/unit/test_hpa_tissue_columns_and_units.py
+++ b/tests/unit/test_hpa_tissue_columns_and_units.py
@@ -1,0 +1,326 @@
+"""Regression guard for Fix-R31 (HPA column codes, units and tissue counts).
+
+HPA's search_download.php SILENTLY DROPS column codes it does not recognise,
+so a wrong code is byte-identical to "this gene has no data" -- and the tool
+blamed the caller. Three consequences, all verified live:
+
+1. `t_RNA_skin` does not exist; HPA publishes the tissue as `t_RNA_skin_1`
+   ("Tissue RNA - skin 1 [nTPM]"), so every 'skin' query was reported as an
+   unrecognized tissue name. Confirmed against the live API:
+     ?search=NCSTN&columns=g,eg,t_RNA_skin_1,t_RNA_skin,t_RNA_liver ->
+     [{"Gene":"NCSTN","Ensembl":"ENSG00000162736",
+       "Tissue RNA - liver [nTPM]":"48.9",
+       "Tissue RNA - skin 1 [nTPM]":"34.4"}]      <- no "skin" key at all
+   'stomach' (`stomach_1`) and 'endometrium' (`endometrium_1`) had the same
+   defect.
+2. `rnascm` and `rnablm` are not column codes at all, so source_type
+   'single_cell' and 'blood' were 100% dead. The real per-source columns are
+   `sc_RNA_<CellType>` and `blood_RNA_<CellType>`.
+3. `expression_unit` was hard-coded to "nTPM" even for single cell data,
+   which HPA reports in nCPM ("Single Cell Type RNA - Hepatocytes [nCPM]").
+
+Plus: HPA_get_comprehensive_gene_details_by_ensembl_id reported
+"tissues_with_expression": 184 for NCSTN -- a raw row count of a
+tissue x antibody array in which 135 rows had no level, 9 said "not detected"
+and "Skin 1" appeared 4 times. HPA publishes ~44 consensus tissues, so the
+number was impossible on its face.
+
+All fixtures below are the exact response shapes returned by the live API.
+No network access is performed.
+"""
+
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.hpa_tool import (
+    HPA_TISSUE_COLUMN_ALIASES,
+    HPA_UNAVAILABLE_SOURCES,
+    HPAGetGenePageDetailsTool,
+    HPAGetRnaExpressionBySourceTool,
+    HPAGetRnaExpressionByTissueTool,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    def __init__(self, payload, status_code=200):
+        self._payload = payload
+        self.status_code = status_code
+        self.text = str(payload)
+
+    def json(self):
+        return self._payload
+
+
+# HPA's /{ensembl_id}.json record for NCSTN. The enrichment summary is empty
+# for a broadly-expressed gene -- which is exactly why the per-tissue columns
+# have to work.
+_NCSTN_JSON = {
+    "Gene": "NCSTN",
+    "Gene synonym": ["APH2", "KIAA0253"],
+    "Ensembl": "ENSG00000162736",
+    "RNA tissue specific nTPM": {},
+}
+
+# Live: ?search=NCSTN&columns=g,eg,t_RNA_skin_1,t_RNA_skin,t_RNA_liver
+# -- note HPA returned no key whatsoever for the bogus `t_RNA_skin`.
+_NCSTN_TISSUE_PANEL = [
+    {
+        "Gene": "NCSTN",
+        "Ensembl": "ENSG00000162736",
+        "Tissue RNA - liver [nTPM]": "48.9",
+        "Tissue RNA - skin 1 [nTPM]": "34.4",
+    }
+]
+
+
+def _tissue_tool():
+    return HPAGetRnaExpressionByTissueTool(
+        {"name": "HPA_get_rna_expression_in_specific_tissues", "fields": {}}
+    )
+
+
+def _source_tool():
+    return HPAGetRnaExpressionBySourceTool(
+        {"name": "HPA_get_rna_expression_by_source", "fields": {}}
+    )
+
+
+def _run_tissue_query(tissue_names):
+    """Run the tissue tool offline, returning (data, requested column strings)."""
+    tool = _tissue_tool()
+    requested = []
+
+    def fake_get(url, **kwargs):
+        params = kwargs.get("params") or {}
+        if "search_download.php" in url:
+            requested.append(params.get("columns", ""))
+            return _FakeResponse(_NCSTN_TISSUE_PANEL)
+        return _FakeResponse(_NCSTN_JSON)
+
+    with patch("tooluniverse.hpa_tool.requests.get", side_effect=fake_get):
+        result = tool.run(
+            {"ensembl_id": "ENSG00000162736", "tissue_names": tissue_names}
+        )
+    assert result["status"] == "success", result
+    return result["data"], requested
+
+
+# ---------------------------------------------------------------------------
+# 1. 'skin' resolves to HPA's real `t_RNA_skin_1` column
+# ---------------------------------------------------------------------------
+
+
+def test_skin_reads_the_skin_1_column_and_is_not_called_unrecognized():
+    data, requested = _run_tissue_query(["skin", "liver"])
+    skin = data["tissue_expression"]["skin"]
+
+    assert skin["expression_value"] == "34.4"
+    assert skin["source_field"] == "Tissue RNA - skin 1 [nTPM]"
+    assert skin["matched_tissue"] != "Not found"
+    # The old failure mode: blaming the caller's tissue name.
+    assert "unrecognized" not in skin.get("note", "").lower()
+    # ...and the request must actually ask for the column HPA has.
+    assert any("t_RNA_skin_1" in c for c in requested)
+
+
+def test_skin_column_alias_is_pinned_to_the_real_hpa_suffix():
+    assert HPA_TISSUE_COLUMN_ALIASES["skin"] == ["skin_1"]
+    assert HPA_TISSUE_COLUMN_ALIASES["stomach"] == ["stomach_1"]
+    assert HPA_TISSUE_COLUMN_ALIASES["endometrium"] == ["endometrium_1"]
+
+
+def test_tissue_without_an_hpa_rna_column_says_so_instead_of_blaming_the_name():
+    # HPA covers bronchus only in its protein/IHC atlas: t_RNA_bronchus is
+    # dropped by the API, exactly like a typo would be.
+    assert "bronchus" in HPA_UNAVAILABLE_SOURCES["tissue"]
+    data, _ = _run_tissue_query(["bronchus"])
+    note = data["tissue_expression"]["bronchus"]["note"]
+    assert "protein/IHC" in note
+    assert "unrecognized" not in note.lower()
+
+
+# ---------------------------------------------------------------------------
+# 2. liver is unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_liver_is_unchanged():
+    data, _ = _run_tissue_query(["skin", "liver"])
+    liver = data["tissue_expression"]["liver"]
+
+    assert liver["expression_value"] == "48.9"
+    assert liver["matched_tissue"] == "liver"
+    assert liver["expression_level"] == "High"
+    assert liver["source_field"] == "Tissue RNA - liver [nTPM]"
+    assert liver["expression_unit"] == "nTPM"
+    assert "note" not in liver
+
+
+# ---------------------------------------------------------------------------
+# 3. single_cell / blood return data, with the unit HPA actually used
+# ---------------------------------------------------------------------------
+
+
+def test_single_cell_returns_hepatocyte_value_in_nCPM():
+    tool = _source_tool()
+    requested = []
+
+    # Live: ?search=ALB&columns=g,eg,rnascm,sc_RNA_Hepatocytes ->
+    # [{"Gene":"ALB","Ensembl":"ENSG00000163631",
+    #   "Single Cell Type RNA - Hepatocytes [nCPM]":"81391.2"}]  (no "rnascm")
+    def fake_request(gene, columns, format_type="json"):
+        requested.append(columns)
+        if "sc_RNA_Hepatocytes" in columns:
+            return [
+                {
+                    "Gene": "ALB",
+                    "Ensembl": "ENSG00000163631",
+                    "Single Cell Type RNA - Hepatocytes [nCPM]": "81391.2",
+                }
+            ]
+        # HPA drops `rnascm` entirely -- the row comes back with no data key.
+        return [{"Gene": "ALB"}]
+
+    with patch.object(tool, "_make_api_request", side_effect=fake_request):
+        result = tool.run(
+            {
+                "gene_name": "ALB",
+                "source_type": "single_cell",
+                "source_name": "hepatocyte",
+            }
+        )
+
+    data = result["data"]
+    assert data["expression_value"] == "81391.2"
+    # HPA reports single cell data in nCPM, not nTPM.
+    assert data["expression_unit"] == "nCPM"
+    assert data["column_queried"] == "Single Cell Type RNA - Hepatocytes [nCPM]"
+    assert data["status"] == "ok"
+    assert any("sc_RNA_Hepatocytes" in c for c in requested)
+    assert not any(c.endswith("rnascm") for c in requested)
+
+
+def test_blood_returns_t_reg_value_in_nTPM():
+    tool = _source_tool()
+    requested = []
+
+    # Live: ?search=CD3E&columns=g,rnablm,blood_RNA_T-reg,rnabcs ->
+    # [{"Gene":"CD3E","RNA blood cell specificity":"Group enriched",
+    #   "Blood RNA - T-reg [nTPM]":"427.4"}]      (no "rnablm" key)
+    def fake_request(gene, columns, format_type="json"):
+        requested.append(columns)
+        if "blood_RNA_T-reg" in columns:
+            return [{"Gene": "CD3E", "Blood RNA - T-reg [nTPM]": "427.4"}]
+        return [{"Gene": "CD3E"}]
+
+    with patch.object(tool, "_make_api_request", side_effect=fake_request):
+        result = tool.run(
+            {"gene_name": "CD3E", "source_type": "blood", "source_name": "t_cell"}
+        )
+
+    data = result["data"]
+    assert data["expression_value"] == "427.4"
+    assert data["expression_unit"] == "nTPM"
+    assert data["column_queried"] == "Blood RNA - T-reg [nTPM]"
+    assert data["status"] == "ok"
+    assert any("blood_RNA_T-reg" in c for c in requested)
+    assert not any(c.endswith("rnablm") for c in requested)
+    # HPA's blood atlas has no aggregate T-cell column, so say which subset
+    # the number is instead of passing it off as "t_cell".
+    assert "T-reg" in data["note"]
+
+
+# ---------------------------------------------------------------------------
+# 4. tissues_with_expression counts detected tissues, not assay rows
+# ---------------------------------------------------------------------------
+
+
+_GENE_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<proteinAtlas>
+  <entry>
+    <name>NCSTN</name>
+    <tissueExpression>
+      <data>
+        <tissue organ="Skin">Skin 1</tissue>
+        <level type="expression">medium</level>
+      </data>
+      <data>
+        <tissue organ="Skin">Skin 1</tissue>
+        <level type="expression">medium</level>
+      </data>
+      <data>
+        <tissue organ="Skin">Skin 1</tissue>
+        <level type="expression">medium</level>
+      </data>
+      <data>
+        <tissue organ="Skin">Skin 1</tissue>
+        <level type="expression">medium</level>
+      </data>
+      <data>
+        <tissue organ="Kidney &amp; urinary bladder">Kidney</tissue>
+        <level type="expression">high</level>
+      </data>
+      <data>
+        <tissue organ="Liver &amp; gallbladder">Liver</tissue>
+        <level type="expression">not detected</level>
+      </data>
+      <data>
+        <tissue organ="Connective &amp; soft tissue">Adipose tissue</tissue>
+      </data>
+    </tissueExpression>
+  </entry>
+</proteinAtlas>
+"""
+
+
+def _parse_summary():
+    tool = HPAGetGenePageDetailsTool(
+        {"name": "HPA_get_comprehensive_gene_details_by_ensembl_id", "fields": {}}
+    )
+    root = ET.fromstring(_GENE_XML)
+    parsed = tool._parse_gene_xml(root, "ENSG00000162736", False, False, True)
+    return parsed
+
+
+def test_summary_counts_only_distinct_tissues_with_detected_expression():
+    parsed = _parse_summary()
+    summary = parsed["summary"]
+
+    # 7 assay rows / 4 distinct tissues, of which only Skin 1 and Kidney have
+    # a detected level ("not detected" and the blank row do not count).
+    assert summary["tissues_with_expression"] == 2
+    assert summary["distinct_tissues_assayed"] == 4
+    assert summary["tissue_expression_rows"] == 7
+    assert len(parsed["tissue_expression"]) == 7
+
+
+def test_summary_note_explains_the_denominator():
+    summary = _parse_summary()["summary"]
+    assert "not detected" in summary["summary_note"]
+    assert "tissue_expression_rows" in summary["summary_note"]
+
+
+def test_count_tissues_helper_ignores_blank_and_not_detected():
+    count = HPAGetGenePageDetailsTool._count_tissues
+    rows = [
+        {"tissue_name": "Skin 1", "expression_level": "expression: medium"},
+        {"tissue_name": "Skin 1", "expression_level": "expression: medium"},
+        {"tissue_name": "Liver", "expression_level": "expression: not detected"},
+        {"tissue_name": "Adipose tissue", "expression_level": ""},
+        {"tissue_name": "", "expression_level": "expression: high"},
+    ]
+    assert count(rows) == (1, 3)
+    assert count([]) == (0, 0)

--- a/tests/unit/test_interpro_no_results_not_crash.py
+++ b/tests/unit/test_interpro_no_results_not_crash.py
@@ -1,0 +1,213 @@
+"""Regression guard: the EBI InterPro API answers a zero-hit search with
+HTTP 204 No Content and a zero-length body, not a 200 carrying
+{"count": 0, "results": []}.
+
+``requests``' ``raise_for_status()`` treats 204 as success, so the tools fell
+straight through to ``response.json()``, which raised a JSONDecodeError. That
+escaped the blanket ``except Exception`` as an opaque internal error:
+
+    Pfam_search_families {"query": "trypanothione"}
+      -> Error: Unexpected error querying Pfam API:
+         Expecting value: line 1 column 1 (char 0)
+
+Confirmed live (2026-08):
+    /entry/pfam/?search=trypanothione&page_size=20   -> HTTP 204, len(body)=0
+    /entry/pfam/?search=kinase&page_size=5           -> HTTP 200
+    /entry/interpro?search=zzzznotarealzzz           -> HTTP 204, len(body)=0
+
+A caller could not distinguish "no such family" from "the tool is broken".
+A 204 is now reported as a well-formed empty result set (status "success",
+count 0, empty list), with the hit-producing shape left untouched.
+
+These tests are offline: ``requests.get`` is patched in each module.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.interpro_entry_tool import InterProEntryTool
+from tooluniverse.pfam_tool import PfamTool
+
+pytestmark = pytest.mark.unit
+
+
+def _no_content_response():
+    """A response shaped like the real HTTP 204: empty body, .json() raises."""
+    resp = MagicMock()
+    resp.status_code = 204
+    resp.text = ""
+    resp.content = b""
+    resp.raise_for_status.return_value = None
+    # requests raises requests.exceptions.JSONDecodeError, a ValueError subclass.
+    resp.json.side_effect = ValueError("Expecting value: line 1 column 1 (char 0)")
+    return resp
+
+
+def _ok_response(body):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.content = b'{"stub": true}'
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = body
+    return resp
+
+
+def _pfam_search_tool():
+    return PfamTool({"name": "Pfam_search_families", "fields": {"endpoint": "search_families"}})
+
+
+def _interpro_search_tool():
+    return InterProEntryTool(
+        {"name": "InterPro_search_entries", "fields": {"endpoint": "search_entries"}}
+    )
+
+
+class TestPfamSearchFamiliesNoResults:
+    def test_204_is_empty_success_not_error(self):
+        tool = _pfam_search_tool()
+
+        with patch(
+            "tooluniverse.pfam_tool.requests.get", return_value=_no_content_response()
+        ):
+            result = tool.run({"query": "trypanothione"})
+
+        assert result["status"] == "success"
+        assert result["data"]["families"] == []
+        assert result["data"]["total_results"] == 0
+        assert result["data"]["returned"] == 0
+        assert result["data"]["query"] == "trypanothione"
+
+    def test_200_with_empty_body_is_also_empty_success(self):
+        """Defensive: a 200 carrying no body must not crash either."""
+        tool = _pfam_search_tool()
+        resp = _no_content_response()
+        resp.status_code = 200
+
+        with patch("tooluniverse.pfam_tool.requests.get", return_value=resp):
+            result = tool.run({"query": "trypanothione"})
+
+        assert result["status"] == "success"
+        assert result["data"]["total_results"] == 0
+        assert result["data"]["families"] == []
+
+    def test_hit_producing_response_shape_unchanged(self):
+        tool = _pfam_search_tool()
+        body = {
+            "count": 304,
+            "results": [
+                {
+                    "metadata": {
+                        "accession": "PF00069",
+                        "name": "Protein kinase domain",
+                        "type": "domain",
+                        "integrated": "IPR000719",
+                    }
+                }
+            ],
+        }
+
+        with patch("tooluniverse.pfam_tool.requests.get", return_value=_ok_response(body)):
+            result = tool.run({"query": "kinase"})
+
+        assert result["status"] == "success"
+        assert result["data"]["total_results"] == 304
+        assert result["data"]["returned"] == 1
+        assert result["data"]["families"] == [
+            {
+                "accession": "PF00069",
+                "name": "Protein kinase domain",
+                "type": "domain",
+                "integrated_interpro": "IPR000719",
+            }
+        ]
+
+
+class TestInterProSearchEntriesNoResults:
+    def test_204_is_empty_success_not_error(self):
+        tool = _interpro_search_tool()
+
+        with patch(
+            "tooluniverse.interpro_entry_tool.requests.get",
+            return_value=_no_content_response(),
+        ):
+            result = tool.run({"query": "zzzznotarealfamilyzzzz"})
+
+        assert result["status"] == "success"
+        assert result["data"]["entries"] == []
+        assert result["data"]["total_results"] == 0
+        assert result["data"]["returned"] == 0
+        assert result["data"]["query"] == "zzzznotarealfamilyzzzz"
+
+    def test_200_with_empty_body_is_also_empty_success(self):
+        tool = _interpro_search_tool()
+        resp = _no_content_response()
+        resp.status_code = 200
+
+        with patch("tooluniverse.interpro_entry_tool.requests.get", return_value=resp):
+            result = tool.run({"query": "zzzznotarealfamilyzzzz"})
+
+        assert result["status"] == "success"
+        assert result["data"]["total_results"] == 0
+        assert result["data"]["entries"] == []
+
+    def test_hit_producing_response_shape_unchanged(self):
+        tool = _interpro_search_tool()
+        body = {
+            "count": 2,
+            "results": [
+                {
+                    "metadata": {
+                        "accession": "IPR000719",
+                        "name": "Protein kinase domain",
+                        "type": "domain",
+                        "counters": {
+                            "proteins": 1000,
+                            "structures": 50,
+                            "taxa": 20,
+                        },
+                    }
+                }
+            ],
+        }
+
+        with patch(
+            "tooluniverse.interpro_entry_tool.requests.get",
+            return_value=_ok_response(body),
+        ):
+            result = tool.run({"query": "kinase"})
+
+        assert result["status"] == "success"
+        assert result["data"]["total_results"] == 2
+        assert result["data"]["returned"] == 1
+        assert result["data"]["entries"] == [
+            {
+                "accession": "IPR000719",
+                "name": "Protein kinase domain",
+                "type": "domain",
+                "protein_count": 1000,
+                "structure_count": 50,
+                "taxa_count": 20,
+            }
+        ]
+
+
+class TestNoExceptionEscapes:
+    """The failure mode was an exception leaking through the blanket handler."""
+
+    def test_pfam_204_raises_nothing(self):
+        tool = _pfam_search_tool()
+        with patch(
+            "tooluniverse.pfam_tool.requests.get", return_value=_no_content_response()
+        ):
+            result = tool.run({"query": "schistosoma"})
+        assert "error" not in result
+
+    def test_interpro_204_raises_nothing(self):
+        tool = _interpro_search_tool()
+        with patch(
+            "tooluniverse.interpro_entry_tool.requests.get",
+            return_value=_no_content_response(),
+        ):
+            result = tool.run({"query": "schistosoma"})
+        assert "error" not in result

--- a/tests/unit/test_medlineplus_rettype_and_output.py
+++ b/tests/unit/test_medlineplus_rettype_and_output.py
@@ -1,0 +1,284 @@
+"""Regression guards for MedlinePlus_search_topics_by_keyword.
+
+Three separate defects, all confirmed live against NLM's wsearch service:
+
+1. Only rettype="topic" parsed. wsearch returns the health-topic data in two
+   different shapes: rettype=topic ships a single <content name="healthTopic">
+   node wrapping a structured <health-topic> record, while rettype=brief ships
+   several flat <content name="title|altTitle|FullSummary|groupName|snippet">
+   nodes (and rettype=all ships both in one list). The parser only handled
+   `doc["content"]` when xmltodict gave it a *dict* -- the brief/all list shape
+   fell straight through, so a perfectly good HTTP 200 with 2 documents was
+   discarded with "Failed to parse health topic information".
+
+2. Developer debug output. Every call print()ed the request URL, response
+   status/length, the first 500 response characters, the parse strategy, the
+   top-level keys and a 2000-character dump of the raw structure to stdout,
+   corrupting any consumer reading the JSON payload from there. Diagnostics now
+   go to the shared ToolUniverse logger at DEBUG level.
+
+3. Unsupported `db` values reported as "no results". wsearch accepts
+   db=drugs/drugsSpanish/genetics/medicalTests/medicalEncyclopedia but answers
+   <count>0</count> for every query against them (verified with aspirin,
+   cancer, heart, BRCA1, diabetes and vitamin). The generic "document list not
+   found" made that look like "your term had no match". The enum values stay
+   accepted; the error now names the real cause.
+
+All fixtures below are trimmed captures of real responses for
+  https://wsearch.nlm.nih.gov/ws/query?db=healthTopics&term=leishmaniasis&rettype=...
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse import medlineplus_tool
+from tooluniverse.medlineplus_tool import MedlinePlusRESTTool
+
+pytestmark = pytest.mark.unit
+
+
+_TOPIC_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<nlmSearchResult>
+  <term>leishmaniasis</term>
+  <count>1</count>
+  <retstart>0</retstart>
+  <retmax>10</retmax>
+  <list num="1" start="0" per="10">
+    <document rank="0" url="https://medlineplus.gov/leishmaniasis.html">
+      <content name="healthTopic">
+        <health-topic meta-desc="Leishmaniasis or leishmania, also known as Kala-azar is a parasitic disease spread by the bite of infected sand flies." title="Leishmaniasis" url="https://medlineplus.gov/leishmaniasis.html" id="3748" language="English" date-created="02/17/2004">
+          <also-called>Kala-azar</also-called>
+          <full-summary>&lt;p&gt;Leishmaniasis is a parasitic disease spread by the bite of infected sand flies.&lt;/p&gt;</full-summary>
+          <group url="https://medlineplus.gov/infections.html" id="12">Infections</group>
+          <group url="https://medlineplus.gov/skinhairandnails.html" id="18">Skin, Hair and Nails</group>
+        </health-topic>
+      </content>
+    </document>
+  </list>
+</nlmSearchResult>
+"""
+
+# rettype=brief: no <health-topic> record at all, just flat content nodes.
+# Matched terms are wrapped in <span class="qt0"> highlight markup.
+_BRIEF_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<nlmSearchResult>
+  <term>leishmaniasis</term>
+  <count>1</count>
+  <retstart>0</retstart>
+  <retmax>10</retmax>
+  <list num="1" start="0" per="10">
+    <document rank="0" url="https://medlineplus.gov/leishmaniasis.html">
+      <content name="title">&lt;span class="qt0"&gt;Leishmaniasis&lt;/span&gt;</content>
+      <content name="organizationName">National Library of Medicine</content>
+      <content name="altTitle">Kala-azar</content>
+      <content name="FullSummary">&lt;p&gt;&lt;span class="qt0"&gt;Leishmaniasis&lt;/span&gt; is a parasitic disease spread by the bite of infected sand flies.&lt;/p&gt;</content>
+      <content name="mesh">&lt;span class="qt0"&gt;Leishmaniasis&lt;/span&gt;</content>
+      <content name="groupName">Infections</content>
+      <content name="groupName">Skin, Hair and Nails</content>
+      <content name="snippet"> &lt;span class="qt0"&gt;Leishmaniasis&lt;/span&gt; is a parasitic disease spread by the bite of infected sand flies. ... </content>
+    </document>
+  </list>
+</nlmSearchResult>
+"""
+
+# rettype=all: the flat brief nodes AND the structured healthTopic node.
+_ALL_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<nlmSearchResult>
+  <term>leishmaniasis</term>
+  <count>1</count>
+  <retstart>0</retstart>
+  <retmax>10</retmax>
+  <list num="1" start="0" per="10">
+    <document rank="0" url="https://medlineplus.gov/leishmaniasis.html">
+      <content name="title">&lt;span class="qt0"&gt;Leishmaniasis&lt;/span&gt;</content>
+      <content name="organizationName">National Library of Medicine</content>
+      <content name="altTitle">Kala-azar</content>
+      <content name="FullSummary">&lt;p&gt;&lt;span class="qt0"&gt;Leishmaniasis&lt;/span&gt; is a parasitic disease spread by the bite of infected sand flies.&lt;/p&gt;</content>
+      <content name="mesh">&lt;span class="qt0"&gt;Leishmaniasis&lt;/span&gt;</content>
+      <content name="groupName">Infections</content>
+      <content name="groupName">Skin, Hair and Nails</content>
+      <content name="healthTopic">
+        <health-topic meta-desc="Leishmaniasis or leishmania, also known as Kala-azar is a parasitic disease spread by the bite of infected sand flies." title="Leishmaniasis" url="https://medlineplus.gov/leishmaniasis.html" id="3748" language="English" date-created="02/17/2004">
+          <also-called>Kala-azar</also-called>
+          <full-summary>&lt;p&gt;Leishmaniasis is a parasitic disease spread by the bite of infected sand flies.&lt;/p&gt;</full-summary>
+          <group url="https://medlineplus.gov/infections.html" id="12">Infections</group>
+          <group url="https://medlineplus.gov/skinhairandnails.html" id="18">Skin, Hair and Nails</group>
+        </health-topic>
+      </content>
+      <content name="snippet"> &lt;span class="qt0"&gt;Leishmaniasis&lt;/span&gt; is a parasitic disease spread by the bite of infected sand flies. ... </content>
+    </document>
+  </list>
+</nlmSearchResult>
+"""
+
+# What wsearch really answers for any query against an unserved db.
+_ZERO_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<nlmSearchResult>
+  <term>praziquantel</term>
+  <count>0</count>
+</nlmSearchResult>
+"""
+
+_FIXTURES = {"topic": _TOPIC_XML, "brief": _BRIEF_XML, "all": _ALL_XML}
+
+
+def _tool():
+    return MedlinePlusRESTTool(
+        {
+            "name": "MedlinePlus_search_topics_by_keyword",
+            "fields": {
+                "endpoint": "https://wsearch.nlm.nih.gov/ws/query?db={db}&term={term}&rettype={rettype}"
+            },
+            "parameter": {"properties": {"rettype": {"default": "topic"}}},
+        }
+    )
+
+
+def _xml_resp(text):
+    r = MagicMock()
+    r.status_code = 200
+    r.text = text
+    return r
+
+
+def _run(xml, arguments):
+    with patch(
+        "tooluniverse.medlineplus_tool.requests.get", return_value=_xml_resp(xml)
+    ):
+        return _tool().run(dict(arguments))
+
+
+class TestAllRettypesParse:
+    @pytest.mark.parametrize("rettype", ["topic", "brief", "all"])
+    def test_leishmaniasis_topic_returned(self, rettype):
+        result = _run(
+            _FIXTURES[rettype],
+            {"term": "leishmaniasis", "db": "healthTopics", "rettype": rettype},
+        )
+
+        assert "error" not in result, result
+        topics = result["topics"]
+        assert len(topics) == 1
+        topic = topics[0]
+        assert topic["title"] == "Leishmaniasis"
+        assert topic["url"] == "https://medlineplus.gov/leishmaniasis.html"
+        assert topic["rank"] == "0"
+        assert topic["language"] == "English"
+        assert topic["also_called"] == ["Kala-azar"]
+        assert "parasitic disease" in topic["summary"]
+        assert topic["meta_desc"]
+
+    def test_brief_keys_match_topic_keys(self):
+        args = {"term": "leishmaniasis", "db": "healthTopics"}
+        brief = _run(_BRIEF_XML, dict(args, rettype="brief"))["topics"][0]
+        topic = _run(_TOPIC_XML, dict(args, rettype="topic"))["topics"][0]
+        assert set(brief) == set(topic)
+
+    def test_all_parses_identically_to_topic(self):
+        args = {"term": "leishmaniasis", "db": "healthTopics"}
+        assert _run(_ALL_XML, dict(args, rettype="all")) == _run(
+            _TOPIC_XML, dict(args, rettype="topic")
+        )
+
+    def test_brief_strips_search_highlight_markup(self):
+        topic = _run(
+            _BRIEF_XML,
+            {"term": "leishmaniasis", "db": "healthTopics", "rettype": "brief"},
+        )["topics"][0]
+        assert "<span" not in json.dumps(topic)
+        assert topic["groups"] == ["Infections", "Skin, Hair and Nails"]
+
+    def test_brief_language_derived_from_spanish_db(self):
+        topic = _run(
+            _BRIEF_XML,
+            {"term": "leishmaniasis", "db": "healthTopicsSpanish", "rettype": "brief"},
+        )["topics"][0]
+        assert topic["language"] == "Spanish"
+
+
+class TestNoStdoutPollution:
+    @pytest.mark.parametrize("rettype", ["topic", "brief", "all"])
+    def test_nothing_printed_on_success(self, capsys, rettype):
+        _run(
+            _FIXTURES[rettype],
+            {"term": "leishmaniasis", "db": "healthTopics", "rettype": rettype},
+        )
+        captured = capsys.readouterr()
+        assert captured.out == ""
+
+    def test_nothing_printed_on_zero_results(self, capsys):
+        _run(_ZERO_XML, {"term": "praziquantel", "db": "drugs", "rettype": "topic"})
+        assert capsys.readouterr().out == ""
+
+    def test_debug_diagnostics_still_available_via_logger(self):
+        with patch.object(medlineplus_tool, "logger") as mock_logger:
+            _run(
+                _TOPIC_XML,
+                {"term": "leishmaniasis", "db": "healthTopics", "rettype": "topic"},
+            )
+        assert mock_logger.debug.called
+
+
+class TestUnsupportedDbErrorNamesCause:
+    @pytest.mark.parametrize(
+        "db", ["drugs", "drugsSpanish", "genetics", "medicalTests"]
+    )
+    def test_error_names_the_db_and_the_working_alternatives(self, db):
+        result = _run(_ZERO_XML, {"term": "praziquantel", "db": db, "rettype": "topic"})
+
+        error = result["error"]
+        assert result["status"] == "error"
+        assert db in error
+        assert "healthTopics" in error
+        # Not the old generic text that read as "no match for your term".
+        assert error != "document list not found"
+
+    def test_supported_db_with_no_hits_does_not_blame_the_database(self):
+        result = _run(
+            _ZERO_XML,
+            {"term": "zzzznotaterm", "db": "healthTopics", "rettype": "topic"},
+        )
+        assert result["status"] == "error"
+        assert "does not serve" not in result["error"]
+        assert "zzzznotaterm" in result["error"]
+
+
+class TestConfigMatchesReality:
+    def _search_config(self):
+        data = json.loads(
+            (
+                Path(medlineplus_tool.__file__).parent
+                / "data"
+                / "medlineplus_tools.json"
+            ).read_text()
+        )
+        return next(
+            c for c in data if c["name"] == "MedlinePlus_search_topics_by_keyword"
+        )
+
+    def test_rettype_description_agrees_with_schema_default(self):
+        rettype = self._search_config()["parameter"]["properties"]["rettype"]
+        assert rettype["default"] == "topic"
+        # The description used to advertise "brief (concise information,
+        # default)" while the schema default was "topic".
+        assert "brief (concise information, default)" not in rettype["description"]
+        assert "default: topic" in rettype["description"]
+
+    def test_db_description_states_which_databases_are_served(self):
+        config = self._search_config()
+        db = config["parameter"]["properties"]["db"]
+        # Enum values stay accepted -- removing them would break callers.
+        assert set(db["enum"]) == {
+            "healthTopics",
+            "healthTopicsSpanish",
+            "drugs",
+            "drugsSpanish",
+            "genetics",
+            "medicalTests",
+            "medicalEncyclopedia",
+        }
+        assert "zero results" in db["description"]
+        assert "zero results" in config["description"]

--- a/tests/unit/test_monarch_v3_object_direction_reachable.py
+++ b/tests/unit/test_monarch_v3_object_direction_reachable.py
@@ -1,0 +1,282 @@
+"""Unit test: MonarchV3_get_associations must expose the `object` side.
+
+Regression: Biolink association categories are directed --
+biolink:CausalGeneToDiseaseAssociation has the GENE as subject and the DISEASE
+as object. `MonarchV3Tool._get_associations` already read an `object` argument
+and forwarded it upstream, but the registered JSON schema exposed only
+`subject` and marked it required, so the single most common question for that
+category -- "which genes cause this disease?" -- was unreachable:
+
+    {"object": "MONDO:0006559", ...}  -> rejected before reaching the tool
+    {"subject": "MONDO:0006559", ...} -> accepted, confident empty list
+
+Confirmed live against the API: object=MONDO:0006559 with that category
+returns 3 rows (NCSTN, PSENEN, PSEN1). The schema now requires only
+`category`, exposes `object`, and the tool itself rejects a call that supplies
+neither anchor with an error naming both parameters.
+
+Offline: `requests.get` in the tool module is patched.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.monarch_v3_tool import MonarchV3Tool
+
+pytestmark = pytest.mark.unit
+
+CATEGORY = "biolink:CausalGeneToDiseaseAssociation"
+DISEASE = "MONDO:0006559"
+
+# Shape of https://api.monarchinitiative.org/v3/api/association/all
+# ?object=MONDO:0006559&category=biolink:CausalGeneToDiseaseAssociation
+OBJECT_SIDE_RESPONSE = {
+    "total": 3,
+    "items": [
+        {
+            "subject": "HGNC:17091",
+            "subject_label": "NCSTN",
+            "object": "MONDO:0007728",
+            "object_label": "acne inversa, familial, 1",
+            "category": CATEGORY,
+            "predicate": "biolink:causes",
+            "negated": None,
+            "provided_by": "omim_gene_to_disease_edges",
+            "primary_knowledge_source": "infores:omim",
+        },
+        {
+            "subject": "HGNC:30100",
+            "subject_label": "PSENEN",
+            "object": "MONDO:0013397",
+            "object_label": "acne inversa, familial, 2",
+            "category": CATEGORY,
+            "predicate": "biolink:causes",
+            "negated": None,
+            "provided_by": "omim_gene_to_disease_edges",
+            "primary_knowledge_source": "infores:omim",
+        },
+        {
+            "subject": "HGNC:9508",
+            "subject_label": "PSEN1",
+            "object": "MONDO:0013398",
+            "object_label": "acne inversa, familial, 3",
+            "category": CATEGORY,
+            "predicate": "biolink:causes",
+            "negated": None,
+            "provided_by": "omim_gene_to_disease_edges",
+            "primary_knowledge_source": "infores:omim",
+        },
+    ],
+}
+
+SUBJECT_SIDE_RESPONSE = {
+    "total": 1,
+    "items": [OBJECT_SIDE_RESPONSE["items"][0]],
+}
+
+EMPTY_RESPONSE = {"total": 0, "items": []}
+
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+def _tool():
+    return MonarchV3Tool(
+        {
+            "name": "MonarchV3_get_associations",
+            "type": "MonarchV3Tool",
+            "parameter": {"properties": {}},
+            "fields": {"endpoint": "associations"},
+        }
+    )
+
+
+def _run(arguments, payload):
+    """Run the tool with requests.get patched; return (result, captured params)."""
+    captured = {}
+
+    def fake_get(url, params=None, timeout=None):
+        captured["url"] = url
+        captured["params"] = params
+        return _FakeResponse(payload)
+
+    with patch("tooluniverse.monarch_v3_tool.requests.get", side_effect=fake_get):
+        result = _tool().run(arguments)
+    return result, captured
+
+
+# --- the schema must actually expose `object` --------------------------------
+
+
+def _associations_schema():
+    import json
+
+    config_path = (
+        Path(__file__).parent.parent.parent
+        / "src"
+        / "tooluniverse"
+        / "data"
+        / "monarch_v3_tools.json"
+    )
+    configs = json.loads(config_path.read_text())
+    for cfg in configs:
+        if cfg.get("name") == "MonarchV3_get_associations":
+            return cfg["parameter"]
+    raise AssertionError("MonarchV3_get_associations not found in monarch_v3_tools.json")
+
+
+def test_schema_exposes_object_parameter():
+    schema = _associations_schema()
+    assert "object" in schema["properties"], (
+        "the implementation forwards an `object` argument upstream; the schema "
+        "must expose it or disease->gene queries are unreachable"
+    )
+    assert "subject" in schema["properties"]
+
+
+def test_schema_does_not_force_subject():
+    # subject must be optional so an object-only call validates; `category`
+    # stays required exactly as before.
+    schema = _associations_schema()
+    assert "subject" not in schema["required"]
+    assert "object" not in schema["required"]
+    assert "category" in schema["required"]
+
+
+def test_schema_documents_the_direction():
+    schema = _associations_schema()
+    obj_doc = schema["properties"]["object"]["description"].lower()
+    assert "object" in obj_doc
+    assert "disease" in obj_doc
+
+
+# --- object-only call: accepted, forwarded, parsed ---------------------------
+
+
+def test_object_only_call_forwards_object_upstream():
+    result, captured = _run(
+        {"object": DISEASE, "category": CATEGORY, "limit": 20},
+        OBJECT_SIDE_RESPONSE,
+    )
+
+    assert result["status"] == "success"
+    assert captured["params"]["object"] == DISEASE
+    assert "subject" not in captured["params"], (
+        "an object-only query must not be silently rewritten onto the subject side"
+    )
+    assert captured["params"]["category"] == CATEGORY
+    assert captured["params"]["limit"] == 20
+
+
+def test_object_only_call_returns_the_three_causal_genes():
+    result, _ = _run({"object": DISEASE, "category": CATEGORY}, OBJECT_SIDE_RESPONSE)
+
+    assert len(result["data"]) == 3
+    assert [row["subject"] for row in result["data"]] == [
+        "HGNC:17091",
+        "HGNC:30100",
+        "HGNC:9508",
+    ]
+    assert [row["subject_label"] for row in result["data"]] == [
+        "NCSTN",
+        "PSENEN",
+        "PSEN1",
+    ]
+    assert result["metadata"]["object"] == DISEASE
+    assert result["metadata"]["total_results"] == 3
+
+
+def test_object_curie_is_normalized_like_subject():
+    _, captured = _run(
+        {"object": "MONDO_0006559", "category": CATEGORY}, OBJECT_SIDE_RESPONSE
+    )
+    assert captured["params"]["object"] == "MONDO:0006559"
+
+
+# --- subject-only call: unchanged -------------------------------------------
+
+
+def test_subject_only_call_unchanged():
+    result, captured = _run(
+        {"subject": "HGNC:17091", "category": CATEGORY, "limit": 5},
+        SUBJECT_SIDE_RESPONSE,
+    )
+
+    assert result["status"] == "success"
+    assert captured["params"]["subject"] == "HGNC:17091"
+    assert "object" not in captured["params"]
+    assert captured["params"]["limit"] == 5
+    assert len(result["data"]) == 1
+    assert result["data"][0]["object"] == "MONDO:0007728"
+    assert result["metadata"]["subject"] == "HGNC:17091"
+    assert result["metadata"]["category"] == CATEGORY
+    assert result["metadata"]["total_results"] == 1
+
+
+def test_both_sides_may_be_supplied_together():
+    _, captured = _run(
+        {"subject": "HGNC:17091", "object": "MONDO:0007728", "category": CATEGORY},
+        SUBJECT_SIDE_RESPONSE,
+    )
+    assert captured["params"]["subject"] == "HGNC:17091"
+    assert captured["params"]["object"] == "MONDO:0007728"
+
+
+# --- neither side supplied: clear error naming both --------------------------
+
+
+def test_neither_subject_nor_object_is_a_clear_error():
+    called = []
+
+    def fake_get(url, params=None, timeout=None):  # pragma: no cover - must not run
+        called.append(url)
+        return _FakeResponse(EMPTY_RESPONSE)
+
+    with patch("tooluniverse.monarch_v3_tool.requests.get", side_effect=fake_get):
+        result = _tool().run({"category": CATEGORY})
+
+    assert result["status"] == "error"
+    assert "subject" in result["error"]
+    assert "object" in result["error"]
+    assert not called, "no upstream request should be made without an anchor CURIE"
+
+
+# --- zero results keep status success, but hint at the direction -------------
+
+
+def test_wrong_side_zero_result_stays_success_and_hints():
+    result, _ = _run(
+        {"subject": DISEASE, "category": CATEGORY, "limit": 20}, EMPTY_RESPONSE
+    )
+
+    assert result["status"] == "success", "an empty result must not become an error"
+    assert result["data"] == []
+    note = result["metadata"].get("note", "")
+    assert "object" in note and DISEASE in note
+
+
+def test_correct_side_zero_result_has_no_misleading_hint():
+    # A gene subject is on the right side for this category; an empty result
+    # there just means "no known causal disease", not a direction mistake.
+    result, _ = _run({"subject": "HGNC:11998", "category": CATEGORY}, EMPTY_RESPONSE)
+
+    assert result["status"] == "success"
+    assert "note" not in result["metadata"]
+
+
+def test_non_empty_result_carries_no_hint():
+    result, _ = _run({"object": DISEASE, "category": CATEGORY}, OBJECT_SIDE_RESPONSE)
+    assert "note" not in result["metadata"]

--- a/tests/unit/test_orphanet_missing_subrecord_not_unknown_disease.py
+++ b/tests/unit/test_orphanet_missing_subrecord_not_unknown_disease.py
@@ -1,0 +1,230 @@
+"""Regression guard: Orphanet_get_phenotypes reported a missing sub-record as
+"this disease does not exist".
+
+Confirmed live for ORPHA:1247 (Schistosomiasis), a current, valid code:
+
+    GET https://api.orphadata.com/rd-phenotypes/orphacodes/1247   -> HTTP 404
+    GET https://api.orphadata.com/rd-phenotypes/orphacodes/558     -> HTTP 200
+    GET https://api.orphadata.com/rd-phenotypes/orphacodes/99999999 -> HTTP 404
+
+The 404 body is byte-identical for the unknown code and for the valid-but-
+unannotated one ({"error":{"code":404,"type":"Query not found"}}), so the
+dataset endpoint alone cannot tell them apart. _get_phenotypes blanket-
+converted that 404 into "Disease ORPHA:1247 not found. Use
+Orphanet_search_diseases to find a valid ORPHA code." -- a false statement
+whose advice loops (that search returns 1247 again), while four sibling
+tools resolve the same code happily (get_disease, get_icd_mapping,
+get_natural_history, search_diseases).
+
+The discriminator is the RDcode Name endpoint, already used by the sibling
+operations via _orpha_code_exists (Fix-R20D-1). Confirmed live:
+
+    GET https://api.orphacode.org/EN/ClinicalEntity/orphacode/1247/Name
+        -> HTTP 200 {"ORPHAcode":1247,"Preferred term":"Schistosomiasis",...}
+    GET https://api.orphacode.org/EN/ClinicalEntity/orphacode/99999999/Name
+        -> HTTP 404 "Query not found"
+
+Fixed additively: the status stays "error" in both cases (Orphadata does not
+expose "zero phenotypes" as distinct from "no record", so fabricating an
+empty phenotype list would not be honest), the unknown-code message is
+preserved verbatim, and the valid-code branch now names what is actually
+missing and points at sibling tools instead of at a search loop.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.orphanet_tool import OrphanetTool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return OrphanetTool({"name": "Orphanet_get_phenotypes"})
+
+
+def _resp(status_code, json_body=None):
+    r = MagicMock()
+    r.status_code = status_code
+    r.json.return_value = json_body if json_body is not None else {}
+    if status_code >= 400:
+        import requests
+
+        r.raise_for_status = MagicMock(
+            side_effect=requests.exceptions.HTTPError(response=r)
+        )
+    else:
+        r.raise_for_status = MagicMock()
+    return r
+
+
+def _route(name_response):
+    """rd-phenotypes 404s; the RDcode Name endpoint answers `name_response`."""
+
+    def fake_get(url, **kwargs):
+        if "ClinicalEntity" in url:
+            return name_response
+        return _resp(404, {"error": {"code": 404, "type": "Query not found"}})
+
+    return fake_get
+
+
+def _phenotypes(orpha_code, name_response):
+    with patch(
+        "tooluniverse.orphanet_tool.requests.get", side_effect=_route(name_response)
+    ):
+        return _tool().run({"operation": "get_phenotypes", "orpha_code": orpha_code})
+
+
+# --- the core bug: valid code, no rd-phenotypes record ----------------------
+
+
+def test_valid_code_missing_phenotypes_does_not_claim_disease_not_found():
+    result = _phenotypes(
+        "1247", _resp(200, {"ORPHAcode": 1247, "Preferred term": "Schistosomiasis"})
+    )
+
+    assert result["status"] == "error"
+    message = result["error"]
+    assert "not found" not in message.lower()
+    assert "does not exist" not in message.lower()
+
+
+def test_valid_code_missing_phenotypes_names_what_is_actually_missing():
+    result = _phenotypes(
+        "1247", _resp(200, {"ORPHAcode": 1247, "Preferred term": "Schistosomiasis"})
+    )
+
+    message = result["error"].lower()
+    assert "phenotype annotations" in message
+    assert "rd-phenotypes" in message
+    assert "1247" in result["error"]
+    # The resolved preferred term proves the code really is live.
+    assert "Schistosomiasis" in result["error"]
+
+
+def test_valid_code_missing_phenotypes_does_not_loop_caller_back_to_search():
+    """Following the old advice returned ORPHA:1247 again. The message must
+    point at sibling tools that do hold data for the code instead."""
+    result = _phenotypes(
+        "1247", _resp(200, {"ORPHAcode": 1247, "Preferred term": "Schistosomiasis"})
+    )
+
+    message = result["error"]
+    assert "Orphanet_search_diseases" not in message
+    assert "Orphanet_get_disease" in message
+    assert "Orphanet_get_natural_history" in message
+    assert "Orphanet_get_icd_mapping" in message
+
+
+def test_missing_preferred_term_still_produces_a_usable_message():
+    """If the Name endpoint 200s without a usable term, the message must not
+    grow an empty '()' and must still avoid the not-found claim."""
+    result = _phenotypes("1247", _resp(200, {"ORPHAcode": 1247}))
+
+    assert result["status"] == "error"
+    assert "()" not in result["error"]
+    assert "not found" not in result["error"].lower()
+    assert "phenotype annotations" in result["error"].lower()
+
+
+# --- the genuinely-unknown-code path must not regress ----------------------
+
+
+def test_unknown_orpha_code_still_reports_disease_not_found():
+    """The RDcode Name endpoint 404s only for a code that truly does not
+    exist -- that path keeps its original message verbatim."""
+    result = _phenotypes("99999999", _resp(404))
+
+    assert result["status"] == "error"
+    assert result["error"] == (
+        "Disease ORPHA:99999999 not found. Use Orphanet_search_diseases to "
+        "find a valid ORPHA code."
+    )
+
+
+def test_network_failure_on_discriminator_does_not_fabricate_not_found():
+    """"Can't tell" must never become "disease does not exist"."""
+    import requests
+
+    def fake_get(url, **kwargs):
+        if "ClinicalEntity" in url:
+            raise requests.exceptions.ConnectionError("boom")
+        return _resp(404)
+
+    with patch("tooluniverse.orphanet_tool.requests.get", side_effect=fake_get):
+        result = _tool().run({"operation": "get_phenotypes", "orpha_code": "1247"})
+
+    assert result["status"] == "error"
+    assert "not found" not in result["error"].lower()
+    assert "phenotype annotations" in result["error"].lower()
+
+
+# --- unrelated behavior preserved ------------------------------------------
+
+
+def test_successful_phenotype_lookup_unaffected():
+    payload = {
+        "data": {
+            "results": {
+                "Preferred term": "Marfan syndrome",
+                "HPODisorderAssociation": [
+                    {
+                        "HPO": {"HPOId": "HP:0001166", "HPOTerm": "Arachnodactyly"},
+                        "HPOFrequency": {"name": "Very frequent (99-80%)"},
+                        "DiagnosticCriteria": None,
+                    }
+                ],
+            }
+        }
+    }
+
+    with patch(
+        "tooluniverse.orphanet_tool.requests.get", return_value=_resp(200, payload)
+    ):
+        result = _tool().run({"operation": "get_phenotypes", "orpha_code": "558"})
+
+    assert result["status"] == "success"
+    assert result["data"]["phenotype_count"] == 1
+    assert result["data"]["phenotypes"][0]["hpo_id"] == "HP:0001166"
+
+
+def test_non_404_http_error_still_surfaced_as_http_error():
+    with patch("tooluniverse.orphanet_tool.requests.get", return_value=_resp(503)):
+        result = _tool().run({"operation": "get_phenotypes", "orpha_code": "558"})
+
+    assert result["status"] == "error"
+    assert "HTTP error: 503" in result["error"]
+
+
+# --- the refactored helper keeps its documented contract -------------------
+
+
+def test_lookup_orpha_name_returns_term_for_live_code():
+    with patch(
+        "tooluniverse.orphanet_tool.requests.get",
+        return_value=_resp(200, {"Preferred term": "Schistosomiasis"}),
+    ):
+        assert _tool()._lookup_orpha_name("1247") == (True, "Schistosomiasis")
+
+
+def test_lookup_orpha_name_reports_unknown_code():
+    with patch("tooluniverse.orphanet_tool.requests.get", return_value=_resp(404)):
+        assert _tool()._lookup_orpha_name("99999999") == (False, None)
+
+
+def test_orpha_code_exists_helper_still_lenient_on_network_error():
+    """_orpha_code_exists now delegates to _lookup_orpha_name; its existing
+    contract (used by five sibling operations) must be unchanged."""
+    import requests
+
+    with patch(
+        "tooluniverse.orphanet_tool.requests.get",
+        side_effect=requests.exceptions.ConnectionError("boom"),
+    ):
+        assert _tool()._orpha_code_exists("558") is True

--- a/tests/unit/test_sider_placebo_not_fabricated.py
+++ b/tests/unit/test_sider_placebo_not_fabricated.py
@@ -1,0 +1,328 @@
+"""SIDER_get_drug_side_effects must not invent a placebo rate.
+
+The side-effect table on a SIDER drug page has three fixed leading columns --
+``Side effect`` | ``Data for drug`` | ``Placebo`` -- followed by one cell per
+source label. The parser used to ignore that layout and instead ran
+
+    re.findall(r"([\\d.]+%\\s*-\\s*[\\d.]+%|[\\d.]+%)", row)
+
+over the *whole* ``<tr>``, taking match[0] as the drug frequency and match[1] as
+the placebo frequency. Two things in a row also contain percentages:
+
+  * the trailing per-label anchors, whose tooltips read
+    ``title="<b>Acitretin</b> : 65%"``, and
+  * the MedDRA concept description in the side-effect cell, e.g.
+    "Depression affects 15-25% of cancer patients."
+
+So the second ``%`` in the row was never the placebo cell. The result was that
+the drug's own rate got copied into ``placebo_frequency`` for every row that had
+a rate at all -- 43/43 dapsone rows, 233/233 acitretin rows -- which reads as
+"this drug causes the event at exactly the placebo rate", i.e. no drug effect.
+It could also invent a drug frequency outright: varenicline / Depression is
+labelled ``frequent`` upstream but was reported as ``25%``, a number scraped out
+of the prose description of what depression is.
+
+The fix reads each value from its own ``<td>``. An empty placebo cell -- the
+common case, since most SIDER labels have no placebo arm -- yields None.
+
+Second, unrelated-looking but same-file defect: ``_fetch_page`` collapsed every
+non-200 status to None, so SIDER answering HTTP 500 ("Page unavailable") was
+reported as "Drug page not found for ID 5538" -- a transient outage dressed up
+as a stable absence, which no agent will retry.
+
+All fixtures below are trimmed from the real pages; no network is used.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from tooluniverse.sider_tool import SiderTool
+
+
+CONFIG = {
+    "type": "SiderTool",
+    "name": "SIDER_get_drug_side_effects",
+    "description": "Get side effects for a drug from SIDER",
+    "parameter": {"type": "object", "properties": {}, "required": []},
+}
+
+
+def _page(rows_html):
+    """A minimal SIDER drug page carrying the given side-effect rows."""
+    return (
+        "<h1>Acitretin</h1>\n"
+        "<table>\n"
+        "<tr><th>Side effect</th><th>Data for drug</th><th>Placebo</th>"
+        '<th colspan="6">Labels</th></tr>\n' + rows_html + "\n</table>\n"
+        "<h3 class='top'>Indications</h3>\n"
+    )
+
+
+# Trimmed verbatim from http://sideeffects.embl.de/drugs/41317/ (acitretin).
+# Drug cell 65%, placebo cell EMPTY, and a trailing label tooltip that also
+# says 65% -- the exact shape that produced the fabricated placebo rate.
+ROW_EMPTY_PLACEBO = """<tr class="bg1">
+<td class="nowrap">
+<a href="/se/C0020557/" title="condition of elevated triglyceride concentration in the blood.">Hypertriglyceridaemia <small class='pull-right glyphicon glyphicon-info-sign'></small></a>
+</td>
+<td style="background-color: #F4573D; border-right: 2px solid #c1c9c7; color: black" class="nowrap">
+65%
+</td>
+<td class="nowrap bg_grey fill fg_grey" style="outline: 2px solid black;">
+</td>
+<td style="border-left: 2px solid #c1c9c7; background-color: white" class="lCl1">
+</td>
+<td style="background-color: #F4573D" class="nowrap">
+<a class="fill" style="color: #F4573D" href="/labels/bccancer/Acitretinmonograph_1Aug08/C0020557/" title="&lt;b&gt;Acitretin&lt;/b&gt; : 65%">x</a>
+</td>
+<td style="" class="nowrap bg_grey">
+<a class="fill fg_grey" href="/labels/dpdonline/PdLVhg+tG2c=/C0020557/" title="&lt;b&gt;ACITRETIN&lt;/b&gt; : no frequency information">x</a>
+</td>
+</tr>"""
+
+# Trimmed from http://sideeffects.embl.de/drugs/170361/ (varenicline): a row
+# where SIDER really does report a placebo arm, in its own column.
+ROW_REAL_PLACEBO = """<tr class="bg0">
+<td class="nowrap">
+<a href="/se/C0027497/" title="Sensation of unease and discomfort in the upper stomach.">Nausea <small class='pull-right glyphicon glyphicon-info-sign'></small></a>
+</td>
+<td style="background-color: #F4573D" class="nowrap">
+16% - 30%
+</td>
+<td style="background-color: #F4F43D" class="nowrap">
+10%
+</td>
+<td style="background-color: white" class="lCl1">
+</td>
+<td style="background-color: #F4573D" class="nowrap">
+<a class="fill" href="/labels/fda/xyz/C0027497/" title="&lt;b&gt;Varenicline&lt;/b&gt; : 30%">x</a>
+</td>
+<td style="background-color: white" class="lCl3">
+</td>
+</tr>"""
+
+# Also from varenicline: the drug column is the qualitative term "frequent",
+# and the only percentage anywhere in the row lives inside the MedDRA concept
+# description prose. The old parser reported frequency "25%" for this row.
+ROW_QUALITATIVE_WITH_PCT_IN_PROSE = """<tr class="bg1">
+<td class="nowrap">
+<a href="/se/C0011570/" title="A mental condition marked by ongoing feelings of sadness. Depression affects 15-25% of cancer patients.">Depression <small class='pull-right glyphicon glyphicon-info-sign'></small></a>
+</td>
+<td style="background-color: #F4F43D; border-right: 2px solid #c1c9c7; color: black" class="nowrap">
+frequent
+</td>
+<td class="nowrap bg_grey fill fg_grey" style="outline: 2px solid black;">
+</td>
+<td style="border-left: 2px solid #c1c9c7; background-color: white" class="lCl1">
+</td>
+<td style="background-color: white" class="lCl2">
+</td>
+<td style="background-color: white" class="lCl3">
+</td>
+</tr>"""
+
+# Acitretin again: a hyphenated range written "1-10%" with a leading qualifier.
+# The old percentage regex could only match the trailing "10%".
+ROW_HYPHENATED_RANGE = """<tr class="bg0">
+<td class="nowrap">
+<a href="/se/C0018681/" title="Pain in the head.">Headache</a>
+</td>
+<td style="background-color: #F4F43D" class="nowrap">
+postmarketing, 1-10%
+</td>
+<td class="nowrap bg_grey fill fg_grey">
+</td>
+<td style="background-color: white" class="lCl1">
+</td>
+</tr>"""
+
+
+def _tool(status_code=200, body=""):
+    """A SiderTool whose HTTP session is a stub -- no network is touched."""
+    tool = SiderTool(dict(CONFIG))
+    response = MagicMock()
+    response.status_code = status_code
+    response.text = body
+    session = MagicMock()
+    session.get.return_value = response
+    tool.session = session
+    return tool
+
+
+def _side_effects(rows_html):
+    tool = _tool(200, _page(rows_html))
+    result = tool.run({"operation": "get_side_effects", "sider_drug_id": "41317"})
+    assert result["status"] == "success", result
+    return {e["side_effect_name"]: e for e in result["data"]["side_effects"]}
+
+
+# --- (a) the regression: an empty placebo cell must be null, never a copy -----
+
+
+def test_empty_placebo_cell_is_null_not_the_drugs_own_rate():
+    """The headline bug: placebo_frequency == frequency for every row."""
+    entry = _side_effects(ROW_EMPTY_PLACEBO)["Hypertriglyceridaemia"]
+    assert entry["frequency"] == "65%"
+    assert entry["placebo_frequency"] is None
+    # Be explicit about what used to happen.
+    assert entry["placebo_frequency"] != entry["frequency"]
+
+
+def test_label_tooltip_percentage_is_not_mistaken_for_placebo():
+    """The trailing anchor's title="<b>Acitretin</b> : 65%" is not a column."""
+    entry = _side_effects(ROW_EMPTY_PLACEBO)["Hypertriglyceridaemia"]
+    assert entry["placebo_frequency"] is None
+    assert entry["meddra_code"] == "C0020557"
+
+
+def test_every_row_of_a_placebo_free_page_reports_null_placebo():
+    entries = _side_effects(
+        ROW_EMPTY_PLACEBO
+        + "\n"
+        + ROW_QUALITATIVE_WITH_PCT_IN_PROSE
+        + "\n"
+        + ROW_HYPHENATED_RANGE
+    )
+    assert len(entries) == 3
+    assert all(e["placebo_frequency"] is None for e in entries.values()), entries
+
+
+# --- (b) a genuine placebo value is still read, from its own column -----------
+
+
+def test_real_placebo_value_is_read_from_the_placebo_column():
+    entry = _side_effects(ROW_REAL_PLACEBO)["Nausea"]
+    assert entry["frequency"] == "16% - 30%"
+    assert entry["placebo_frequency"] == "10%"
+
+
+def test_mixed_page_keeps_each_rows_own_placebo_state():
+    entries = _side_effects(ROW_REAL_PLACEBO + "\n" + ROW_EMPTY_PLACEBO)
+    assert entries["Nausea"]["placebo_frequency"] == "10%"
+    assert entries["Hypertriglyceridaemia"]["placebo_frequency"] is None
+
+
+# --- (c) the drug frequency itself comes from its own cell -------------------
+
+
+def test_percentage_in_the_concept_description_is_not_a_frequency():
+    """Varenicline/Depression was reported as 25%; upstream says "frequent"."""
+    entry = _side_effects(ROW_QUALITATIVE_WITH_PCT_IN_PROSE)["Depression"]
+    assert entry["frequency"] == "frequent"
+    assert entry["placebo_frequency"] is None
+    # The prose is still returned as the concept description -- it just must not
+    # leak into either frequency field.
+    assert "15-25%" in entry["description"]
+    assert "%" not in entry["frequency"]
+
+
+def test_hyphenated_range_is_not_truncated_to_its_upper_bound():
+    entry = _side_effects(ROW_HYPHENATED_RANGE)["Headache"]
+    assert entry["frequency"] == "postmarketing, 1-10%"
+    assert entry["placebo_frequency"] is None
+
+
+def test_side_effect_name_and_description_still_parse():
+    entry = _side_effects(ROW_EMPTY_PLACEBO)["Hypertriglyceridaemia"]
+    assert entry["meddra_code"] == "C0020557"
+    assert "triglyceride" in entry["description"]
+
+
+# --- (d) HTTP 5xx is an upstream outage, not a missing drug -------------------
+
+
+def test_http_500_is_reported_as_a_retryable_server_error():
+    """SIDER answers 500 with <title>Page unavailable</title> for /drugs/5538/."""
+    tool = _tool(500, "<html><title>Page unavailable</title></html>")
+    result = tool.run({"operation": "get_side_effects", "sider_drug_id": "5538"})
+    assert result["status"] == "error"
+    error = result["error"].lower()
+    assert "500" in error
+    assert "server error" in error
+    assert "retried" in error or "retry" in error
+    # The whole point: it must not claim the drug is absent from SIDER.
+    assert "not found" not in error, result["error"]
+    assert result["retryable"] is True
+    assert result["http_status"] == 500
+
+
+def test_http_503_is_also_retryable():
+    tool = _tool(503, "")
+    result = tool.run({"operation": "get_side_effects", "sider_drug_id": "5538"})
+    assert result["status"] == "error"
+    assert result["retryable"] is True
+    assert "not found" not in result["error"].lower()
+
+
+def test_http_500_on_the_search_endpoint_is_also_surfaced():
+    """The same fix covers name lookups, which hit /searchBox/ first."""
+    tool = _tool(500, "")
+    result = tool.run({"operation": "get_side_effects", "drug_name": "isotretinoin"})
+    assert result["status"] == "error"
+    assert result["retryable"] is True
+    assert "server error" in result["error"].lower()
+
+
+# --- (e) a genuine 404 keeps its not-found wording ---------------------------
+
+
+def test_http_404_still_reports_not_found():
+    tool = _tool(404, "")
+    result = tool.run({"operation": "get_side_effects", "sider_drug_id": "99999999"})
+    assert result["status"] == "error"
+    assert "not found" in result["error"].lower()
+    assert "99999999" in result["error"]
+    assert result.get("retryable") is not True
+
+
+def test_http_404_on_indications_still_reports_not_found():
+    tool = _tool(404, "")
+    result = tool.run({"operation": "get_indications", "sider_drug_id": "99999999"})
+    assert result["status"] == "error"
+    assert "not found" in result["error"].lower()
+
+
+def test_http_404_on_a_side_effect_page_still_reports_not_found():
+    tool = _tool(404, "")
+    result = tool.run(
+        {"operation": "get_drugs_for_side_effect", "meddra_code": "C9999999"}
+    )
+    assert result["status"] == "error"
+    assert "not found" in result["error"].lower()
+
+
+# --- (f) shipped config documents the nullable placebo ------------------------
+
+
+def _sider_config():
+    path = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "tooluniverse"
+        / "data"
+        / "sider_tools.json"
+    )
+    return {t["name"]: t for t in json.loads(path.read_text())}
+
+
+@pytest.mark.parametrize("field", ["frequency", "placebo_frequency"])
+def test_return_schema_allows_null_frequencies(field):
+    tool = _sider_config()["SIDER_get_drug_side_effects"]
+    prop = tool["return_schema"]["properties"]["side_effects"]["items"]["properties"][
+        field
+    ]
+    assert "null" in prop["type"], prop
+
+
+def test_placebo_description_warns_that_null_is_not_zero():
+    tool = _sider_config()["SIDER_get_drug_side_effects"]
+    text = tool["return_schema"]["properties"]["side_effects"]["items"]["properties"][
+        "placebo_frequency"
+    ]["description"].lower()
+    assert "null" in text
+    assert "placebo" in text
+    # It must say what null means, since null is now the majority answer.
+    assert "zero" in text or "not" in text

--- a/tests/unit/test_togoid_no_route_message_surfaced.py
+++ b/tests/unit/test_togoid_no_route_message_surfaced.py
@@ -1,0 +1,127 @@
+"""Regression guard: TogoID reports an unroutable conversion as an HTTP 400
+carrying a JSON body {"message": "no route: hgnc_symbol <> uniprot"}.
+
+_togoid_get called resp.raise_for_status() before ever looking at the body, so
+the RequestException handler discarded the server's explanation and the caller
+got an opaque URL dump instead:
+
+    TogoID request failed: 400 Client Error: Bad Request for url:
+    https://api.togoid.dbcls.jp/convert?ids=TP53&route=hgnc_symbol%2Cuniprot...
+
+which also made TogoIDConvertTool's deliberate "no route" guidance branch
+unreachable. Confirmed live: the 2-step hgnc_symbol->uniprot route 400s with
+that message, while the multi-hop hgnc_symbol,hgnc,uniprot route succeeds.
+
+The fix reads the JSON body on an error response and surfaces its `message`,
+falling back to the previous text when there is no parseable body.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from tooluniverse.togoid_tool import TogoIDConvertTool, TogoIDDatasetsTool
+
+pytestmark = pytest.mark.unit
+
+
+def _cfg(name, typ):
+    return {"name": name, "type": typ, "parameter": {"type": "object", "properties": {}}}
+
+
+def _error_resp(status, json_body=None, http_error_text=""):
+    """A response that raise_for_status() rejects, as requests would."""
+    resp = MagicMock()
+    resp.status_code = status
+    if json_body is None:
+        resp.json.side_effect = ValueError("Expecting value: line 1 column 1 (char 0)")
+    else:
+        resp.json.return_value = json_body
+    resp.raise_for_status.side_effect = requests.exceptions.HTTPError(
+        http_error_text or f"{status} Error for url: https://api.togoid.dbcls.jp/convert"
+    )
+    return resp
+
+
+def _convert_tool():
+    return TogoIDConvertTool(_cfg("TogoID_convert", "TogoIDConvertTool"))
+
+
+def test_no_route_400_surfaces_upstream_message():
+    resp = _error_resp(400, {"message": "no route: hgnc_symbol <> uniprot"})
+
+    with patch("tooluniverse.togoid_tool.requests.get", return_value=resp):
+        out = _convert_tool().run(
+            {"ids": "TP53", "source": "hgnc_symbol", "target": "uniprot"}
+        )
+
+    assert out["status"] == "error"
+    error = out["error"]
+    assert "no route" in error
+    assert "hgnc_symbol" in error
+    assert "uniprot" in error
+    # Actionable guidance, not a bare URL dump.
+    assert "directly related" in error
+    assert "https://api.togoid.dbcls.jp" not in error
+
+
+def test_non_json_500_still_produces_a_sane_error():
+    resp = _error_resp(
+        500,
+        json_body=None,
+        http_error_text="500 Server Error: Internal Server Error for url: "
+        "https://api.togoid.dbcls.jp/convert",
+    )
+
+    with patch("tooluniverse.togoid_tool.requests.get", return_value=resp):
+        out = _convert_tool().run(
+            {"ids": "TP53", "source": "hgnc_symbol", "target": "uniprot"}
+        )
+
+    assert out["status"] == "error"
+    assert "500" in out["error"]
+    assert out["error"].strip()
+
+
+def test_json_error_body_without_message_falls_back_to_http_text():
+    resp = _error_resp(400, {"detail": "something else"}, "400 Client Error: Bad Request")
+
+    with patch("tooluniverse.togoid_tool.requests.get", return_value=resp):
+        out = _convert_tool().run(
+            {"ids": "TP53", "source": "hgnc_symbol", "target": "uniprot"}
+        )
+
+    assert out["status"] == "error"
+    assert "400" in out["error"]
+
+
+def test_successful_convert_is_unaffected():
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = {
+        "ids": ["ENSG00000139618"],
+        "results": ["P51587"],
+        "route": ["ensembl_gene", "uniprot"],
+    }
+
+    with patch("tooluniverse.togoid_tool.requests.get", return_value=resp):
+        out = _convert_tool().run(
+            {"ids": "ENSG00000139618", "source": "ensembl_gene", "target": "uniprot"}
+        )
+
+    assert out["status"] == "success"
+    assert out["data"]["converted_ids"] == ["P51587"]
+
+
+def test_datasets_error_response_stays_an_error_not_an_empty_success():
+    resp = _error_resp(400, {"message": "bad request"})
+
+    with patch("tooluniverse.togoid_tool.requests.get", return_value=resp):
+        out = TogoIDDatasetsTool(
+            _cfg("TogoID_list_datasets", "TogoIDDatasetsTool")
+        ).run({"category": "Gene"})
+
+    assert out["status"] == "error"
+    assert "bad request" in out["error"]

--- a/tests/unit/test_unichem_inchikey_from_response.py
+++ b/tests/unit/test_unichem_inchikey_from_response.py
@@ -1,0 +1,121 @@
+"""Unit tests for UniChem_search_compound returning the real InChIKey.
+
+Regression: ``_search_compound`` used to set
+``"inchikey": compound if search_type == "inchikey" else None``, so any
+search by ``sourceID`` or ``uci`` returned ``inchikey: null`` even though
+the ``/compounds`` response carries ``standardInchiKey`` at the top level
+(the same field ``_connectivity_search`` already reads correctly).
+
+All tests are offline: ``requests.post`` is patched.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.unichem_tool import UniChemTool
+
+INCHIKEY = "BSYNRYMUTXBXSQ-UHFFFAOYSA-N"
+
+
+def _make_tool():
+    return UniChemTool(
+        {
+            "name": "UniChem_search_compound",
+            "type": "UniChemTool",
+            "fields": {"endpoint_type": "search_compound"},
+            "parameter": {"type": "object", "properties": {}},
+        }
+    )
+
+
+def _compounds_payload(include_inchikey=True):
+    compound = {
+        "inchi": {
+            "inchi": "InChI=1S/C9H8O4/c1-6(10)13-8-5-3-2-4-7(8)9(11)12/h2-5H,1H3,(H,11,12)",
+            "formula": "C9H8O4",
+        },
+        "uci": 161671,
+        "sources": [
+            {
+                "shortName": "chembl",
+                "longName": "ChEMBL",
+                "compoundId": "CHEMBL25",
+                "url": "https://www.ebi.ac.uk/chembldb/compound/inspect/CHEMBL25",
+            }
+        ],
+    }
+    if include_inchikey:
+        compound["standardInchiKey"] = INCHIKEY
+    return {"compounds": [compound]}
+
+
+def _mock_post(payload):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = payload
+    return patch("tooluniverse.unichem_tool.requests.post", return_value=resp)
+
+
+@pytest.mark.unit
+def test_source_id_search_returns_inchikey_from_response():
+    """Searching by sourceID must surface standardInchiKey, not None."""
+    tool = _make_tool()
+    with _mock_post(_compounds_payload()):
+        result = tool.run(
+            {"compound": "CHEMBL25", "type": "sourceID", "sourceID": "1"}
+        )
+
+    assert result["status"] == "success"
+    assert result["data"]["inchikey"] == INCHIKEY
+    # Previously-working fields must be untouched.
+    assert result["data"]["formula"] == "C9H8O4"
+    assert result["data"]["inchi"].startswith("InChI=1S/C9H8O4/")
+    assert result["data"]["source_count"] == 1
+
+
+@pytest.mark.unit
+def test_uci_is_surfaced_from_response():
+    """``uci`` is additive, mirroring UniChem_connectivity_search."""
+    tool = _make_tool()
+    with _mock_post(_compounds_payload()):
+        result = tool.run(
+            {"compound": "CHEMBL25", "type": "sourceID", "sourceID": "1"}
+        )
+
+    assert result["data"]["uci"] == 161671
+
+
+@pytest.mark.unit
+def test_inchikey_search_still_echoes_query_when_field_absent():
+    """Fallback: no standardInchiKey in the response must not regress."""
+    tool = _make_tool()
+    with _mock_post(_compounds_payload(include_inchikey=False)):
+        result = tool.run({"compound": INCHIKEY, "type": "inchikey"})
+
+    assert result["status"] == "success"
+    assert result["data"]["inchikey"] == INCHIKEY
+
+
+@pytest.mark.unit
+def test_non_inchikey_search_without_field_stays_none():
+    """Fallback keeps the old behaviour when nothing better is available."""
+    tool = _make_tool()
+    with _mock_post(_compounds_payload(include_inchikey=False)):
+        result = tool.run(
+            {"compound": "CHEMBL25", "type": "sourceID", "sourceID": "1"}
+        )
+
+    assert result["data"]["inchikey"] is None
+
+
+@pytest.mark.unit
+def test_empty_compounds_response_includes_uci_key():
+    tool = _make_tool()
+    with _mock_post({"compounds": []}):
+        result = tool.run({"compound": "NOPE", "type": "inchikey"})
+
+    assert result["status"] == "success"
+    assert result["data"]["uci"] is None
+    assert result["data"]["source_count"] == 0

--- a/tests/unit/test_vep_variant_allele_surfaced.py
+++ b/tests/unit/test_vep_variant_allele_surfaced.py
@@ -1,0 +1,234 @@
+"""Regression guard: EnsemblVEPTool discarded `variant_allele`, making
+multi-allelic results self-contradictory and unattributable.
+
+rs1815739 is the ACTN3 R577X variant with allele_string "C/A/T". Confirmed
+live against https://rest.ensembl.org/vep/human/id/rs1815739 -- every one of
+the 128 transcript_consequences entries carries a `variant_allele` field, and
+transcript ENST00000502692 appears twice at the *same* protein position 620:
+
+    variant_allele "A" -> synonymous_variant, LOW,  Cga/Aga, R
+    variant_allele "T" -> stop_gained,        HIGH, Cga/Tga, R/*
+
+`_format_vep_result`'s field whitelist omitted `variant_allele`, so both rows
+came back with identical transcript_id/protein_start and opposite verdicts and
+no way to tell them apart -- the T allele is the clinically relevant null (X)
+allele, A is benign. Fixed by adding `variant_allele` to the whitelist, which
+is shared by the HGVS and rsID annotation modes.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.ensembl_vep_tool import EnsemblVEPTool
+
+pytestmark = pytest.mark.unit
+
+# Trimmed from the real rs1815739 response: the two ENST00000502692 rows that
+# collided pre-fix, plus one unrelated row.
+_RS1815739 = [
+    {
+        "input": "rs1815739",
+        "id": "rs1815739",
+        "assembly_name": "GRCh38",
+        "seq_region_name": "11",
+        "start": 66560624,
+        "end": 66560624,
+        "strand": 1,
+        "allele_string": "C/A/T",
+        "most_severe_consequence": "stop_gained",
+        "transcript_consequences": [
+            {
+                "gene_symbol": "ACTN3",
+                "gene_id": "ENSG00000248746",
+                "transcript_id": "ENST00000502692",
+                "biotype": "protein_coding",
+                "variant_allele": "A",
+                "consequence_terms": ["synonymous_variant"],
+                "impact": "LOW",
+                "amino_acids": "R",
+                "codons": "Cga/Aga",
+                "protein_start": 620,
+                "protein_end": 620,
+                "strand": 1,
+            },
+            {
+                "gene_symbol": "ACTN3",
+                "gene_id": "ENSG00000248746",
+                "transcript_id": "ENST00000502692",
+                "biotype": "protein_coding",
+                "variant_allele": "T",
+                "consequence_terms": ["stop_gained"],
+                "impact": "HIGH",
+                "amino_acids": "R/*",
+                "codons": "Cga/Tga",
+                "protein_start": 620,
+                "protein_end": 620,
+                "strand": 1,
+            },
+            {
+                "gene_symbol": "CTSF",
+                "gene_id": "ENSG00000174080",
+                "transcript_id": "ENST00000310325",
+                "biotype": "protein_coding",
+                "variant_allele": "A",
+                "consequence_terms": ["downstream_gene_variant"],
+                "impact": "MODIFIER",
+                "strand": -1,
+            },
+        ],
+        "colocated_variants": [
+            {"id": "rs1815739", "allele_string": "C/A/T", "frequencies": {}}
+        ],
+    }
+]
+
+
+def _tool(mode):
+    return EnsemblVEPTool({"name": "vep_test", "fields": {"mode": mode}})
+
+
+def _resp(json_body):
+    r = MagicMock()
+    r.status_code = 200
+    r.json.return_value = json_body
+    r.raise_for_status.return_value = None
+    return r
+
+
+def _run_rsid():
+    with patch(
+        "tooluniverse.ensembl_vep_tool.requests.get", return_value=_resp(_RS1815739)
+    ):
+        return _tool("vep_id").run({"variant_id": "rs1815739"})
+
+
+def test_multiallelic_rows_carry_their_variant_allele():
+    """Both ENST00000502692 rows survive AND are now distinguishable."""
+    result = _run_rsid()
+
+    assert result["status"] == "success"
+    tcs = result["data"]["transcript_consequences"]
+    assert len(tcs) == 3, "no consequence row may be dropped"
+
+    same_transcript = [t for t in tcs if t["transcript_id"] == "ENST00000502692"]
+    assert len(same_transcript) == 2
+
+    # Every row carries the allele that produced it.
+    for row in tcs:
+        assert "variant_allele" in row, f"missing variant_allele: {row}"
+
+    # The two colliding rows are no longer identical apart from their verdict.
+    assert {t["variant_allele"] for t in same_transcript} == {"A", "T"}
+
+
+def test_stop_gained_is_attributable_to_the_T_allele():
+    """The clinical point of R577X: T is the null (X) allele, A is benign."""
+    result = _run_rsid()
+    tcs = result["data"]["transcript_consequences"]
+
+    stop_gained = [t for t in tcs if "stop_gained" in t["consequence_terms"]]
+    assert len(stop_gained) == 1
+    assert stop_gained[0]["variant_allele"] == "T"
+    assert stop_gained[0]["impact"] == "HIGH"
+    assert stop_gained[0]["codons"] == "Cga/Tga"
+
+    synonymous = next(
+        t
+        for t in tcs
+        if t["transcript_id"] == "ENST00000502692"
+        and "synonymous_variant" in t["consequence_terms"]
+    )
+    assert synonymous["variant_allele"] == "A"
+    assert synonymous["impact"] == "LOW"
+
+    # Same transcript, same protein position -- allele is the only discriminator.
+    assert stop_gained[0]["protein_start"] == synonymous["protein_start"] == 620
+
+
+def test_hgvs_mode_shares_the_fix():
+    """_format_vep_result is shared, so the HGVS operation gains it too."""
+    with patch(
+        "tooluniverse.ensembl_vep_tool.requests.get", return_value=_resp(_RS1815739)
+    ):
+        result = _tool("vep_hgvs").run({"hgvs_notation": "ACTN3:p.Arg577Ter"})
+
+    assert result["status"] == "success"
+    tcs = result["data"]["transcript_consequences"]
+    assert [t["variant_allele"] for t in tcs] == ["A", "T", "A"]
+
+
+def test_no_pre_existing_key_changed():
+    """Purely additive: variant_allele is the only new key, all old values hold."""
+    result = _run_rsid()
+    data = result["data"]
+
+    # Top-level record is untouched.
+    assert data["input"] == "rs1815739"
+    assert data["assembly_name"] == "GRCh38"
+    assert data["seq_region_name"] == "11"
+    assert data["start"] == 66560624
+    assert data["end"] == 66560624
+    assert data["strand"] == 1
+    assert data["allele_string"] == "C/A/T"
+    assert data["most_severe_consequence"] == "stop_gained"
+    assert data["colocated_variants"] == [
+        {"id": "rs1815739", "allele_string": "C/A/T", "frequencies": {}}
+    ]
+
+    # Row ordering is preserved.
+    tcs = data["transcript_consequences"]
+    assert [t["transcript_id"] for t in tcs] == [
+        "ENST00000502692",
+        "ENST00000502692",
+        "ENST00000310325",
+    ]
+
+    # variant_allele is the ONLY key added to any row.
+    expected_pre_existing = {
+        "gene_symbol": "ACTN3",
+        "gene_id": "ENSG00000248746",
+        "transcript_id": "ENST00000502692",
+        "biotype": "protein_coding",
+        "consequence_terms": ["stop_gained"],
+        "impact": "HIGH",
+        "amino_acids": "R/*",
+        "codons": "Cga/Tga",
+        "protein_start": 620,
+        "protein_end": 620,
+        "strand": 1,
+    }
+    row = tcs[1]
+    assert set(row) - set(expected_pre_existing) == {"variant_allele"}
+    for key, value in expected_pre_existing.items():
+        assert row[key] == value, f"{key} changed"
+
+
+def test_missing_variant_allele_upstream_is_not_fabricated():
+    """None-valued fields are still dropped; the tool must not invent an allele."""
+    record = [
+        {
+            "input": "rs999",
+            "id": "rs999",
+            "allele_string": "A/G",
+            "transcript_consequences": [
+                {
+                    "transcript_id": "ENST00000000001",
+                    "gene_symbol": "FOO",
+                    "consequence_terms": ["intron_variant"],
+                }
+            ],
+        }
+    ]
+    with patch(
+        "tooluniverse.ensembl_vep_tool.requests.get", return_value=_resp(record)
+    ):
+        result = _tool("vep_id").run({"variant_id": "rs999"})
+
+    assert result["status"] == "success"
+    row = result["data"]["transcript_consequences"][0]
+    assert "variant_allele" not in row

--- a/tests/unit/test_worms_marine_only_disclosed.py
+++ b/tests/unit/test_worms_marine_only_disclosed.py
@@ -1,0 +1,266 @@
+"""WoRMS_search_species must disclose (and let callers lift) the marine filter.
+
+WoRMS's AphiaRecordsByName endpoint defaults to ``marine_only=true``. The tool
+neither set nor exposed that parameter, so a search for a real, WoRMS-catalogued
+but non-marine taxon came back as a confident empty success:
+
+    WoRMS_search_species {"query": "Schistosoma mansoni"}
+    -> {"status": "success", "data": [], "count": 0,
+        "message": "No results found for this query"}
+
+even though AphiaID 1599676 exists and the sibling tools (WoRMS_get_classification,
+WoRMS_get_distribution) serve it happily -- their docs say to obtain the AphiaID
+from WoRMS_search_species, so the documented workflow was unreachable for every
+freshwater/terrestrial taxon.
+
+The fix is additive: a new optional ``marine_only`` parameter that defaults to
+today's behaviour, plus a zero-result message that names the filter. Callers who
+do not pass it must see byte-identical requests and identical result sets.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from tooluniverse.worms_tool import WoRMSRESTTool
+
+
+SEARCH_CONFIG = {
+    "type": "WoRMSRESTTool",
+    "name": "WoRMS_search_species",
+    "description": "Search species in WoRMS",
+    "parameter": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string"},
+            "limit": {"type": "integer"},
+            "offset": {"type": "integer"},
+            "marine_only": {"type": "boolean"},
+        },
+        "required": ["query"],
+    },
+    "fields": {"return_format": "JSON"},
+}
+
+# Trimmed from the real upstream response for
+# AphiaRecordsByName/Schistosoma%20mansoni?marine_only=false&offset=1
+SCHISTOSOMA = {
+    "AphiaID": 1599676,
+    "scientificname": "Schistosoma mansoni",
+    "authority": "Sambon, 1907",
+    "status": "accepted",
+    "rank": "Species",
+    "valid_AphiaID": 1599676,
+    "kingdom": "Animalia",
+    "phylum": "Platyhelminthes",
+    "class": "Trematoda",
+    "family": "Schistosomatidae",
+    "isMarine": None,
+    "isFreshwater": 1,
+    "isTerrestrial": 1,
+    "match_type": "exact",
+}
+
+GADUS = {
+    "AphiaID": 126436,
+    "scientificname": "Gadus morhua",
+    "status": "accepted",
+    "isMarine": 1,
+    "match_type": "exact",
+}
+
+
+def _session(records):
+    """Session returning `records` on the first page, then nothing."""
+
+    def get(url, timeout=None):
+        response = MagicMock()
+        offset = int(url.split("offset=")[1].split("&")[0]) if "offset=" in url else 1
+        page = records if offset == 1 else []
+        if not page:
+            response.status_code = 204
+            response.text = ""
+            response.json.return_value = []
+            return response
+        response.status_code = 200
+        response.text = "[...]"
+        response.json.return_value = page
+        return response
+
+    session = MagicMock()
+    session.get.side_effect = get
+    return session
+
+
+def _run(arguments, records):
+    tool = WoRMSRESTTool(dict(SEARCH_CONFIG))
+    tool.session = _session(records)
+    result = tool.run(arguments)
+    return result, [c.args[0] for c in tool.session.get.call_args_list]
+
+
+# --- (a) marine_only unset: request unchanged, empty answer now discloses -----
+
+
+def test_unset_marine_only_sends_todays_request_unchanged():
+    """No marine_only argument => no marine_only in the outgoing URL."""
+    _, urls = _run({"query": "Schistosoma mansoni"}, [])
+    assert urls, "the tool must actually call WoRMS"
+    for url in urls:
+        assert "marine_only" not in url
+        assert url.endswith("?offset=1")
+
+
+def test_empty_result_discloses_the_marine_filter():
+    """A confidently-wrong empty answer becomes an actionable one."""
+    result, _ = _run({"query": "Schistosoma mansoni"}, [])
+    assert result["status"] == "success"
+    assert result["data"] == []
+    assert result["count"] == 0
+    message = result["message"].lower()
+    assert "marine" in message, message
+    # It must name the escape hatch, not merely mention the restriction.
+    assert "marine_only=false" in message, message
+    assert "freshwater" in message and "terrestrial" in message, message
+
+
+def test_empty_result_reports_the_effective_marine_only_value():
+    result, _ = _run({"query": "Schistosoma mansoni"}, [])
+    assert result["marine_only"] is True
+
+
+# --- (b) marine_only=false is forwarded and its records parse normally --------
+
+
+def test_marine_only_false_is_forwarded_upstream():
+    _, urls = _run(
+        {"query": "Schistosoma mansoni", "marine_only": False}, [SCHISTOSOMA]
+    )
+    assert urls
+    assert all("marine_only=false" in url for url in urls), urls
+    # Still 1-based offset paging, unchanged.
+    assert "offset=1" in urls[0]
+
+
+def test_marine_only_false_returns_the_non_marine_record():
+    result, _ = _run(
+        {"query": "Schistosoma mansoni", "marine_only": False}, [SCHISTOSOMA]
+    )
+    assert result["status"] == "success"
+    assert result["count"] == 1
+    assert result["has_more"] is False
+    assert result["marine_only"] is False
+    record = result["data"][0]
+    assert record["AphiaID"] == 1599676
+    assert record["scientificname"] == "Schistosoma mansoni"
+    # The AphiaID the sibling tools need is now reachable from the search.
+    assert record["family"] == "Schistosomatidae"
+
+
+def test_marine_only_true_is_forwarded_explicitly_when_requested():
+    _, urls = _run({"query": "Gadus morhua", "marine_only": True}, [GADUS])
+    assert all("marine_only=true" in url for url in urls), urls
+
+
+def test_marine_only_accepts_json_string_booleans():
+    """CLI/agent callers sometimes stringify booleans."""
+    result, urls = _run(
+        {"query": "Schistosoma mansoni", "marine_only": "false"}, [SCHISTOSOMA]
+    )
+    assert result["status"] == "success"
+    assert result["marine_only"] is False
+    assert all("marine_only=false" in url for url in urls)
+
+
+def test_non_boolean_marine_only_is_rejected_clearly():
+    result, _ = _run({"query": "Gadus", "marine_only": "maybe"}, [GADUS])
+    assert result["status"] == "error"
+    assert "marine_only" in result["error"]
+
+
+# --- (c) a successful marine search is unchanged -----------------------------
+
+
+def test_successful_marine_search_is_unchanged():
+    result, urls = _run({"query": "Gadus morhua"}, [GADUS])
+    assert result["status"] == "success"
+    assert result["count"] == 1
+    assert result["data"] == [GADUS]
+    assert result["offset"] == 1
+    assert result["limit"] == 20
+    assert result["has_more"] is False
+    # No behaviour change for the existing marine caller: same URL as before.
+    assert urls[0].endswith("?offset=1")
+    assert "marine_only" not in urls[0]
+    # A non-empty result carries no filter warning.
+    assert "message" not in result
+
+
+def test_marine_only_does_not_leak_into_aphia_operations():
+    """Enrichment endpoints keep their exact URLs."""
+    config = dict(SEARCH_CONFIG)
+    config["fields"] = {"operation": "classification"}
+    tool = WoRMSRESTTool(config)
+    response = MagicMock()
+    response.status_code = 200
+    response.text = "{}"
+    response.json.return_value = {"AphiaID": 1599676, "rank": "Species"}
+    session = MagicMock()
+    session.get.return_value = response
+    tool.session = session
+    result = tool.run({"AphiaID": 1599676, "marine_only": False})
+    assert result["status"] == "success"
+    assert "marine_only" not in session.get.call_args.args[0]
+
+
+# --- shipped config documents the new parameter ------------------------------
+
+
+def _search_config():
+    import json
+    from pathlib import Path
+
+    path = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "tooluniverse"
+        / "data"
+        / "worms_tools.json"
+    )
+    return {t["name"]: t for t in json.loads(path.read_text())}
+
+
+def test_config_declares_marine_only_and_documents_the_default():
+    tools = _search_config()
+    search = tools["WoRMS_search_species"]
+    param = search["parameter"]["properties"]["marine_only"]
+    assert param["type"] == "boolean"
+    assert param["default"] is True
+    assert "marine_only" not in search["parameter"].get("required", [])
+    assert "marine" in search["description"].lower()
+    assert "marine_only=false" in search["description"]
+
+
+def test_sibling_tools_point_at_the_new_parameter():
+    """Their docs send callers to the search tool, which needed the caveat."""
+    tools = _search_config()
+    for name in (
+        "WoRMS_get_classification",
+        "WoRMS_get_distribution",
+        "WoRMS_get_vernaculars",
+        "WoRMS_get_synonyms",
+    ):
+        text = tools[name]["parameter"]["properties"]["AphiaID"]["description"]
+        assert "WoRMS_search_species" in text
+        assert "marine_only=false" in text, name
+
+
+def test_return_schema_does_not_forbid_extra_metadata():
+    """The `marine_only` echo must not violate the declared schema."""
+    search = _search_config()["WoRMS_search_species"]
+    assert "additionalProperties" not in str(search["return_schema"])
+
+
+@patch("tooluniverse.worms_tool.requests")
+def test_no_network_is_touched(_requests):
+    """Guard: the module's requests object is never used directly here."""
+    result, _ = _run({"query": "Schistosoma mansoni"}, [])
+    assert result["status"] == "success"


### PR DESCRIPTION
Round 31 explored three domains untouched by rounds 20-30 — tropical/neglected disease, dermatology/cutaneous genetics, and sports/exercise physiology — plus an orchestrator probe of population genetics and identifier cross-referencing. 46 issues were reported across the three personas; 13 survived CLI verification, sibling-PR deduplication and root-cause confirmation at the upstream API.

Every fix below was reproduced by the orchestrator with `tu run` before and after, and every root cause was established against the upstream service (direct `curl`, upstream OpenAPI documents, or upstream source), not inferred from tool behaviour.

## The wrong-number fixes

**DrugCentral reported a −log10 potency under an `IC50` label.** `DrugCentral_get_targets '{"chem_id":"CHEMBL976"}'` returned `activity_type: "IC50", activity_value: "4.01"` for praziquantel/BSEP. ChEMBL's record for the same pair is `IC50 96800 nM, pChEMBL 4.01` — so `4.01` is the p-scale value and the tool was asserting a concentration roughly five orders of magnitude off. 143 sampled live rows all fell in 4.05–12.301, confirming the scale is universal. `activity_value` and `activity_type` are unchanged; new sibling keys (`activity_type_reported`, `activity_value_scale`, `activity_value_nM`) make the scale explicit.

**SIDER invented a placebo rate for every side effect.** `placebo_frequency` equalled the drug's own frequency on 43/43 dapsone rows and 233/233 acitretin rows — every side effect reading as occurring at exactly the placebo rate. SIDER's placebo cell is empty for those labels; the parser scanned the whole table row for percentages and took the second match, which is a per-label tooltip echoing the drug's own rate. Values are now read per cell; an empty placebo cell yields `null` (already permitted by the schema). Two further row-wide-regex defects fell out: a qualitative frequency (`frequent`) overwritten by a percentage found inside the row's MedDRA prose, and ranges written `1-10%` truncated to their upper bound.

**A missing-value sentinel outranked real genome-wide hits.** `GWASSumStats_get_region_associations` at `p_upper=5e-8` returned ten rows, eight of them `p_value: -99.0`, ranked above the two genuine hits (5.31e-24, 5.71e-23). `-99` is the GWAS Catalog missing-value sentinel and `-99 <= 5e-8` is numerically true; our own ascending sort then lifted every sentinel above every real result. Rows are dropped only when a threshold was requested, and the excluded count is disclosed.

**HPA labelled single-cell values with the wrong unit** (`nTPM` where HPA reports `nCPM`), and `tissues_with_expression` reported 184 against HPA's ~44 consensus tissues — it was a row count including 135 rows with no level, 9 explicitly "not detected", and per-antibody duplicates.

## The tools that blamed the caller

**HPA blamed the caller for column codes HPA never had.** Asking for skin expression returned "'skin' did not match an HPA tissue column (t_RNA_skin). This means the tissue name is unrecognized" — but HPA's column is `t_RNA_skin_1`, and HPA silently omits unknown codes, so a wrong code and a missing value look identical. The same defect hid behind `stomach`, `endometrium` and `brain`; four further names map to no RNA column at all. It was masked for skin-enriched genes, which fell through to the tissue-specificity summary column and answered plausibly — so the tool worked for exactly the genes you would already have guessed. `source_type` values `single_cell` and `blood` were dead for every gene: `rnascm`/`rnablm` are not HPA column codes.

**GWAS blamed the trait term for its own filter's zero result.** BMI associations at `p<5e-8` returned an empty list plus advice that the EFO term might be wrong — while the same payload reported 23,608 total elements for that term. The `p_value` filter is client-side over one page, and with `direction=desc` page 0 holds the least significant rows. The v2 OpenAPI document declares no p-value parameter and 15 candidate names were probed, so the filter must stay client-side; the tool now fetches the significant end and attributes an empty result to the filter.

**Orphanet called a valid disease code nonexistent.** `Orphanet_get_phenotypes '{"orpha_code":"1247"}'` answered "Disease not found. Use Orphanet_search_diseases to find a valid ORPHA code" — a false statement whose advice loops. Four sibling tools resolve that code. The `rd-phenotypes` 404 body is byte-identical for a valid-but-unannotated code and a made-up one, so the RDcode Name endpoint is now used to discriminate.

**MedlinePlus threw away documents it had already fetched.** Two of three documented `rettype` values fetched HTTP 200 with valid documents and then reported "Failed to parse health topic information". Every call also printed ten lines of diagnostics plus a raw structure dump to stdout ahead of the payload.

**InterPro reported a zero-hit search as an internal error.** The EBI API answers a zero-hit query with HTTP 204 and an empty body; `raise_for_status()` treats 204 as success, so `.json()` ran on an empty string. A caller could not distinguish "no such family" from "the tool is broken".

## The answers that were unreachable or incomplete

**Monarch could not be asked which genes cause a disease.** The implementation already read an `object` argument, but the registered schema exposed only `subject` and marked it required, so the disease-anchored direction of a directed Biolink category was unreachable. Upstream answers with three genes for MONDO:0006559.

**WoRMS search could not reach the records its siblings serve.** `WoRMS_search_species` returned a confident empty success for *Schistosoma mansoni* while `WoRMS_get_classification` and `WoRMS_get_distribution` both serve AphiaID 1599676 — and their docs say to obtain that ID from the search tool. An optional `marine_only` parameter is added rather than the default flipped.

**VEP dropped the allele each consequence belongs to.** For rs1815739 (ACTN3 R577X) the tool emitted two rows for the same transcript and protein position with opposite verdicts and nothing to tell them apart. Which allele is the null one is the entire clinical content of R577X.

**UniChem discarded the InChIKey it was already given.** The `/compounds` response carries `standardInchiKey` at the top level, but the field only ever echoed the caller's own query, so the common direction — "I have CHEMBL25, what is its InChIKey?" — always returned null.

**TogoID answered an unroutable conversion with a URL dump.** TogoID reports the actionable reason with HTTP 400, and the tool already had a branch written to turn that message into guidance — but it sat behind `raise_for_status()` and could never run.

## Contract changes flagged for review

Most of this round is additive. Six changes alter what a caller receives, and every one replaces a value that was wrong:

1. **SIDER `placebo_frequency` → `null`** for most rows, and `frequency` changes shape for qualitative/range labels. An additive disclosure was rejected: the old number was synthesised, not published, and the specific claim it made inverts the clinical conclusion.
2. **GWASSumStats row set** shrinks when `p_upper` is set (10 → 2 for the repro). Additive disclosure alone was rejected because `-99` was passing a significance filter and ranking first.
3. **InterPro zero-hit: error → success.** The safe direction; no caller could depend on an unconditional error.
4. **HPA `tissues_with_expression` re-meant** (184 → 40). This is the one key re-meaning in the round. The raw count is preserved additively as `tissue_expression_rows`; 184 was impossible under the name it carried.
5. **HPA tissue/source values** appear where `"N/A"` was returned, and single-cell `expression_unit` changes `nTPM` → `nCPM`.
6. **GWAS fetch direction** is overridden when a p-value threshold is present; rows are returned in the caller's requested direction and the override is disclosed in metadata.

MedlinePlus's stdout removal is a behaviour change in the benign direction — the diagnostics move to `logger.debug`, recoverable via `TOOLUNIVERSE_LOG_LEVEL=DEBUG`.

## Not touched

Files owned by open PRs #500-#504 were treated as a do-not-touch list, fetched per-PR at verification time. Six verified findings were skipped as sibling-PR duplicates or declined on conflict risk, and the InterPro guard was kept as a small per-module helper rather than moved into `base_rest_tool.py`, which #503 owns. The tracked wrapper tree under `src/tooluniverse/tools/` was not regenerated.
