### PR TITLE
Fix Round 32: numbers and emptiness that a reader would have acted on

### DIFF
--- a/src/tooluniverse/clingen_allele_tool.py
+++ b/src/tooluniverse/clingen_allele_tool.py
@@ -103,6 +103,9 @@ class ClinGenAlleleTool(BaseTool):
         # Extract genomic coordinates
         genomic = []
         for ga in data.get("genomicAlleles") or []:
+            # `referenceGenome` (and `chromosome`) live on the parent
+            # genomicAlleles[i] object, not on the inner coordinates[j]
+            # dict -- the inner dict only has start/end/allele/referenceAllele.
             for coord in ga.get("coordinates") or []:
                 genomic.append(
                     {
@@ -111,7 +114,7 @@ class ClinGenAlleleTool(BaseTool):
                         "end": coord.get("end"),
                         "allele": coord.get("allele"),
                         "reference_allele": coord.get("referenceAllele"),
-                        "reference_genome": coord.get("referenceGenome"),
+                        "reference_genome": ga.get("referenceGenome"),
                     }
                 )
 

--- a/src/tooluniverse/clinical_calculators_tool.py
+++ b/src/tooluniverse/clinical_calculators_tool.py
@@ -37,6 +37,68 @@ def _req_number(args: Dict[str, Any], key: str) -> float:
         raise ValueError(f"'{key}' must be a number, got {val!r}")
 
 
+# Accepted string values for the `sex` parameter (case-insensitive).
+_SEX_STRING_MAP = {"female": True, "f": True, "male": False, "m": False}
+
+
+def _resolve_sex(a: Dict[str, Any]) -> "tuple[bool, Any]":
+    """Resolve biological sex from the `female` boolean and/or `sex` string args.
+
+    Both are accepted for backward compatibility: `female` is the original
+    parameter, `sex` is the natural-language clinical term this tool's own
+    output already speaks in terms of ("components": {"sex": ...}). Accepting
+    it as input too makes the interface symmetric.
+
+    Returns (is_female, assumption_note). `assumption_note` is None unless
+    neither `female` nor `sex` was supplied, in which case the *existing*
+    default (male) is still used, but a note is returned so the caller can
+    disclose that the default was silently assumed.
+
+    Raises ValueError if:
+      - `sex` is supplied but is not a recognised value (female/f/male/m,
+        case-insensitive), or
+      - both `female` and `sex` are supplied and they disagree.
+    """
+    has_female = "female" in a and a.get("female") is not None
+    has_sex = "sex" in a and a.get("sex") is not None
+
+    sex_is_female = None
+    if has_sex:
+        raw = str(a["sex"]).strip().lower()
+        if raw not in _SEX_STRING_MAP:
+            raise ValueError(
+                "'sex' must be one of "
+                f"{sorted(_SEX_STRING_MAP)} (case-insensitive), got {a['sex']!r}"
+            )
+        sex_is_female = _SEX_STRING_MAP[raw]
+
+    female_is_female = _truthy(a["female"]) if has_female else None
+
+    if has_sex and has_female:
+        if sex_is_female != female_is_female:
+            raise ValueError(
+                "conflicting sex inputs: "
+                f"'female'={a['female']!r} implies "
+                f"{'female' if female_is_female else 'male'}, but "
+                f"'sex'={a['sex']!r} implies "
+                f"{'female' if sex_is_female else 'male'}. "
+                "Provide consistent values (or only one of the two)."
+            )
+        return female_is_female, None
+
+    if has_sex:
+        return sex_is_female, None
+    if has_female:
+        return female_is_female, None
+
+    return False, (
+        "Neither 'female' nor 'sex' was supplied; male coefficients/points "
+        "were assumed by default. This choice materially changes the "
+        "result — supply 'sex' (or 'female') explicitly for an accurate "
+        "calculation."
+    )
+
+
 def _ok(score, interpretation, components, **extra) -> Dict[str, Any]:
     data = {"score": score, "interpretation": interpretation, "components": components}
     data.update(extra)
@@ -53,6 +115,7 @@ def _ok(score, interpretation, components, **extra) -> Dict[str, Any]:
 def _cha2ds2_vasc(a: Dict[str, Any]) -> Dict[str, Any]:
     """CHA2DS2-VASc stroke risk in atrial fibrillation (Lip 2010)."""
     age = _req_number(a, "age")
+    female, sex_note = _resolve_sex(a)
     comp = {
         "CHF": int(_truthy(a.get("chf"))),
         "Hypertension": int(_truthy(a.get("hypertension"))),
@@ -62,7 +125,7 @@ def _cha2ds2_vasc(a: Dict[str, Any]) -> Dict[str, Any]:
         "Stroke/TIA/thromboembolism": 2 if _truthy(a.get("stroke_history")) else 0,
         "Vascular_disease": int(_truthy(a.get("vascular_disease"))),
         "Age_65-74": 1 if 65 <= age < 75 else 0,
-        "Female": int(_truthy(a.get("female"))),
+        "Female": int(female),
     }
     score = sum(comp.values())
     if score == 0:
@@ -71,7 +134,10 @@ def _cha2ds2_vasc(a: Dict[str, Any]) -> Dict[str, Any]:
         interp = "Low-moderate risk (1) — consider anticoagulation"
     else:
         interp = f"Elevated risk ({score}) — oral anticoagulation recommended"
-    return _ok(score, interp, comp, max_score=9)
+    extra = {"max_score": 9}
+    if sex_note:
+        extra["assumptions"] = [sex_note]
+    return _ok(score, interp, comp, **extra)
 
 
 def _has_bled(a: Dict[str, Any]) -> Dict[str, Any]:
@@ -301,7 +367,7 @@ def _ckd_epi(a: Dict[str, Any]) -> Dict[str, Any]:
     """eGFR by CKD-EPI 2021 creatinine equation, race-free (Inker 2021)."""
     scr = _req_number(a, "creatinine")  # mg/dL
     age = _req_number(a, "age")
-    female = _truthy(a.get("female"))
+    female, sex_note = _resolve_sex(a)
     kappa = 0.7 if female else 0.9
     alpha = -0.241 if female else -0.302
     egfr = (
@@ -325,11 +391,14 @@ def _ckd_epi(a: Dict[str, Any]) -> Dict[str, Any]:
     else:
         stage = "G5 (kidney failure, <15)"
     comp = {"creatinine_mg_dL": scr, "age": age, "sex": "female" if female else "male"}
+    extra = {"unit": "mL/min/1.73m^2"}
+    if sex_note:
+        extra["assumptions"] = [sex_note]
     return _ok(
         egfr,
         f"eGFR {egfr} mL/min/1.73m^2 — CKD stage {stage}",
         comp,
-        unit="mL/min/1.73m^2",
+        **extra,
     )
 
 
@@ -410,12 +479,25 @@ def _ascvd(a: Dict[str, Any]) -> Dict[str, Any]:
     treated = _truthy(a.get("bp_treated"))
     smoker = _truthy(a.get("smoker"))
     diabetes = _truthy(a.get("diabetes"))
-    female = _truthy(a.get("female"))
-    black = str(a.get("race", "")).strip().lower() in (
+    female, sex_note = _resolve_sex(a)
+    race_raw = a.get("race")
+    black = str(race_raw or "").strip().lower() in (
         "black",
         "african american",
         "aa",
     )
+    assumptions = []
+    if sex_note:
+        assumptions.append(sex_note)
+    if race_raw is None or str(race_raw).strip() == "":
+        assumptions.append(
+            "'race' was not supplied; White/other coefficients were assumed "
+            "by default (per the Pooled Cohort Equations guideline, which "
+            "uses White coefficients for race/ethnicities other than "
+            "non-Hispanic Black). This choice materially changes the result "
+            "for Black patients — supply 'race' explicitly for an accurate "
+            "calculation."
+        )
 
     key = f"{'black' if black else 'white'}_{'female' if female else 'male'}"
     c = _ASCVD_COEFF[key]
@@ -466,7 +548,10 @@ def _ascvd(a: Dict[str, Any]) -> Dict[str, Any]:
         "smoker": smoker,
         "diabetes": diabetes,
     }
-    return _ok(risk, f"10-year ASCVD risk {risk}% — {band} risk", comp, unit="percent")
+    extra = {"unit": "percent"}
+    if assumptions:
+        extra["assumptions"] = assumptions
+    return _ok(risk, f"10-year ASCVD risk {risk}% — {band} risk", comp, **extra)
 
 
 _DISPATCH: Dict[str, Callable[[Dict[str, Any]], Dict[str, Any]]] = {

--- a/src/tooluniverse/data/clinical_calculators_tools.json
+++ b/src/tooluniverse/data/clinical_calculators_tools.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "ClinicalCalc_CHA2DS2_VASc",
-    "description": "CHA2DS2-VASc score: stroke risk in non-valvular atrial fibrillation, used to decide oral anticoagulation. Deterministic point score (0-9). Provide age plus boolean risk factors. Returns score, anticoagulation interpretation, and per-component points.",
+    "description": "CHA2DS2-VASc score: stroke risk in non-valvular atrial fibrillation, used to decide oral anticoagulation. Deterministic point score (0-9). Provide age plus boolean risk factors and sex. Returns score, anticoagulation interpretation, and per-component points.",
     "parameter": {"type": "object", "properties": {
       "age": {"type": "number", "description": "Age in years"},
       "chf": {"type": "boolean", "description": "Congestive heart failure / LV dysfunction"},
@@ -9,13 +9,15 @@
       "diabetes": {"type": "boolean", "description": "Diabetes mellitus"},
       "stroke_history": {"type": "boolean", "description": "Prior stroke, TIA, or thromboembolism (2 points)"},
       "vascular_disease": {"type": "boolean", "description": "Vascular disease (prior MI, PAD, aortic plaque)"},
-      "female": {"type": "boolean", "description": "Female sex"}
+      "female": {"type": "boolean", "description": "Female sex (legacy boolean; equivalent to sex='female'). If both 'female' and 'sex' are given they must agree."},
+      "sex": {"type": "string", "description": "Biological sex: 'female'/'f' or 'male'/'m' (case-insensitive). Preferred over 'female'. If neither 'sex' nor 'female' is supplied, male is assumed by default and the response's 'assumptions' field discloses this."}
     }, "required": ["age"]},
     "fields": {"calculator": "cha2ds2_vasc"},
     "type": "ClinicalCalculatorTool",
     "test_examples": [
       {"age": 80, "female": true, "hypertension": true, "diabetes": true},
-      {"age": 55, "chf": false, "hypertension": false}
+      {"age": 55, "chf": false, "hypertension": false},
+      {"age": 68, "sex": "female", "hypertension": true}
     ],
     "return_schema": {
       "oneOf": [
@@ -30,6 +32,12 @@
             },
             "components": {
               "type": "object"
+            },
+            "assumptions": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           },
           "required": [
@@ -417,13 +425,15 @@
     "parameter": {"type": "object", "properties": {
       "creatinine": {"type": "number", "description": "Serum creatinine in mg/dL"},
       "age": {"type": "number", "description": "Age in years"},
-      "female": {"type": "boolean", "description": "Female sex"}
+      "female": {"type": "boolean", "description": "Female sex (legacy boolean; equivalent to sex='female'). If both 'female' and 'sex' are given they must agree."},
+      "sex": {"type": "string", "description": "Biological sex: 'female'/'f' or 'male'/'m' (case-insensitive). Preferred over 'female'. If neither 'sex' nor 'female' is supplied, male is assumed by default and the response's 'assumptions' field discloses this — this materially changes the eGFR value."}
     }, "required": ["creatinine", "age"]},
     "fields": {"calculator": "ckd_epi"},
     "type": "ClinicalCalculatorTool",
     "test_examples": [
       {"creatinine": 0.9, "age": 60, "female": true},
-      {"creatinine": 1.3, "age": 60, "female": false}
+      {"creatinine": 1.3, "age": 60, "female": false},
+      {"creatinine": 1.2, "age": 55, "sex": "female"}
     ],
     "return_schema": {
       "oneOf": [
@@ -441,6 +451,12 @@
             },
             "unit": {
               "type": "string"
+            },
+            "assumptions": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           },
           "required": [
@@ -472,14 +488,16 @@
       "bp_treated": {"type": "boolean", "description": "Currently on blood-pressure-lowering medication"},
       "smoker": {"type": "boolean", "description": "Current smoker"},
       "diabetes": {"type": "boolean", "description": "Diabetes mellitus"},
-      "female": {"type": "boolean", "description": "Female sex"},
-      "race": {"type": "string", "description": "'white' (or other) vs 'black'/'African American'; affects the coefficient set", "default": "white"}
+      "female": {"type": "boolean", "description": "Female sex (legacy boolean; equivalent to sex='female'). If both 'female' and 'sex' are given they must agree."},
+      "sex": {"type": "string", "description": "Biological sex: 'female'/'f' or 'male'/'m' (case-insensitive). Preferred over 'female'. If neither 'sex' nor 'female' is supplied, male is assumed by default and the response's 'assumptions' field discloses this — this materially changes the risk value."},
+      "race": {"type": "string", "description": "'white' (or other) vs 'black'/'African American'; affects the coefficient set. If omitted, White/other coefficients are assumed by default and the response's 'assumptions' field discloses this.", "default": "white"}
     }, "required": ["age", "total_cholesterol", "hdl_cholesterol", "systolic_bp"]},
     "fields": {"calculator": "ascvd"},
     "type": "ClinicalCalculatorTool",
     "test_examples": [
       {"age": 55, "total_cholesterol": 213, "hdl_cholesterol": 50, "systolic_bp": 120, "bp_treated": false, "smoker": false, "diabetes": false, "female": false, "race": "white"},
-      {"age": 60, "total_cholesterol": 240, "hdl_cholesterol": 40, "systolic_bp": 140, "bp_treated": true, "smoker": true, "diabetes": true, "female": true, "race": "black"}
+      {"age": 60, "total_cholesterol": 240, "hdl_cholesterol": 40, "systolic_bp": 140, "bp_treated": true, "smoker": true, "diabetes": true, "female": true, "race": "black"},
+      {"age": 60, "total_cholesterol": 240, "hdl_cholesterol": 40, "systolic_bp": 140, "bp_treated": true, "smoker": true, "diabetes": true, "sex": "female", "race": "black"}
     ],
     "return_schema": {
       "oneOf": [
@@ -497,6 +515,12 @@
             },
             "unit": {
               "type": "string"
+            },
+            "assumptions": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           },
           "required": [

--- a/src/tooluniverse/data/expression_atlas_tools.json
+++ b/src/tooluniverse/data/expression_atlas_tools.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "ExpressionAtlas_get_baseline",
-    "description": "List baseline gene expression experiments in EBI Expression Atlas for a given species. The `gene` argument is used to label the request and suggest a follow-up call, but does NOT filter the returned experiment list (the underlying API has no reliable way to filter experiments by gene) -- use GxA_get_experiment_expression with an experiment_accession from the results and gene_id=<gene> to check whether a specific experiment actually has data for that gene. Complements GTEx and HPA. No API key needed.",
+    "description": "List baseline gene expression experiments in EBI Expression Atlas for a given species. The `gene` argument is used to label the request and suggest a follow-up call, but does NOT filter the returned experiment list (the underlying API has no reliable way to filter experiments by gene). Do NOT use GxA_get_experiment_expression's gene_id filter to check whether a specific experiment has data for a gene -- that endpoint only returns a small default sample of the experiment's genes (verified live: ~29 of 9,570 for E-MTAB-2836) and silently ignores gene-filter parameters, so a miss there is not evidence of absence. For a reliable per-gene baseline expression check, use GTEx_get_expression_summary (human tissues, verified working) or HPA_get_rna_expression_in_specific_tissues instead. Complements GTEx and HPA. No API key needed.",
     "parameter": {
       "type": "object",
       "properties": {

--- a/src/tooluniverse/data/gxa_tools.json
+++ b/src/tooluniverse/data/gxa_tools.json
@@ -90,7 +90,7 @@
   },
   {
     "name": "GxA_get_experiment_expression",
-    "description": "Get gene expression data from a specific Expression Atlas experiment. Returns expression levels across tissues or conditions, with optional filtering by gene ID. Experiment E-MTAB-2836 contains RNA-seq of 122 human tissues, E-MTAB-2706 covers 675 cancer cell lines. For each gene, expression values are provided across all assayed conditions (tissues, cell types, developmental stages, etc.).",
+    "description": "Get gene expression data from a specific Expression Atlas experiment. Returns expression levels across tissues or conditions. IMPORTANT limitation (verified live): the upstream /experiments/{accession} endpoint always returns only a small, arbitrary default SAMPLE of the experiment's genes (e.g. ~29 of 9,570 for E-MTAB-2836) and silently ignores every gene-filter parameter we can send it -- so the optional `gene_id` filter can only ever match within that tiny sample, never the full gene set. The response discloses `profiles_returned_by_upstream` and `profiles_available_upstream` so callers can see the sample size vs. the true total; when a `gene_id` filter matches nothing, `coverage_warning` explains that this is NOT evidence the gene is unexpressed -- it may simply have fallen outside the sample. For a reliable per-gene answer, use GTEx_get_expression_summary (human tissues) or HPA_get_rna_expression_in_specific_tissues instead. Experiment E-MTAB-2836 contains RNA-seq of 122 human tissues, E-MTAB-2706 covers 675 cancer cell lines.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -100,7 +100,7 @@
         },
         "gene_id": {
           "type": "string",
-          "description": "Optional Ensembl gene ID to filter expression data for a specific gene (e.g., 'ENSG00000141510' for TP53). Leave empty for all genes in the experiment."
+          "description": "Optional Ensembl gene ID to look for within the small default SAMPLE of genes the upstream API returns for this experiment (e.g. 'ENSG00000141510' for TP53). This is NOT a true server-side or full-experiment filter -- the upstream endpoint ignores gene-filter parameters and only ever returns a default sample (commonly ~20-30 genes) of the experiment's full gene set (which can be thousands). A miss does not mean the gene is absent or unexpressed; check `coverage_warning` in the response. Leave empty to see the same default sample unfiltered."
         }
       },
       "required": [
@@ -189,6 +189,21 @@
                   }
                 }
               }
+            },
+            "profiles_returned_by_upstream": {
+              "type": "integer",
+              "description": "Number of gene-profile rows the upstream Expression Atlas endpoint actually returned (its default sample size), before any client-side gene_id filtering."
+            },
+            "profiles_available_upstream": {
+              "type": "integer",
+              "description": "The true total number of genes with profiles available for this experiment upstream (searchResultTotal), which is almost always much larger than profiles_returned_by_upstream and total_gene_profiles."
+            },
+            "coverage_warning": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Present (non-null) only when a gene_id filter was supplied and matched nothing in the upstream sample. Explains that the upstream API returns only a partial sample and ignores gene filters, so an empty match is not evidence the gene is unexpressed or absent from the experiment."
             }
           }
         },

--- a/src/tooluniverse/data/interpro_member_db_tools.json
+++ b/src/tooluniverse/data/interpro_member_db_tools.json
@@ -227,6 +227,10 @@
                   }
                 }
               }
+            },
+            "note": {
+              "type": "string",
+              "description": "Present only when InterPro returned HTTP 204 No Content: explains that the query was valid but matched zero signatures (optionally noting which filter narrowed it to zero)."
             }
           },
           "required": [
@@ -337,6 +341,10 @@
                   }
                 }
               }
+            },
+            "note": {
+              "type": "string",
+              "description": "Present only when InterPro returned HTTP 204 No Content: explains that the query was valid but matched zero PDB structures."
             }
           },
           "required": [

--- a/src/tooluniverse/data/popgen_tools.json
+++ b/src/tooluniverse/data/popgen_tools.json
@@ -100,7 +100,7 @@
   {
     "name": "PopGen_fst",
     "type": "PopGenTool",
-    "description": "Calculate simplified Weir-Cockerham Fst between two populations given allele frequencies and sample sizes. Fst quantifies genetic differentiation: <0.05 little, 0.05-0.15 moderate, 0.15-0.25 great, >0.25 very great differentiation. Useful for measuring population structure and divergence at individual loci.",
+    "description": "Calculate the Weir-Cockerham (1984) theta Fst estimator between two populations given allele frequencies and sample sizes, including the n_c sample-size correction (theta = (MSP - MSG) / (MSP + (n_c - 1) * MSG)) so the result reflects allele-frequency divergence rather than sample size. Fst quantifies genetic differentiation: <0.05 little, 0.05-0.15 moderate, 0.15-0.25 great, >0.25 very great differentiation. Useful for measuring population structure and divergence at individual loci.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -149,6 +149,9 @@
                 },
                 "p_bar": {
                   "type": "number"
+                },
+                "estimator": {
+                  "type": "string"
                 },
                 "interpretation": {
                   "type": "string"

--- a/src/tooluniverse/expression_atlas_tool.py
+++ b/src/tooluniverse/expression_atlas_tool.py
@@ -166,10 +166,17 @@ class ExpressionAtlasTool(BaseTool):
             # (confirmed live: identical result count with and without it),
             # so there's no cheap way to filter this list by gene. Listing
             # species-level baseline experiments honestly, without a broken
-            # per-gene relevance signal, and pointing to
-            # GxA_get_experiment_expression (which does support per-gene
-            # filtering, against one already-known experiment) for the
-            # actual per-gene lookup.
+            # per-gene relevance signal. Do NOT recommend
+            # GxA_get_experiment_expression + gene_id as a way to check
+            # whether a specific experiment has data for a gene: confirmed
+            # live (Fix round 32) that its gene filter is silently ignored
+            # too -- e.g. E-MTAB-2836 reports searchResultTotal="9570" but
+            # every geneQuery variant tried (plain symbol, JSON-wrapped
+            # symbol, Ensembl ID, with/without specific=true) returns the
+            # same 29-row default sample, so an empty/no-match result from
+            # it is not evidence the gene is absent. For actual per-gene
+            # expression, point callers at tools confirmed to work, e.g.
+            # GTEx_get_expression_summary.
             results = [
                 {
                     "experiment_accession": exp.get("experimentAccession", ""),
@@ -198,10 +205,17 @@ class ExpressionAtlasTool(BaseTool):
                 "note": (
                     f"This lists baseline experiments for '{species}'; it does "
                     "not filter by gene (the underlying API has no reliable way "
-                    "to do so). Use GxA_get_experiment_expression with an "
-                    "experiment_accession from this list and gene_id="
-                    f"'{gene}' to check whether that specific experiment has "
-                    "data for the gene."
+                    f"to do so). This list does not tell you whether '{gene}' "
+                    "was measured in any of these experiments. Do not use "
+                    "GxA_get_experiment_expression with gene_id to check for a "
+                    "gene's presence in an experiment -- its gene filter is "
+                    "silently ignored by the upstream API, so it returns only "
+                    "a small default sample of an experiment's genes and an "
+                    "empty/no-match result is not evidence the gene is absent. "
+                    "For actual per-gene expression data, use a tool confirmed "
+                    "to filter correctly, such as GTEx_get_expression_summary "
+                    f"(gene_symbol='{gene}') for human tissue expression, or "
+                    "HPA_get_rna_expression_in_specific_tissues."
                 ),
                 "source": ("EBI Expression Atlas - Baseline Expression"),
             }

--- a/src/tooluniverse/gxa_tool.py
+++ b/src/tooluniverse/gxa_tool.py
@@ -185,12 +185,42 @@ class GxATool(BaseTool):
 
         # Extract gene expression profiles (apply gene_id filter client-side)
         profiles = data.get("profiles", {})
-        rows = profiles.get("rows", [])
+        raw_rows = profiles.get("rows", [])
+
+        # Feature-69A-004: the upstream endpoint only ever returns a small,
+        # arbitrary default sample of the experiment's genes (confirmed live:
+        # E-MTAB-2836 has searchResultTotal=9570 but only ~29 rows are ever
+        # returned, regardless of any geneQuery/geneId parameter we send).
+        # Disclose that sample size vs. the true total so `total_gene_profiles`
+        # (which reflects only what we searched) is never mistaken for the
+        # experiment's actual gene count.
+        profiles_returned_by_upstream = len(raw_rows)
+        try:
+            # Upstream sometimes serializes this as a numeric string.
+            profiles_available_upstream = int(
+                profiles.get("searchResultTotal", profiles_returned_by_upstream)
+            )
+        except (TypeError, ValueError):
+            profiles_available_upstream = profiles_returned_by_upstream
 
         # Apply client-side gene_id filter (API ignores geneId parameter)
+        rows = raw_rows
+        coverage_warning = None
         if gene_id:
             gene_id_upper = gene_id.upper()
-            rows = [r for r in rows if self._gene_id_matches(r, gene_id_upper)]
+            rows = [r for r in raw_rows if self._gene_id_matches(r, gene_id_upper)]
+            if not rows:
+                coverage_warning = (
+                    "The upstream Expression Atlas endpoint returned only a default "
+                    f"sample of {profiles_returned_by_upstream} of "
+                    f"{profiles_available_upstream} genes in this experiment, and it "
+                    "ignores every gene-filter parameter we can send it (verified "
+                    f"directly against the API). The requested gene '{gene_id}' was "
+                    "not present in that sample. An empty result here is NOT evidence "
+                    "that the gene is unexpressed or absent from the experiment -- it "
+                    "only means the requested gene fell outside the small sample the "
+                    "upstream API happened to return."
+                )
 
         gene_profiles = []
         for row in rows[:50]:  # Limit to first 50 genes
@@ -225,6 +255,9 @@ class GxATool(BaseTool):
                 "columns": columns,
                 "total_gene_profiles": len(rows),
                 "gene_profiles": gene_profiles,
+                "profiles_returned_by_upstream": profiles_returned_by_upstream,
+                "profiles_available_upstream": profiles_available_upstream,
+                "coverage_warning": coverage_warning,
             },
             "metadata": {
                 "source": "EBI Gene Expression Atlas",

--- a/src/tooluniverse/interpro_member_db_tool.py
+++ b/src/tooluniverse/interpro_member_db_tool.py
@@ -165,14 +165,32 @@ class InterProMemberDBTool(BaseTool):
             }
         return db, None
 
-    def _get(self, url: str, params: Dict[str, Any] = None):
-        """GET with shared timeout; returns (json, error_dict). One of them is None."""
+    def _get(self, url: str, params: Dict[str, Any] = None, empty_ok: bool = False):
+        """GET with shared timeout; returns (json, error_dict). One of them is None.
+
+        The InterPro REST API returns HTTP 204 No Content when a *list*
+        query is well-formed but matches zero records (e.g. filtering
+        AntiFam, which is all-family, down to entry_type=domain). For
+        list-shaped endpoints (empty_ok=True) that is a legitimate empty
+        result, not a failure, so we synthesize an empty payload
+        ({"count": 0, "results": []}) instead of erroring. Detail-shaped
+        endpoints (empty_ok=False) keep failing loudly on 204, since a 204
+        there would otherwise turn into an object of all-None fields.
+        """
         resp = requests.get(url, params=params or {}, timeout=self.timeout)
         if resp.status_code == 404:
             return None, {
                 "status": "error",
                 "error": "Not found in InterPro (HTTP 404). "
                 "Check the accession / database slug.",
+            }
+        if resp.status_code == 204:
+            if empty_ok:
+                return {"count": 0, "results": [], "_empty_204": True}, None
+            return None, {
+                "status": "error",
+                "error": "InterPro API returned no content (HTTP 204) for this "
+                "request: the query was valid but matched zero records.",
             }
         if resp.status_code != 200:
             return None, {
@@ -252,7 +270,7 @@ class InterProMemberDBTool(BaseTool):
             params["type"] = str(entry_type).strip().lower()
 
         url = f"{INTERPRO_BASE_URL}/entry/{db}/"
-        payload, err = self._get(url, params)
+        payload, err = self._get(url, params, empty_ok=True)
         if err:
             return err
 
@@ -273,6 +291,14 @@ class InterProMemberDBTool(BaseTool):
             "returned": len(entries),
             "entries": entries,
         }
+        if payload.get("_empty_204"):
+            note = (
+                "InterPro returned no content (HTTP 204) for this query: the "
+                "request was valid and matched zero signatures."
+            )
+            if entry_type:
+                note += f" The filter entry_type='{params['type']}' narrowed the results to zero."
+            result["note"] = note
         return {"status": "success", "data": result}
 
     # ------------------------------------------------------------------ #
@@ -291,7 +317,7 @@ class InterProMemberDBTool(BaseTool):
         page_size = self._clamp_page_size(arguments.get("page_size", 20))
 
         url = f"{INTERPRO_BASE_URL}/structure/pdb/entry/interpro/{interpro_id}/"
-        payload, err = self._get(url, {"page_size": page_size})
+        payload, err = self._get(url, {"page_size": page_size}, empty_ok=True)
         if err:
             return err
 
@@ -312,6 +338,12 @@ class InterProMemberDBTool(BaseTool):
             "returned": len(structures),
             "structures": structures,
         }
+        if payload.get("_empty_204"):
+            result["note"] = (
+                "InterPro returned no content (HTTP 204) for this query: the "
+                "request was valid and matched zero PDB structures for "
+                f"{interpro_id}."
+            )
         return {"status": "success", "data": result}
 
     # ------------------------------------------------------------------ #

--- a/src/tooluniverse/popgen_tool.py
+++ b/src/tooluniverse/popgen_tool.py
@@ -215,13 +215,23 @@ class PopGenTool(BaseTool):
                     "n2": n2,
                     "p_bar": round(p_bar, 4),
                     "Fst": 0.0,
+                    "estimator": "Weir-Cockerham (1984) theta, with n_c sample-size correction",
                     "interpretation": "Allele is fixed or absent in both populations; Fst is 0.",
                 },
             }
 
+        # Weir & Cockerham (1984) theta estimator, r=2 populations (df = r-1 = 1):
+        #   MSP = sum_i n_i*(p_i - p_bar)^2 / (r-1)
+        #   MSG = sum_i n_i*p_i*(1-p_i) / (sum(n_i) - r)
+        #   n_c = (1/(r-1)) * (sum(n_i) - sum(n_i^2)/sum(n_i))
+        #       = (n1 + n2) - (n1**2 + n2**2)/(n1 + n2)      [for r=2]
+        #   theta = (MSP - MSG) / (MSP + (n_c - 1)*MSG)
+        # Source: Weir BS, Cockerham CC (1984) "Estimating F-statistics for the
+        # analysis of population structure." Evolution 38(6):1358-1370, eq. 2-4.
         msp = (n1 * (p1 - p_bar) ** 2 + n2 * (p2 - p_bar) ** 2) / 1.0
         msg = (n1 * p1 * (1 - p1) + n2 * p2 * (1 - p2)) / (n1 + n2 - 2)
-        denom = msp + msg
+        n_c = (n1 + n2) - (n1**2 + n2**2) / (n1 + n2)
+        denom = msp + (n_c - 1) * msg
         fst = max(0.0, (msp - msg) / denom) if denom > 0 else 0.0
 
         if fst < 0.05:
@@ -242,6 +252,7 @@ class PopGenTool(BaseTool):
                 "n2": n2,
                 "p_bar": round(p_bar, 4),
                 "Fst": round(fst, 4),
+                "estimator": "Weir-Cockerham (1984) theta, with n_c sample-size correction",
                 "interpretation": interp,
             },
         }

--- a/tests/unit/test_clingen_allele_assembly_labelled.py
+++ b/tests/unit/test_clingen_allele_assembly_labelled.py
@@ -1,0 +1,116 @@
+"""Regression guard: ClinGenAllele_lookup_hgvs / get_allele used to report
+``reference_genome: null`` on every genomic_alleles row because the code read
+``referenceGenome`` off the inner ``coordinates[j]`` dict, when the upstream
+ClinGen Allele Registry API actually puts it on the parent
+``genomicAlleles[i]`` object (confirmed via a live probe against
+https://reg.clinicalgenome.org/allele?hgvs=...). The inner coordinate dict
+only carries start/end/allele/referenceAllele.
+
+This mocks the upstream response with that exact (parent-level
+referenceGenome / chromosome, child-level coordinates) nesting and asserts
+GRCh38/GRCh37/NCBI36 come through labelled on the right rows, while a
+genuinely assembly-less row (e.g. a RefSeqGene entry) stays null.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.clingen_allele_tool import ClinGenAlleleTool
+
+pytestmark = pytest.mark.unit
+
+# Mirrors the real shape returned by reg.clinicalgenome.org for
+# NC_000015.10:g.48134287A>G: referenceGenome/chromosome live on the parent
+# genomicAlleles[i] object, not inside coordinates[j].
+UPSTREAM_RESPONSE = {
+    "@id": "http://reg.genome.network/allele/CA7545842",
+    "communityStandardTitle": ["NM_205850.3(SLC24A5):c.331A>G (p.Thr111Ala)"],
+    "externalRecords": {},
+    "genomicAlleles": [
+        {
+            "referenceGenome": "GRCh38",
+            "chromosome": "15",
+            "coordinates": [
+                {"start": 48134286, "end": 48134287, "allele": "G", "referenceAllele": "A"}
+            ],
+        },
+        {
+            "referenceGenome": "GRCh37",
+            "chromosome": "15",
+            "coordinates": [
+                {"start": 48426483, "end": 48426484, "allele": "G", "referenceAllele": "A"}
+            ],
+        },
+        {
+            "referenceGenome": "NCBI36",
+            "chromosome": "15",
+            "coordinates": [
+                {"start": 46213775, "end": 46213776, "allele": "G", "referenceAllele": "A"}
+            ],
+        },
+        {
+            # RefSeqGene-style row: genuinely has no assembly label upstream.
+            "referenceGenome": None,
+            "chromosome": None,
+            "coordinates": [
+                {"start": 18315, "end": 18316, "allele": "G", "referenceAllele": "A"}
+            ],
+        },
+    ],
+    "transcriptAlleles": [],
+}
+
+
+def _tool(operation="lookup_hgvs"):
+    return ClinGenAlleleTool(
+        {"name": "ClinGenAllele_test", "fields": {"operation": operation}}
+    )
+
+
+def _resp(payload, status_code=200):
+    r = MagicMock()
+    r.status_code = status_code
+    r.text = str(payload)
+    r.json = MagicMock(return_value=payload)
+    return r
+
+
+def test_lookup_hgvs_labels_each_assembly_correctly():
+    tool = _tool("lookup_hgvs")
+    with patch.object(
+        tool.session, "get", return_value=_resp(UPSTREAM_RESPONSE)
+    ):
+        result = tool.run({"hgvs": "NC_000015.10:g.48134287A>G"})
+
+    assert result["status"] == "success"
+    genomic = result["data"]["genomic_alleles"]
+    assert len(genomic) == 4
+
+    by_start = {row["start"]: row for row in genomic}
+    assert by_start[48134286]["reference_genome"] == "GRCh38"
+    assert by_start[48426483]["reference_genome"] == "GRCh37"
+    assert by_start[46213775]["reference_genome"] == "NCBI36"
+
+    # The genuinely assembly-less (RefSeqGene) row must stay null, not be
+    # invented -- and chromosome should be null there too, not "15".
+    assert by_start[18315]["reference_genome"] is None
+    assert by_start[18315]["chromosome"] is None
+
+    # chromosome should still be correctly labelled on the assembly rows.
+    assert by_start[48134286]["chromosome"] == "15"
+
+
+def test_get_allele_shares_same_fix_via_format_allele():
+    """_get_allele() reuses _format_allele(), so the fix should apply there
+    too without duplicating the mistake."""
+    tool = _tool("get_allele")
+    with patch.object(
+        tool.session, "get", return_value=_resp(UPSTREAM_RESPONSE)
+    ):
+        result = tool.run({"ca_id": "CA7545842"})
+
+    assert result["status"] == "success"
+    genomic = result["data"]["genomic_alleles"]
+    labels = {row["reference_genome"] for row in genomic}
+    assert labels == {"GRCh38", "GRCh37", "NCBI36", None}

--- a/tests/unit/test_clinical_calc_sex_not_silently_ignored.py
+++ b/tests/unit/test_clinical_calc_sex_not_silently_ignored.py
@@ -1,0 +1,241 @@
+"""Round-32 fix: sex-dependent clinical calculators must not silently ignore
+a caller-supplied `sex` string.
+
+Previously ClinicalCalc_eGFR_CKD_EPI, ClinicalCalc_CHA2DS2_VASc, and
+ClinicalCalc_ASCVD_risk only read a `female` boolean. A caller who passed the
+natural clinical parameter `sex: "female"` had it silently dropped (unknown
+keys pass validation since the JSON config sets no `additionalProperties:
+false`), and the tool fell back to `female=False` (male), while still
+reporting a `sex`/`Female` field in the output that looked like it reflected
+the caller's input.
+
+This test file locks in the additive fix:
+  - `sex` (case-insensitive female/f/male/m) is accepted on all three tools.
+  - `female` keeps working exactly as before.
+  - Supplying both `female` and `sex` in agreement is fine; in conflict is an
+    explicit error naming both values.
+  - An unrecognised `sex` string is a clear error, not a silent male default.
+  - Omitting both `female` and `sex` keeps the existing default (male) and
+    existing score, but now also discloses the assumption via a sibling
+    `assumptions` key so it isn't silently baked into the result.
+"""
+
+import pytest
+
+from tooluniverse.clinical_calculators_tool import ClinicalCalculatorTool
+
+
+def _tool(calc):
+    return ClinicalCalculatorTool(
+        {
+            "name": f"calc_{calc}",
+            "type": "ClinicalCalculatorTool",
+            "fields": {"calculator": calc},
+            "parameter": {"type": "object", "properties": {}},
+        }
+    )
+
+
+# --------------------------------------------------------------------------- #
+# eGFR (CKD-EPI 2021) — the flagship reported bug: sex='female' silently
+# ignored, returning a male eGFR ~33% higher than the correct female value.
+# Verified against the official CKD-EPI 2021 equation (Inker et al., NEJM
+# 2021;385(19):1737-1749; NIDDK "2021 CKD-EPI Creatinine Equation" summary):
+# kappa=0.7/alpha=-0.241 (female), kappa=0.9/alpha=-0.302 (male),
+# age factor 0.9938^age, female multiplier 1.012.
+# --------------------------------------------------------------------------- #
+def test_egfr_sex_string_female_matches_female_boolean():
+    via_sex = _tool("ckd_epi").run({"creatinine": 1.2, "age": 55, "sex": "female"})
+    via_bool = _tool("ckd_epi").run({"creatinine": 1.2, "age": 55, "female": True})
+    assert via_sex["status"] == "success"
+    assert via_sex["data"]["score"] == via_bool["data"]["score"]
+    assert via_sex["data"]["components"]["sex"] == "female"
+
+
+def test_egfr_sex_female_is_not_silently_treated_as_male():
+    # Correct CKD-EPI 2021 value for 55yo female, Scr 1.2 mg/dL is ~53.5
+    # (CKD stage G3a), not the ~71.4 male value.
+    out = _tool("ckd_epi").run({"creatinine": 1.2, "age": 55, "sex": "female"})
+    assert out["data"]["score"] == pytest.approx(53.5, abs=0.2)
+    assert "G3a" in out["data"]["interpretation"]
+
+
+def test_egfr_female_boolean_unchanged():
+    # Locks in the existing (pre-fix) male and female boolean behaviour.
+    male = _tool("ckd_epi").run({"creatinine": 1.2, "age": 55, "female": False})
+    assert male["data"]["score"] == pytest.approx(71.4, abs=0.05)
+    female = _tool("ckd_epi").run({"creatinine": 1.2, "age": 55, "female": True})
+    assert female["data"]["score"] == pytest.approx(53.5, abs=0.2)
+
+
+def test_egfr_no_sex_supplied_keeps_default_but_discloses_assumption():
+    out = _tool("ckd_epi").run({"creatinine": 1.2, "age": 55})
+    # Same score as before the fix (male assumed) — default not changed.
+    assert out["data"]["score"] == pytest.approx(71.4, abs=0.05)
+    assert out["data"]["components"]["sex"] == "male"
+    # New: the silent default is now disclosed.
+    assert "assumptions" in out["data"]
+    assert any("male" in note.lower() for note in out["data"]["assumptions"])
+
+
+def test_egfr_unrecognised_sex_string_errors_clearly():
+    out = _tool("ckd_epi").run({"creatinine": 1.2, "age": 55, "sex": "woman"})
+    assert out["status"] == "error"
+    assert "sex" in out["error"]
+    assert "female" in out["error"] and "male" in out["error"]
+
+
+# --------------------------------------------------------------------------- #
+# CHA2DS2-VASc
+# --------------------------------------------------------------------------- #
+def test_cha2ds2_vasc_sex_string_matches_female_boolean():
+    via_sex = _tool("cha2ds2_vasc").run(
+        {"age": 68, "sex": "female", "hypertension": True}
+    )
+    via_bool = _tool("cha2ds2_vasc").run(
+        {"age": 68, "female": True, "hypertension": True}
+    )
+    assert via_sex["data"]["score"] == via_bool["data"]["score"] == 3
+    assert via_sex["data"]["components"]["Female"] == 1
+
+
+def test_cha2ds2_vasc_female_boolean_unchanged():
+    out = _tool("cha2ds2_vasc").run({"age": 68, "female": True, "hypertension": True})
+    assert out["data"]["score"] == 3
+
+
+def test_cha2ds2_vasc_conflicting_sex_inputs_error():
+    out = _tool("cha2ds2_vasc").run({"age": 68, "female": True, "sex": "male"})
+    assert out["status"] == "error"
+    assert "female" in out["error"] and "sex" in out["error"]
+
+
+def test_cha2ds2_vasc_agreeing_sex_inputs_proceed():
+    out = _tool("cha2ds2_vasc").run({"age": 68, "female": True, "sex": "female"})
+    assert out["status"] == "success"
+    assert out["data"]["components"]["Female"] == 1
+
+
+def test_cha2ds2_vasc_no_sex_supplied_keeps_default_and_discloses():
+    with_sex = _tool("cha2ds2_vasc").run({"age": 68, "hypertension": True})
+    assert with_sex["data"]["score"] == 2  # unchanged from pre-fix behaviour
+    assert "assumptions" in with_sex["data"]
+
+
+# --------------------------------------------------------------------------- #
+# ASCVD risk
+# --------------------------------------------------------------------------- #
+def test_ascvd_sex_string_matches_female_boolean():
+    args_common = {
+        "age": 60,
+        "total_cholesterol": 240,
+        "hdl_cholesterol": 40,
+        "systolic_bp": 140,
+        "bp_treated": True,
+        "smoker": True,
+        "diabetes": True,
+        "race": "black",
+    }
+    via_sex = _tool("ascvd").run({**args_common, "sex": "female"})
+    via_bool = _tool("ascvd").run({**args_common, "female": True})
+    assert via_sex["data"]["score"] == via_bool["data"]["score"]
+    assert via_sex["data"]["components"]["group"] == "black_female"
+
+
+def test_ascvd_sex_was_previously_silently_ignored_now_fixed():
+    # Reported bug: sex='female' produced the male coefficient group
+    # ("black_male", 47.2%) instead of the correct female group
+    # ("black_female", 46.8%).
+    out = _tool("ascvd").run(
+        {
+            "age": 60,
+            "total_cholesterol": 240,
+            "hdl_cholesterol": 40,
+            "systolic_bp": 140,
+            "bp_treated": True,
+            "smoker": True,
+            "diabetes": True,
+            "sex": "female",
+            "race": "black",
+        }
+    )
+    assert out["data"]["components"]["group"] == "black_female"
+    assert out["data"]["score"] == pytest.approx(46.8, abs=0.1)
+
+
+def test_ascvd_female_boolean_unchanged():
+    out = _tool("ascvd").run(
+        {
+            "age": 55,
+            "total_cholesterol": 213,
+            "hdl_cholesterol": 50,
+            "systolic_bp": 120,
+            "bp_treated": False,
+            "smoker": False,
+            "diabetes": False,
+            "female": True,
+            "race": "white",
+        }
+    )
+    assert out["data"]["score"] == pytest.approx(2.1, abs=0.2)
+
+
+def test_ascvd_conflicting_sex_inputs_error():
+    out = _tool("ascvd").run(
+        {
+            "age": 60,
+            "total_cholesterol": 240,
+            "hdl_cholesterol": 40,
+            "systolic_bp": 140,
+            "female": True,
+            "sex": "male",
+        }
+    )
+    assert out["status"] == "error"
+    assert "female" in out["error"] and "sex" in out["error"]
+
+
+def test_ascvd_unrecognised_sex_string_errors():
+    out = _tool("ascvd").run(
+        {
+            "age": 60,
+            "total_cholesterol": 240,
+            "hdl_cholesterol": 40,
+            "systolic_bp": 140,
+            "sex": "unspecified",
+        }
+    )
+    assert out["status"] == "error"
+    assert "sex" in out["error"]
+
+
+def test_ascvd_no_race_supplied_discloses_assumption():
+    out = _tool("ascvd").run(
+        {
+            "age": 60,
+            "total_cholesterol": 240,
+            "hdl_cholesterol": 40,
+            "systolic_bp": 140,
+            "female": True,
+        }
+    )
+    assert out["status"] == "success"
+    assert out["data"]["components"]["group"] == "white_female"
+    assert "assumptions" in out["data"]
+    assert any("race" in note.lower() for note in out["data"]["assumptions"])
+
+
+def test_ascvd_no_sex_and_no_race_discloses_both_assumptions():
+    out = _tool("ascvd").run(
+        {
+            "age": 60,
+            "total_cholesterol": 240,
+            "hdl_cholesterol": 40,
+            "systolic_bp": 140,
+        }
+    )
+    assert out["status"] == "success"
+    assert out["data"]["components"]["group"] == "white_male"  # unchanged default
+    notes = out["data"]["assumptions"]
+    assert any("sex" in n.lower() or "male" in n.lower() for n in notes)
+    assert any("race" in n.lower() for n in notes)

--- a/tests/unit/test_expression_atlas_baseline_honesty.py
+++ b/tests/unit/test_expression_atlas_baseline_honesty.py
@@ -77,7 +77,25 @@ class TestBaselineListingIsHonest:
         assert "gene_specific_count" not in result["data"]
         for exp in result["data"]["baseline_experiments"]:
             assert "gene_mentioned" not in exp
-        assert "GxA_get_experiment_expression" in result["note"]
+        # Fix round 32: the note used to tell callers to use
+        # GxA_get_experiment_expression with gene_id to check whether a
+        # specific experiment has data for the gene. That is itself broken
+        # -- confirmed live that GXA's gene filter is silently ignored
+        # (e.g. E-MTAB-2836 reports searchResultTotal="9570" but every
+        # geneQuery variant returns the same 29-row default sample), so an
+        # empty/no-match result from it is not evidence the gene is absent.
+        # The note must no longer steer callers into that unsafe check, but
+        # it must still say plainly that this listing doesn't filter by gene.
+        assert "does not filter by gene" in result["note"]
+        # The old, unsafe recommendation told callers to *use*
+        # GxA_get_experiment_expression + gene_id to check presence; that
+        # exact instruction must be gone.
+        assert "to check whether that specific experiment has" not in result["note"]
+        # If GxA_get_experiment_expression is mentioned at all, it must be
+        # framed as unreliable for this purpose, not recommended for it.
+        if "GxA_get_experiment_expression" in result["note"]:
+            assert "Do not use" in result["note"]
+            assert "not evidence" in result["note"]
 
     def test_only_baseline_experiments_returned_for_species(self):
         tool = _tool()

--- a/tests/unit/test_gxa_partial_sample_disclosed.py
+++ b/tests/unit/test_gxa_partial_sample_disclosed.py
@@ -1,0 +1,177 @@
+"""Regression guard for the GxA partial-sample disclosure fix.
+
+`GxA_get_experiment_expression` calls the upstream EBI Expression Atlas
+`/experiments/{accession}` endpoint. That endpoint (confirmed live against
+E-MTAB-2836: searchResultTotal=9570, len(rows)=29) always returns only a
+small, arbitrary default SAMPLE of the experiment's genes and silently
+ignores every gene-filter parameter we can send it. A prior fix already
+applied a client-side `gene_id` filter over that sample, but a filtered
+miss still came back as a bare, confident-looking empty result -- easily
+misread as "this gene is not expressed here" when it may simply have
+fallen outside the tiny sample.
+
+This test mocks the upstream JSON with `searchResultTotal` far larger than
+`len(rows)` and asserts:
+  * the filtered-miss path still returns status=success (strictly additive,
+    not a re-meaning of success/error)
+  * it discloses `profiles_returned_by_upstream` / `profiles_available_upstream`
+  * it carries a `coverage_warning` explaining an empty result is not
+    evidence of absence
+  * the filtered-hit path returns real rows and does NOT carry that warning
+  * the unfiltered path also carries the coverage numbers (so
+    `total_gene_profiles` is never mistaken for the true experiment gene
+    count), and does not carry the warning
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.gxa_tool import GxATool
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeResponse:
+    def __init__(self, status_code=200, payload=None):
+        self.status_code = status_code
+        self._payload = payload if payload is not None else {}
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise Exception(f"HTTP {self.status_code}")
+
+    def json(self):
+        return self._payload
+
+
+def _tool():
+    return GxATool(
+        {
+            "name": "GxA_get_experiment_expression",
+            "fields": {"endpoint": "get_experiment_expression"},
+        }
+    )
+
+
+# A small sample of 3 rows out of a much larger upstream total, mirroring
+# the live E-MTAB-2836 shape (searchResultTotal is a numeric *string*
+# upstream -- confirmed live -- so the fake mirrors that quirk too).
+SAMPLE_RESPONSE = {
+    "experiment": {"description": "RNA-seq of 122 human tissues"},
+    "columnHeaders": [
+        {
+            "assayGroupId": "g1",
+            "factorValue": "liver",
+            "factorValueOntologyTermId": "UBERON_0002107",
+            "assayGroupSummary": {"replicates": 3},
+        },
+        {
+            "assayGroupId": "g2",
+            "factorValue": "kidney",
+            "factorValueOntologyTermId": "UBERON_0002113",
+            "assayGroupSummary": {"replicates": 4},
+        },
+    ],
+    "profiles": {
+        "searchResultTotal": "9570",
+        "rows": [
+            {
+                "id": "ENSG00000252920",
+                "name": "ENSG00000252920",
+                "expressions": [{"value": 6.0}, {"value": "N/A"}],
+            },
+            {
+                "id": "ENSG00000111111",
+                "name": "DEFA1B",
+                "expressions": [{"value": 1.2}, {"value": 2.3}],
+            },
+            {
+                "id": "ENSG00000222222",
+                "name": "INSL5",
+                "expressions": [{"value": None}, {"value": 0.5}],
+            },
+        ],
+    },
+}
+
+
+def _fake_get(url, **kwargs):
+    return _FakeResponse(200, SAMPLE_RESPONSE)
+
+
+def test_filtered_miss_returns_success_with_coverage_warning(monkeypatch):
+    tool = _tool()
+    monkeypatch.setattr("tooluniverse.gxa_tool.requests.get", _fake_get)
+
+    # TP53 is not in the fake sample -- mirrors the real-world bug report.
+    result = tool.run(
+        {
+            "experiment_accession": "E-MTAB-2836",
+            "gene_id": "ENSG00000141510",
+        }
+    )
+
+    assert result["status"] == "success"
+    data = result["data"]
+
+    # Existing keys keep their existing meaning (strictly additive).
+    assert data["total_gene_profiles"] == 0
+    assert data["gene_profiles"] == []
+
+    # New disclosure keys.
+    assert data["profiles_returned_by_upstream"] == 3
+    assert data["profiles_available_upstream"] == 9570
+    assert isinstance(data["profiles_available_upstream"], int)
+
+    warning = data["coverage_warning"]
+    assert warning is not None
+    assert "not evidence" in warning.lower()
+    assert "3" in warning and "9570" in warning
+    assert "ENSG00000141510" in warning
+
+
+def test_filtered_hit_returns_rows_without_warning(monkeypatch):
+    tool = _tool()
+    monkeypatch.setattr("tooluniverse.gxa_tool.requests.get", _fake_get)
+
+    # ENSG00000252920 IS in the fake sample.
+    result = tool.run(
+        {
+            "experiment_accession": "E-MTAB-2836",
+            "gene_id": "ENSG00000252920",
+        }
+    )
+
+    assert result["status"] == "success"
+    data = result["data"]
+
+    assert data["total_gene_profiles"] == 1
+    assert len(data["gene_profiles"]) == 1
+    assert data["gene_profiles"][0]["gene_id"] == "ENSG00000252920"
+
+    # Coverage numbers are still present...
+    assert data["profiles_returned_by_upstream"] == 3
+    assert data["profiles_available_upstream"] == 9570
+    # ...but no warning, since the requested gene WAS found.
+    assert data["coverage_warning"] is None
+
+
+def test_unfiltered_path_carries_coverage_numbers_without_warning(monkeypatch):
+    tool = _tool()
+    monkeypatch.setattr("tooluniverse.gxa_tool.requests.get", _fake_get)
+
+    result = tool.run({"experiment_accession": "E-MTAB-2836"})
+
+    assert result["status"] == "success"
+    data = result["data"]
+
+    # total_gene_profiles reflects only the sample searched, never the
+    # true experiment gene count -- the new keys make that explicit.
+    assert data["total_gene_profiles"] == 3
+    assert data["profiles_returned_by_upstream"] == 3
+    assert data["profiles_available_upstream"] == 9570
+    assert data["coverage_warning"] is None

--- a/tests/unit/test_interpro_member_db_204_is_zero_result.py
+++ b/tests/unit/test_interpro_member_db_204_is_zero_result.py
@@ -1,0 +1,108 @@
+"""Regression guard for round-32 fix: the EBI InterPro REST API returns HTTP
+204 No Content to mean "the query was valid but matched zero records" (e.g.
+GET /entry/antifam/?type=domain -- AntiFam has zero entries of type
+'domain', they're all 'family'). InterProMemberDBTool._get() used to map
+every non-200/non-404 status -- including 204 -- to a generic
+'InterPro API HTTP error: 204', turning a legitimate empty result into a
+false failure.
+
+The fix: list-shaped endpoints (_list_member_entries,
+_get_structures_for_entry) treat 204 as a valid empty result and return
+status "success" with an honest zero count plus an explanatory 'note' key.
+Detail-shaped endpoints (_get_member_entry) keep failing loudly on 204,
+since turning a single-record 204 into an object of all-None fields would
+be worse than an explicit error.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.interpro_member_db_tool import InterProMemberDBTool
+
+pytestmark = pytest.mark.unit
+
+
+def _mock_204_response():
+    resp = MagicMock()
+    resp.status_code = 204
+    return resp
+
+
+class TestListMemberEntries204IsZeroResult:
+    def test_204_returns_success_with_zero_count_and_note(self):
+        tool = InterProMemberDBTool({"fields": {"endpoint": "list_member_entries"}})
+
+        with patch(
+            "tooluniverse.interpro_member_db_tool.requests.get",
+            return_value=_mock_204_response(),
+        ):
+            result = tool.run(
+                {
+                    "member_database": "antifam",
+                    "entry_type": "domain",
+                    "page_size": 5,
+                }
+            )
+
+        assert result["status"] == "success"
+        data = result["data"]
+        assert data["total_count"] == 0
+        assert data["returned"] == 0
+        assert data["entries"] == []
+        assert "note" in data
+        assert "204" in data["note"] or "zero" in data["note"].lower()
+        # Filter that narrowed it to zero should be echoed.
+        assert "domain" in data["note"]
+
+
+class TestGetStructuresForEntry204IsZeroResult:
+    def test_204_returns_success_with_zero_count_and_note(self):
+        tool = InterProMemberDBTool(
+            {"fields": {"endpoint": "get_structures_for_entry"}}
+        )
+
+        with patch(
+            "tooluniverse.interpro_member_db_tool.requests.get",
+            return_value=_mock_204_response(),
+        ):
+            result = tool.run({"interpro_id": "IPR000719", "page_size": 5})
+
+        assert result["status"] == "success"
+        data = result["data"]
+        assert data["total_structures"] == 0
+        assert data["returned"] == 0
+        assert data["structures"] == []
+        assert "note" in data
+        assert "204" in data["note"] or "zero" in data["note"].lower()
+
+
+class TestGetMemberEntry204StaysAnError:
+    def test_204_on_detail_endpoint_is_still_an_error(self):
+        tool = InterProMemberDBTool({"fields": {"endpoint": "get_member_entry"}})
+
+        with patch(
+            "tooluniverse.interpro_member_db_tool.requests.get",
+            return_value=_mock_204_response(),
+        ):
+            result = tool.run({"member_database": "pfam", "accession": "PF00069"})
+
+        assert result["status"] == "error"
+        assert "204" in result["error"]
+
+
+class TestListMemberDatabases204StaysAnError:
+    def test_204_on_catalog_endpoint_is_still_an_error(self):
+        """list_member_databases does not pass empty_ok=True: a 204 there
+        would mean the whole catalog vanished, which is not a legitimate
+        empty result and should keep failing loudly."""
+        tool = InterProMemberDBTool({"fields": {"endpoint": "list_member_databases"}})
+
+        with patch(
+            "tooluniverse.interpro_member_db_tool.requests.get",
+            return_value=_mock_204_response(),
+        ):
+            result = tool.run({})
+
+        assert result["status"] == "error"
+        assert "204" in result["error"]

--- a/tests/unit/test_popgen_fst_not_driven_by_sample_size.py
+++ b/tests/unit/test_popgen_fst_not_driven_by_sample_size.py
@@ -1,0 +1,76 @@
+"""Regression guard: PopGen_fst's denominator omitted the Weir & Cockerham
+(1984) (n_c - 1) sample-size-correction factor on MSG, so the reported Fst
+was a monotone function of sample size rather than of allele-frequency
+divergence -- identical p1/p2 gave "little" differentiation at n=50 but
+"very great" at n=10000.
+
+Formula restored (Weir & Cockerham 1984, Evolution 38(6):1358-1370):
+    MSP = n1*(p1-p_bar)^2 + n2*(p2-p_bar)^2                (df = r-1 = 1)
+    MSG = (n1*p1*(1-p1) + n2*p2*(1-p2)) / (n1+n2-2)
+    n_c = (n1+n2) - (n1^2+n2^2)/(n1+n2)
+    theta = (MSP - MSG) / (MSP + (n_c - 1) * MSG)
+"""
+
+import pytest
+
+from tooluniverse.popgen_tool import PopGenTool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return PopGenTool({"name": "popgen_test"})
+
+
+def _fst(p1, p2, n1, n2):
+    tool = _tool()
+    result = tool.run(
+        {"operation": "fst", "p1": p1, "p2": p2, "n1": n1, "n2": n2}
+    )
+    assert result["status"] == "success"
+    return result["data"]
+
+
+def test_identical_frequencies_not_driven_by_sample_size():
+    small = _fst(0.4, 0.45, 50, 50)
+    large = _fst(0.4, 0.45, 10000, 10000)
+
+    # Both must land in the same "little differentiation" bucket, unlike
+    # the old code where n=10000 spuriously jumped to ~0.96.
+    assert small["Fst"] < 0.05
+    assert large["Fst"] < 0.05
+    assert abs(small["Fst"] - large["Fst"]) < 0.05
+
+    assert "Little" in small["interpretation"]
+    assert "Little" in large["interpretation"]
+
+    # New estimator is self-describing.
+    assert "Weir-Cockerham" in small["estimator"]
+    assert "n_c" in small["estimator"] or "sample-size" in small["estimator"]
+
+
+def test_large_divergence_large_n_is_moderate_not_saturated_at_one():
+    data = _fst(0.2, 0.8, 1_000_000, 1_000_000)
+    # Correct Weir-Cockerham theta here is ~0.529, not the old code's 1.0000.
+    assert data["Fst"] == pytest.approx(0.5294, abs=0.001)
+    assert data["Fst"] < 0.99
+
+
+def test_identical_frequencies_unequal_sample_sizes_near_zero():
+    data = _fst(0.5, 0.5, 100, 200)
+    assert data["Fst"] == pytest.approx(0.0, abs=1e-9)
+
+
+def test_fixed_allele_still_returns_zero():
+    data = _fst(0.0, 0.0, 100, 100)
+    assert data["Fst"] == 0.0
+    assert "fixed or absent" in data["interpretation"]
+
+
+def test_hand_computed_unequal_n_matches_weir_cockerham_formula():
+    # p1=0.1, p2=0.9, n1=40, n2=60 hand-derivation:
+    # p_bar = 0.58, MSP = 15.36, MSG = 9/98 = 0.091837,
+    # n_c = 100 - 5200/100 = 48, theta = (15.36-0.091837)/(15.36+47*0.091837)
+    #     = 15.268163/19.676351 = 0.77602...
+    data = _fst(0.1, 0.9, 40, 60)
+    assert data["Fst"] == pytest.approx(0.7760, abs=0.001)


### PR DESCRIPTION
Six verified defects where a tool returned a number or an emptiness that a
reader would act on, and that was wrong. Each was reproduced through the CLI
and traced to its source — five of the six against the live upstream API —
before any code was changed.

This round was deliberately kept **additive**: a new response key, a new
accepted input, a restored field. Exactly one contract change is included and
is called out below, because the additive alternative would have left callers
holding a number that inverts the conclusion.

---

### 1. InterPro member-database listing reported a valid zero-result as an error

`InterPro_list_member_signatures` with `member_database=antifam, entry_type=domain`
failed with `InterPro API HTTP error: 204`. AntiFam has no signatures of type
`domain` — they are all families — so zero is the correct answer.

Established upstream: `GET /entry/antifam/?type=domain` returns **204**, while
`GET /entry/antifam/` returns **200** with results; `GET /entry/sfld/?type=repeat`
also returns 204. The EBI API uses 204 to mean "valid query, zero matches", and
the shared `_get()` mapped every non-200/non-404 to an error.

List endpoints now read 204 as an empty result set, keeping `total_count: 0`,
`returned: 0`, `entries: []` and adding a `note` that echoes the filter that
narrowed it. Detail endpoints still fail loudly on 204, so an empty body can
never become a record of all-null fields. `rcsb_search`, `worms`, `bridgedb`
and `pfam` already follow this convention.

**Additive.**

---

### 2. Sex-dependent clinical calculators silently assumed male

`ClinicalCalc_eGFR_CKD_EPI`, `ClinicalCalc_CHA2DS2_VASc` and
`ClinicalCalc_ASCVD_risk` accept sex as a `female` boolean but report sex back
in their output. A caller passing the natural `sex: "female"` had it dropped —
the configs set no `additionalProperties`, so unknown keys pass validation —
fell through to `female=False`, and received a male result carrying a field
that looked like it echoed their input:

```
run ClinicalCalc_eGFR_CKD_EPI '{"creatinine":1.2,"age":55,"sex":"female"}'
before: score 71.4, "CKD stage G2",  components.sex "male"
after:  score 53.5, "CKD stage G3a", components.sex "female"
```

A 33% overstatement across a CKD stage boundary. CHA2DS2-VASc lost the sex
point (3 → 2 for a 68-year-old woman with hypertension); ASCVD selected the
wrong Pooled Cohort coefficient set (`black_female` → `black_male`).

`sex` is now a documented parameter on all three, resolved by one shared
helper. The `female` boolean is untouched and the no-sex default stays male,
so no existing call changes its answer. A conflicting pair, or an
unrecognised sex string, is now rejected explicitly instead of quietly meaning
male. Where a result does rest on an unstated default — no sex anywhere, or no
race on ASCVD — the response carries an `assumptions` entry saying so.

CKD-EPI 2021 coefficients were checked against NIDDK's published equation and
are unchanged.

**Additive** (new input key; existing key, default and outputs preserved).

> Note for maintainers: the generated convenience wrappers in
> `src/tooluniverse/tools/ClinicalCalc_*.py` have a fixed signature and will not
> expose `sex` as a keyword argument until that tree is regenerated. The CLI,
> MCP and JSON-schema paths already accept it. The tree was intentionally not
> regenerated here.

---

### 3. ClinGen allele coordinates came back without their assembly

`ClinGenAllele_lookup_hgvs` returns one row per genome build, so the same
variant appears three or four times with different coordinates — for
rs1426654: 48134287 (GRCh38), 48426484 (GRCh37), 46213775 (NCBI36). Every row
reported `"reference_genome": null`.

Established upstream: the registry does supply the label, on the parent
`genomicAlleles[i]` object. The shared formatter read it from the inner
`coordinates[j]` dict, which contains only `allele`, `start`, `end`,
`referenceAllele`. Reading it from the parent populates the field for both
operations. The registry's RefSeqGene row genuinely has no build and still
reports `null` rather than a guess.

**Additive** (restores a field that was always null; row count unchanged).

---

### 4. PopGen_fst returned a number driven by sample size — the one contract change

```
run PopGen_fst '{"operation":"fst","p1":0.4,"p2":0.45,"n1":50,"n2":50}'
  before: Fst 0.0    "Little genetic differentiation"
run PopGen_fst '{"operation":"fst","p1":0.4,"p2":0.45,"n1":10000,"n2":10000}'
  before: Fst 0.9617 "Very great genetic differentiation"
```

Identical allele frequencies, opposite conclusions. At p=0.2 vs 0.8 with n=1e6
it saturated at exactly 1.0000, where the true value is about 0.53.

The among-population mean square was correct; the denominator was not. Weir &
Cockerham (1984) theta is `(MSP - MSG) / (MSP + (n_c - 1) * MSG)` with
`n_c = (n1 + n2) - (n1² + n2²)/(n1 + n2)` for two populations. The code used
`MSP + MSG`, under-weighting MSG by a factor of about n. After: 0.005 at both
n=50 and n=10000, and 0.5294 for the p=0.2/0.8 case — matching an independent
hand-derivation and cross-checking against Nei's Gst for order of magnitude.

The value is corrected rather than merely flagged because an ancestry or
forensic comparison of 1000 Genomes or gnomAD superpopulations, where sample
sizes run to the thousands, would otherwise read "very great differentiation"
at essentially every locus. An `estimator` key now names the estimator and its
correction. Interpretation thresholds and all other keys are unchanged.

**Contract change** — the returned `Fst` value changes for a given input. This
is the round's single budgeted contract change.

---

### 5. Expression Atlas answered "no data" from 0.3% of the experiment

`GxA_get_experiment_expression` reported `total_gene_profiles: 0` for TP53 in
E-MTAB-2836 — the 122-tissue human baseline experiment, and the tool's own
documented example.

An earlier round had already found that the endpoint ignores gene filters and
added a client-side filter, but missed why that is not enough: the endpoint
returns only a small default sample. Measured live, **29 rows out of a
`searchResultTotal` of 9570**, so the client-side filter searches 0.3% of the
data.

A controlled negative probe confirms the filter is genuinely unavailable
rather than mis-spelled by us — no params, `geneQuery=TP53`,
`geneQuery=[{"value":"TP53"}]`, `geneQuery=[{"value":"ENSG00000141510"}]` and
`&specific=true` all return the identical 29 rows; the `/genes` subpath returns
HTTP 400. No working per-gene endpoint was found.

Since the right answer cannot be obtained here, the response now says so.
Existing keys keep their names and meanings; three siblings are added:
`profiles_returned_by_upstream`, `profiles_available_upstream`, and a
`coverage_warning` that fires only when a gene filter matched nothing, stating
that an empty result is not evidence the gene is unexpressed. The counts also
stop `total_gene_profiles` from being mistaken for the experiment's gene count.
`searchResultTotal` arrives as a string upstream and is cast defensively.

**Additive.**

---

### 6. The baseline listing still steered callers into that broken check

`ExpressionAtlas_get_baseline`'s response `note` told the caller to "use
`GxA_get_experiment_expression` ... and `gene_id=<gene>` to check whether that
specific experiment has data for the gene" — the check defect 5 shows cannot
work. Updating the JSON description was not enough: this sentence is built in
Python and shipped in the response body, which is what the caller reads.

The note now states the listing cannot tell you whether the gene was measured,
warns against the `gene_id` check and why, and points to
`GTEx_get_expression_summary` and `HPA_get_rna_expression_in_specific_tissues`,
both of which were run and confirmed to return real per-gene values. A nearby
comment claiming the Atlas "does support per-gene filtering" is corrected.

The honesty test previously asserted only that the note *mentioned*
`GxA_get_experiment_expression`, which pinned the unsafe wording and would have
passed for any framing. It now checks that the note still discloses the tool
does not filter by gene, and that any mention of the other tool appears as a
warning rather than a recommendation.

**Additive** (text only; counts, ordering and all keys unchanged).

---

## Verification

- `tests/unit` — full suite green, no failures, same skips as the pre-change
  baseline. This is the CI gate.
- 29 new unit tests across six files covering each fix and its
  non-regression counterpart.
- Every fix re-run through the CLI with the original failing arguments.
- `tests/tools` failures (SemanticScholar, ClinVar, GTEx, IntAct) were
  reproduced identically against source *without* these changes, confirming
  they are inherited from `main` rather than introduced here.
- `src/tooluniverse/tools/` untouched; the generated tree was not regenerated.

## Deliberately not included

Two further defects in `popgen_tool.py` were verified but left alone, because
each would change every returned value and this round's contract-change budget
is spent on `PopGen_fst`:

- `PopGen_inbreeding` uses `F_t = base_F + (1-base_F)·F_{t-1}` for every
  pedigree. Continued full-sib mating needs Wright's second-order recurrence
  `F_t = ¼(1 + 2F_{t-1} + F_{t-2})`. Observed `[0.25, 0.4375, 0.578125]`
  against the textbook `[0.25, 0.375, 0.5]`. The tool does document the
  recurrence it uses, so it is transparent about the approximation.
- `BindingDB`'s `getLigandsByUniprots` route returns `affinities: []` for both
  P35372 and P00533; the emptiness is upstream, and distinguishing a dead route
  from a genuinely empty one would flip a success to a warning.
