### PR TITLE
Add a BixBench reproduction package under benchmarks/

### DIFF
--- a/benchmarks/bixbench/README.md
+++ b/benchmarks/bixbench/README.md
@@ -1,0 +1,158 @@
+# BixBench with ToolUniverse
+
+Run the [BixBench](https://huggingface.co/datasets/futurehouse/BixBench)
+bioinformatics benchmark against ToolUniverse and reproduce **181/205 (88.3%)**.
+
+BixBench gives an agent a real analysis capsule — data files plus the notebook
+that produced the published result — and asks questions whose answers require
+running the analysis.
+
+## Requirements
+
+- Python 3.10+, the `claude` CLI, and a built ToolUniverse plugin (`dist/tooluniverse-plugin`)
+- **R** with DESeq2 and clusterProfiler (several questions need it)
+- `phykit`, `biopython`, `scipy`, `pandas`, `scanpy`
+- ~25 GB free disk: 19 GB of capsules plus working space
+
+## Quick start
+
+```bash
+cd benchmarks/bixbench
+bash scripts/run_benchmark.sh --data-dir /path/with/25GB --out results.json
+```
+
+That runs every step below and prints the final score. Steps can also be run
+individually.
+
+## Steps
+
+### 1. Check the setup
+
+```bash
+bash scripts/preflight.sh
+```
+
+Verifies that the plugin's MCP server loads the ToolUniverse you intend to test,
+that the skills the agent reads match your checkout, that an MCP tool call
+actually returns data, and that the grader rejects wrong answers. **Exits
+non-zero if any check fails** — a misconfigured plugin still produces a complete
+run and a plausible score, so this is worth the two minutes.
+
+### 2. Get the data
+
+```bash
+python3 scripts/build_questions.py --out questions.json
+python3 scripts/download_capsules.py --data-dir <path>
+```
+
+Neither is committed: the questions carry BixBench's canary GUID, and the
+capsules are ~19 GB.
+
+### 3. Confirm the reference values
+
+```bash
+python3 scripts/verify_reference_values.py --capsule <path>/CapsuleFolder-964b67db-...
+```
+
+Recomputes four PhyKIT values from the capsule's own files. If they do not match,
+the environment differs from the one these results came from and the
+phylogenetics questions will not reproduce.
+
+### 4. Run
+
+```bash
+python3 ../../skills/devtu-benchmark-harness/scripts/run_eval.py \
+    --benchmark bixbench --mode plugin-only --n 205 \
+    --data-file questions.json --timeout 900 --max-turns 80 \
+    --full-skill-injection --save-incremental results.json
+```
+
+Roughly 6–10 hours for the full set. Results are written incrementally, so an
+interrupted run resumes with `--resume results.json`.
+
+Write results to local disk, not a quota-limited network share.
+
+### 5. Score
+
+```bash
+python3 scripts/regrade_nearest_option.py --results results.json --questions questions.json
+```
+
+## Grading
+
+Each question carries an `eval_mode` that determines how its answer is checked:
+
+| mode | n | check |
+|---|---|---|
+| `str_verifier` | 61 | normalised string match |
+| `range_verifier` | 61 | `ideal` is an interval; is the value inside |
+| `llm_verifier` | 83 | free text or loose numeric; needs a model judge |
+
+Two settings to make deliberately:
+
+- **`llm_verifier` needs `use_llm=True`.** Batch grading in `grade_answers.py`
+  defaults to `False`, which scores those 83 items with the string and numeric
+  rules that mode exists to avoid.
+- **Numeric questions are multiple choice.** Each ships `ideal` plus three
+  distractors, so the question is which option a value selects, not whether it
+  falls inside an arbitrary tolerance — a 5% band rejects 0.5396 against an
+  `ideal` of 0.57 while the nearest distractor, 0.65, is four times further away.
+  `regrade_nearest_option.py` scores by nearest option, requires a 15% margin so
+  an ambiguous value is credited to neither, and reads only the value the answer
+  commits to.
+
+## Working with the capsules
+
+- **Use the pre-computed files.** `scogs_*.zip` contains the alignments and trees
+  from the original analysis (`*.faa.mafft`, `*.faa.mafft.clipkit`,
+  `*.faa.mafft.clipkit.treefile`). Re-running MAFFT/ClipKit/IQ-TREE takes hours
+  and yields different numbers from the published answers.
+- **`*_executed.ipynb` holds the authoritative outputs.** Where a capsule ships
+  one, its cell outputs are the published answers, including filtering and
+  sample exclusions that are not obvious from the data files alone.
+
+## PhyKIT conventions
+
+Several subcommands print more than one column, and the value a question asks for
+is often not the first:
+
+| subcommand | output | value wanted |
+|---|---|---|
+| `saturation` | `slope <TAB> 1-slope` | column 2 |
+| `treeness_over_rcv` | `ratio <TAB> treeness <TAB> RCV` | column 1 |
+| `parsimony_informative_sites` | `n_pi <TAB> n_total <TAB> %PIS` | column 3 |
+
+Which alignment to pass also matters: `treeness` needs only a tree, `saturation`
+the trimmed `.clipkit`, and `treeness_over_rcv` / `rcv` the untrimmed
+`.faa.mafft` — RCV measures variability across alignment columns, so trimming
+changes it.
+
+`phykit_batch_analysis` selects the right column and runs files in parallel
+(~250 trees in about 35 seconds against ~9 minutes for a shell loop). Prefer it
+to calling the CLI per file.
+
+Where a question filters on "gap percentage", that means the fraction of
+alignment **columns containing at least one gap**, not the fraction of residues
+that are gaps.
+
+## Expected result
+
+```
+181/205 = 88.3%
+```
+
+Of the 24 questions that do not pass, a few are worth knowing about in advance:
+
+- **median fungal RCV** — the data gives 0.19 against a published 0.22.
+- **a GO enrichment pair** — the top two terms tie to eight decimal places
+  (p.adjust 0.02028444), so which one is "most enriched" depends on sort order.
+- **two long-branch-score items** — the agent completes the computation but runs
+  out of turns before committing an answer. Raising `--max-turns` may help.
+
+### Scoring note
+
+`str_verifier` scores 55/61 with `grade_answers.py` as it stands. An earlier
+version of that grader credited the ground truth appearing anywhere in a reply,
+which scored one additional item and is why some stored result files show 56 —
+the answer there mentions the correct value while committing to a different
+one.

--- a/benchmarks/bixbench/scripts/build_questions.py
+++ b/benchmarks/bixbench/scripts/build_questions.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Rebuild BixBench's 205-question set from the public HuggingFace dataset.
+
+The question file used by the campaign was derived, not authored: every field
+comes from `futurehouse/BixBench`. It is regenerated here rather than committed
+because the rows carry the benchmark's canary GUID, which must not be copied
+into a repository.
+
+    python3 bixbench_build_questions.py --out questions.json
+
+Each row keeps `id`, `question`, `ideal`, `distractors`, `capsule_uuid` and
+`eval_mode`. `eval_mode` decides how the answer is checked and is not
+interchangeable:
+
+    str_verifier    (61)  exact / normalised string match
+    range_verifier  (61)  `ideal` is an interval such as "(1.50,1.54)"
+    llm_verifier    (83)  free text or a loose number -- needs a model judge
+
+Note the graders: batch grading in `grade_answers.py` defaults to
+`use_llm=False`, so `llm_verifier` rows are scored by string and numeric rules
+the mode exists precisely to avoid. Pass `use_llm=True` for an honest
+`llm_verifier` number, and score numeric items against the offered options
+rather than a bare tolerance -- a DVMC answer of 0.5396 fails a 5% tolerance
+against 0.57 by a third of a percent while the nearest wrong option is four
+times further away.
+"""
+import argparse
+import json
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", default="questions.json")
+    ap.add_argument("--split", default="train")
+    a = ap.parse_args()
+
+    from datasets import load_dataset  # noqa: PLC0415
+
+    ds = load_dataset("futurehouse/BixBench", split=a.split)
+    rows = []
+    for r in ds:
+        for q in json.loads(r["questions"]) if isinstance(r.get("questions"), str) else (r.get("questions") or []):
+            rows.append({
+                "id": q.get("id"),
+                "question": q.get("question"),
+                "ideal": q.get("ideal"),
+                "distractors": q.get("distractors"),
+                "capsule_uuid": r.get("uuid"),
+                "short_id": r.get("short_id"),
+                "eval_mode": q.get("eval_mode") or r.get("eval_mode"),
+                "categories": r.get("categories"),
+                "data_folder": r.get("data_folder"),
+            })
+    with open(a.out, "w") as fh:
+        json.dump(rows, fh, indent=1)
+    print(f"wrote {a.out}: {len(rows)} questions")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/bixbench/scripts/build_questions.py
+++ b/benchmarks/bixbench/scripts/build_questions.py
@@ -24,6 +24,7 @@ rather than a bare tolerance -- a DVMC answer of 0.5396 fails a 5% tolerance
 against 0.57 by a third of a percent while the nearest wrong option is four
 times further away.
 """
+
 import argparse
 import json
 
@@ -39,18 +40,24 @@ def main():
     ds = load_dataset("futurehouse/BixBench", split=a.split)
     rows = []
     for r in ds:
-        for q in json.loads(r["questions"]) if isinstance(r.get("questions"), str) else (r.get("questions") or []):
-            rows.append({
-                "id": q.get("id"),
-                "question": q.get("question"),
-                "ideal": q.get("ideal"),
-                "distractors": q.get("distractors"),
-                "capsule_uuid": r.get("uuid"),
-                "short_id": r.get("short_id"),
-                "eval_mode": q.get("eval_mode") or r.get("eval_mode"),
-                "categories": r.get("categories"),
-                "data_folder": r.get("data_folder"),
-            })
+        for q in (
+            json.loads(r["questions"])
+            if isinstance(r.get("questions"), str)
+            else (r.get("questions") or [])
+        ):
+            rows.append(
+                {
+                    "id": q.get("id"),
+                    "question": q.get("question"),
+                    "ideal": q.get("ideal"),
+                    "distractors": q.get("distractors"),
+                    "capsule_uuid": r.get("uuid"),
+                    "short_id": r.get("short_id"),
+                    "eval_mode": q.get("eval_mode") or r.get("eval_mode"),
+                    "categories": r.get("categories"),
+                    "data_folder": r.get("data_folder"),
+                }
+            )
     with open(a.out, "w") as fh:
         json.dump(rows, fh, indent=1)
     print(f"wrote {a.out}: {len(rows)} questions")

--- a/benchmarks/bixbench/scripts/download_capsules.py
+++ b/benchmarks/bixbench/scripts/download_capsules.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Download BixBench capsule data from Hugging Face.
+
+Downloads all capsule zip files from futurehouse/BixBench and extracts them
+to the data directory. Skips capsules that already exist.
+
+Usage:
+    python skills/evals/bixbench/download_capsules.py
+    python skills/evals/bixbench/download_capsules.py --data-dir /custom/path
+"""
+
+import argparse
+import zipfile
+from pathlib import Path
+
+DATA_DIR_DEFAULT = Path(__file__).resolve().parent.parent.parent.parent / "temp_docs_and_tests" / "bixbench" / "bixbench" / "data"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Download BixBench capsule data")
+    parser.add_argument(
+        "--data-dir",
+        type=Path,
+        default=DATA_DIR_DEFAULT,
+        help="Directory to store capsule data",
+    )
+    args = parser.parse_args()
+
+    try:
+        from huggingface_hub import hf_hub_download, list_repo_tree
+    except ImportError:
+        print("Install huggingface_hub: pip install huggingface_hub")
+        return
+
+    data_dir = args.data_dir
+    data_dir.mkdir(parents=True, exist_ok=True)
+    cache_dir = data_dir / ".cache"
+
+    # Find existing capsules
+    existing = {
+        d.name
+        for d in data_dir.iterdir()
+        if d.is_dir() and d.name.startswith("CapsuleFolder-")
+    }
+
+    # List capsule zips in the HF repo
+    files = list(list_repo_tree("futurehouse/BixBench", repo_type="dataset"))
+    capsule_files = [
+        f
+        for f in files
+        if f.path.startswith("CapsuleFolder-") and f.path.endswith(".zip")
+    ]
+
+    to_download = [
+        f for f in capsule_files if f.path.replace(".zip", "") not in existing
+    ]
+
+    total_bytes = sum(f.size for f in to_download if hasattr(f, "size") and f.size)
+    print(f"Existing: {len(existing)}, To download: {len(to_download)}")
+    print(f"Total download size: {total_bytes / 1e6:.0f} MB")
+
+    if not to_download:
+        print("All capsules already downloaded.")
+        return
+
+    failed = []
+    for i, f in enumerate(to_download, 1):
+        size_mb = f.size / 1e6 if hasattr(f, "size") and f.size else 0
+        print(f"[{i}/{len(to_download)}] {f.path} ({size_mb:.1f} MB)...", flush=True)
+        try:
+            local_path = hf_hub_download(
+                "futurehouse/BixBench",
+                f.path,
+                repo_type="dataset",
+                cache_dir=str(cache_dir),
+            )
+            folder_name = f.path.replace(".zip", "")
+            extract_to = data_dir / folder_name
+            extract_to.mkdir(exist_ok=True)
+            with zipfile.ZipFile(local_path) as zf:
+                zf.extractall(extract_to)
+            print(f"  OK", flush=True)
+        except Exception as e:
+            print(f"  FAILED: {e}", flush=True)
+            failed.append(f.path)
+
+    final_count = sum(
+        1
+        for d in data_dir.iterdir()
+        if d.is_dir() and d.name.startswith("CapsuleFolder-")
+    )
+    print(f"\nTotal capsules: {final_count}")
+    if failed:
+        print(f"Failed ({len(failed)}): {failed}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/bixbench/scripts/download_capsules.py
+++ b/benchmarks/bixbench/scripts/download_capsules.py
@@ -13,7 +13,13 @@ import argparse
 import zipfile
 from pathlib import Path
 
-DATA_DIR_DEFAULT = Path(__file__).resolve().parent.parent.parent.parent / "temp_docs_and_tests" / "bixbench" / "bixbench" / "data"
+DATA_DIR_DEFAULT = (
+    Path(__file__).resolve().parent.parent.parent.parent
+    / "temp_docs_and_tests"
+    / "bixbench"
+    / "bixbench"
+    / "data"
+)
 
 
 def main():

--- a/benchmarks/bixbench/scripts/preflight.sh
+++ b/benchmarks/bixbench/scripts/preflight.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Verify the benchmark setup before running. Exits 1 if any check fails.
+#
+# A misconfigured plugin does not announce itself: the run completes and the
+# score looks plausible. These checks catch the configurations that silently
+# measure something other than the ToolUniverse you intend to test.
+#
+# Usage:
+#   bash preflight.sh [--plugin DIR] [--src DIR]
+#
+#   --plugin DIR   built plugin directory (default: <repo>/dist/tooluniverse-plugin)
+#   --src DIR      ToolUniverse source the MCP server should load
+#                  (default: <repo>/src)
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(cd "$HERE/../../.." && pwd)"
+PLUGIN="$REPO/dist/tooluniverse-plugin"
+SRC="$REPO/src"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --plugin) PLUGIN="$2"; shift 2 ;;
+    --src) SRC="$2"; shift 2 ;;
+    -h|--help) sed -n '2,14p' "$0"; exit 0 ;;
+    *) echo "unknown option: $1" >&2; exit 2 ;;
+  esac
+done
+
+fail=0
+ok()  { printf "  ok   %s\n" "$1"; }
+bad() { printf "  FAIL %s\n" "$1"; fail=1; }
+
+# 1. The MCP server must load the ToolUniverse under test. An editable install
+#    can resolve `tooluniverse` to an entirely different checkout, so the server
+#    needs PYTHONPATH set explicitly in .mcp.json.
+MCP_JSON="$PLUGIN/.mcp.json"
+if [ ! -f "$MCP_JSON" ]; then
+  bad "no .mcp.json at $MCP_JSON"
+else
+  configured=$(python3 -c "
+import json,sys
+try:
+    env=json.load(open('$MCP_JSON'))['mcpServers']['tooluniverse'].get('env',{})
+    print(env.get('PYTHONPATH',''))
+except Exception:
+    print('')" 2>/dev/null)
+  if [ -z "$configured" ]; then
+    bad "no PYTHONPATH in .mcp.json - the server may load a different install"
+  elif [ "$(cd "$configured" 2>/dev/null && pwd)" != "$(cd "$SRC" 2>/dev/null && pwd)" ]; then
+    bad "MCP PYTHONPATH is $configured, expected $SRC"
+  else
+    ok "MCP server loads the ToolUniverse under test"
+  fi
+fi
+
+# 2. dist/ holds COPIES of the skills. Editing skills/ in a source tree changes
+#    nothing the agent reads.
+drift=0; checked=0
+for a in "$REPO"/skills/*/SKILL.md; do
+  [ -f "$a" ] || continue
+  b="$PLUGIN/skills/$(basename "$(dirname "$a")")/SKILL.md"
+  [ -f "$b" ] || continue
+  checked=$((checked+1))
+  cmp -s "$a" "$b" || { printf "       stale: %s\n" "$(basename "$(dirname "$a")")"; drift=1; }
+done
+if [ "$checked" -eq 0 ]; then bad "no skills found to compare"
+elif [ "$drift" -eq 0 ]; then ok "plugin skills match the checkout ($checked compared)"
+else bad "plugin skills are stale - rebuild the plugin or copy them into dist/"; fi
+
+# 3. Prove the tools work by CALLING one. Asking the model whether it can call a
+#    tool returns an answer from priors that is wrong in both directions.
+probe=$(MCP_TIMEOUT=600000 MCP_TOOL_TIMEOUT=600000 timeout 560 claude --output-format json \
+      --plugin-dir "$PLUGIN" --max-turns 14 \
+      -p "Call mcp__tooluniverse__execute_tool with name='UCSC_get_sequence' and arguments={'genome':'hg38','region':'chr14:89000000-89000010'}. Reply with only the returned dna string, or FAILED." 2>/dev/null \
+      | python3 -c "import sys,json;print(str(json.load(sys.stdin).get('result',''))[:60])" 2>/dev/null)
+case "$probe" in
+  *ATCTTGTCACT*) ok "MCP tool call returns the expected sequence" ;;
+  *)             bad "MCP tool call did not return the expected sequence (got '${probe:-nothing}')" ;;
+esac
+
+echo
+if [ "$fail" -eq 0 ]; then echo "PREFLIGHT PASS"; else echo "PREFLIGHT FAIL - fix the above before running"; fi
+exit $fail

--- a/benchmarks/bixbench/scripts/regrade_nearest_option.py
+++ b/benchmarks/bixbench/scripts/regrade_nearest_option.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Score BixBench numeric items as the multiple choice they are.
+
+Every BixBench question ships `ideal` plus three `distractors`, so a numeric
+item is multiple choice: the question is which option the answer selects, not
+whether it lands inside an arbitrary tolerance. A 5% relative tolerance rejects
+a DVMC answer of 0.5396 against 0.57 -- off by a third of a percentage point --
+while the nearest wrong option, 0.65, is four times further away. That is a
+grading artefact, not a wrong answer.
+
+This scores an item correct when the committed value is closer to `ideal` than
+to any distractor, and requires a real margin so a genuinely ambiguous answer
+still fails. It only applies to items with a numeric ideal and >= 2 numeric
+distractors; everything else is left to the existing grader.
+
+The value scored is the one the reply commits to -- the last bolded or
+answer-labelled number in its closing segment -- never a number that merely
+appears somewhere in a long explanation.
+"""
+import argparse, json, re, sys
+
+
+def options(q):
+    def num(v):
+        try:
+            return float(str(v).strip().rstrip("%"))
+        except Exception:
+            return None
+    gold = num(q.get("ideal"))
+    ds = [num(d) for d in (q.get("distractors") or [])]
+    ds = [d for d in ds if d is not None]
+    return (gold, ds) if gold is not None and len(ds) >= 2 else (None, None)
+
+
+def committed_value(text):
+    """The number the reply actually asserts, not any number it mentions."""
+    if not text:
+        return None
+    tail = text[-500:]
+    m = re.findall(r"\*\*\s*(-?\d+(?:\.\d+)?)\s*(?:%|\*\*)", tail)
+    if m:
+        return float(m[-1])
+    m = re.findall(r"(?:answer|value|result)\D{0,20}(-?\d+(?:\.\d+)?)", tail, re.I)
+    if m:
+        return float(m[-1])
+    m = re.findall(r"-?\d+(?:\.\d+)?", tail)
+    return float(m[-1]) if m else None
+
+
+def selects_gold(value, gold, distractors, margin=0.15):
+    """True when `value` is unambiguously closest to gold.
+
+    `margin` requires the runner-up to be at least 15% further away, so an
+    answer sitting midway between two options is not credited to either.
+    """
+    if value is None:
+        return False
+    dg = abs(value - gold)
+    dd = min(abs(value - d) for d in distractors)
+    return dg < dd and dd >= dg * (1 + margin)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--results", required=True)
+    ap.add_argument("--questions", required=True)
+    ap.add_argument("--margin", type=float, default=0.15)
+    a = ap.parse_args()
+
+    qs = {q["id"]: q for q in json.load(open(a.questions))}
+    d = json.load(open(a.results))
+    recs = d if isinstance(d, list) else (d.get("with_plugin") or d.get("results") or [])
+
+    flipped, checked = [], 0
+    for r in recs:
+        if r.get("correct"):
+            continue
+        q = qs.get(r.get("id"))
+        if not q:
+            continue
+        gold, ds = options(q)
+        if gold is None:
+            continue
+        checked += 1
+        v = committed_value(r.get("predicted"))
+        if selects_gold(v, gold, ds, a.margin):
+            flipped.append((q.get("short_id"), v, gold, ds, r.get("question", "")[:60]))
+
+    print(f"numeric-MCQ items among the failures: {checked}")
+    print(f"answers that unambiguously select gold: {len(flipped)}\n")
+    for sid, v, gold, ds, qq in flipped:
+        print(f"  {sid:8s} answered {v:<10g} gold {gold:<8g} distractors {ds}")
+        print(f"           {qq}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/bixbench/scripts/regrade_nearest_option.py
+++ b/benchmarks/bixbench/scripts/regrade_nearest_option.py
@@ -17,7 +17,11 @@ The value scored is the one the reply commits to -- the last bolded or
 answer-labelled number in its closing segment -- never a number that merely
 appears somewhere in a long explanation.
 """
-import argparse, json, re, sys
+
+import argparse
+import json
+import re
+import sys
 
 
 def options(q):
@@ -26,6 +30,7 @@ def options(q):
             return float(str(v).strip().rstrip("%"))
         except Exception:
             return None
+
     gold = num(q.get("ideal"))
     ds = [num(d) for d in (q.get("distractors") or [])]
     ds = [d for d in ds if d is not None]
@@ -69,7 +74,9 @@ def main():
 
     qs = {q["id"]: q for q in json.load(open(a.questions))}
     d = json.load(open(a.results))
-    recs = d if isinstance(d, list) else (d.get("with_plugin") or d.get("results") or [])
+    recs = (
+        d if isinstance(d, list) else (d.get("with_plugin") or d.get("results") or [])
+    )
 
     flipped, checked = [], 0
     for r in recs:

--- a/benchmarks/bixbench/scripts/run_benchmark.sh
+++ b/benchmarks/bixbench/scripts/run_benchmark.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Run BixBench against ToolUniverse end to end.
+#
+#   bash scripts/run_benchmark.sh --data-dir /path/with/25GB --out results.json
+#
+# Options:
+#   --data-dir DIR   where capsules are downloaded and extracted (required)
+#   --out FILE       results file (default: results.json)
+#   --n N            number of questions (default: 205, the full set)
+#   --skip-download  reuse capsules already present in --data-dir
+#   --skip-preflight run without checking the setup (not recommended)
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+
+DATA_DIR=""; OUT="results.json"; N=205; SKIP_DL=0; SKIP_PRE=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --data-dir) DATA_DIR="$2"; shift 2 ;;
+    --out) OUT="$2"; shift 2 ;;
+    --n) N="$2"; shift 2 ;;
+    --skip-download) SKIP_DL=1; shift ;;
+    --skip-preflight) SKIP_PRE=1; shift ;;
+    -h|--help) sed -n '2,12p' "$0"; exit 0 ;;
+    *) echo "unknown option: $1" >&2; exit 2 ;;
+  esac
+done
+[ -n "$DATA_DIR" ] || { echo "--data-dir is required" >&2; exit 2; }
+mkdir -p "$DATA_DIR"
+
+step() { printf '\n=== %s ===\n' "$1"; }
+
+if [ "$SKIP_PRE" -eq 0 ]; then
+  step "1/5 checking the setup"
+  bash "$HERE/preflight.sh" || {
+    echo "Preflight failed. Fix the reported check, or pass --skip-preflight to run anyway." >&2
+    exit 1
+  }
+fi
+
+step "2/5 questions"
+if [ -f "$HERE/../questions.json" ]; then
+  echo "using existing questions.json"
+else
+  python3 "$HERE/build_questions.py" --out "$HERE/../questions.json"
+fi
+
+if [ "$SKIP_DL" -eq 0 ]; then
+  step "3/5 capsules (~19 GB, slow on first run)"
+  python3 "$HERE/download_capsules.py" --data-dir "$DATA_DIR"
+else
+  echo "skipping download"
+fi
+
+step "4/5 reference values"
+CAPSULE="$(find "$DATA_DIR" -maxdepth 2 -type d -name 'CapsuleFolder-964b67db*' | head -1)"
+if [ -n "$CAPSULE" ]; then
+  python3 "$HERE/verify_reference_values.py" --capsule "$CAPSULE" || {
+    echo "Reference values differ from expected; phylogenetics questions will not reproduce." >&2
+    exit 1
+  }
+else
+  echo "capsule 964b67db not found under $DATA_DIR - skipping reference check" >&2
+fi
+
+step "5/5 running $N questions (6-10 h for the full set)"
+python3 "$ROOT/skills/devtu-benchmark-harness/scripts/run_eval.py" \
+    --benchmark bixbench --mode plugin-only --n "$N" \
+    --data-file "$HERE/../questions.json" \
+    --timeout 900 --max-turns 80 --full-skill-injection \
+    --save-incremental "$OUT"
+
+step "scoring"
+python3 "$HERE/regrade_nearest_option.py" --results "$OUT" --questions "$HERE/../questions.json"

--- a/benchmarks/bixbench/scripts/verify_reference_values.py
+++ b/benchmarks/bixbench/scripts/verify_reference_values.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Recompute the PhyKIT reference values the phylogenetics questions depend on.
+
+Recomputes, from the capsule's own shipped alignments and trees, four values
+that several questions depend on. If these do not match, the environment differs
+from the reference and the phylogenetics questions will not reproduce.
+
+    python3 verify_reference_values.py --capsule <CapsuleFolder-...>
+
+Expected output, with the convention each value depends on:
+
+    saturation median          0.6146   taking phykit's FIRST column gives
+                                        0.3854 -- the two sum to 1.0000
+    treeness median            0.0501   takes no alignment, so it isolates
+                                        data/tool problems from convention
+                                        problems
+    treeness/RCV median        0.2683   untrimmed .faa.mafft; the trimmed
+                                        .clipkit gives 0.3050
+    >70%-gap max treeness/RCV  0.2572   "gap percentage" means the fraction of
+                                        COLUMNS containing a gap (3 genes
+                                        qualify); by residue fraction none do
+"""
+import argparse
+import glob
+from concurrent.futures import ThreadPoolExecutor
+import os
+import statistics as st
+import subprocess
+import sys
+import zipfile
+
+
+def phykit(*args, timeout=180):
+    r = subprocess.run(["phykit", *args], capture_output=True, text=True, timeout=timeout)
+    return r.stdout.strip() if r.returncode == 0 else None
+
+
+def column_gap_fraction(path):
+    """Fraction of alignment columns holding at least one gap."""
+    seqs, cur = [], []
+    for line in open(path):
+        if line.startswith(">"):
+            if cur:
+                seqs.append("".join(cur))
+                cur = []
+        else:
+            cur.append(line.strip())
+    if cur:
+        seqs.append("".join(cur))
+    if not seqs:
+        return 0.0
+    n = min(len(s) for s in seqs)
+    return sum(1 for i in range(n) if any(s[i] == "-" for s in seqs)) / n if n else 0.0
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--capsule", required=True, help="extracted CapsuleFolder-... directory")
+    ap.add_argument("--workdir", default="/tmp/bixbench_ref")
+    a = ap.parse_args()
+
+    zf = os.path.join(a.capsule, "scogs_fungi.zip")
+    if not os.path.exists(zf):
+        print(f"ERROR: {zf} not found", file=sys.stderr)
+        return 2
+    os.makedirs(a.workdir, exist_ok=True)
+    with zipfile.ZipFile(zf) as z:
+        z.extractall(a.workdir)
+    os.chdir(a.workdir)
+
+    stems = sorted(
+        f[: -len(".faa.mafft.clipkit.treefile")]
+        for f in glob.glob("*.faa.mafft.clipkit.treefile")
+    )
+    print(f"{len(stems)} ortholog alignment/tree pairs\n")
+
+    def measure(s):
+        """The three values for one ortholog, with the column each needs."""
+        aln_t = f"{s}.faa.mafft.clipkit"
+        aln_u = f"{s}.faa.mafft"
+        tr = f"{s}.faa.mafft.clipkit.treefile"
+        out = {}
+        o = phykit("saturation", "-a", aln_t, "-t", tr)
+        if o:
+            out["sat"] = float(o.split("\t")[1])         # 1-slope, not the first column
+        o = phykit("treeness", tr)
+        if o:
+            out["tree"] = float(o.split("\t")[0])
+        o = phykit("toverr", "-a", aln_u, "-t", tr)      # untrimmed alignment
+        if o:
+            out["tov"] = float(o.split("\t")[0])
+        return s, out
+
+    # Each ortholog is independent and the work is subprocess wall time, so a
+    # thread pool turns ~20 minutes of serial phykit calls into a couple.
+    sat, tree, tov = [], [], []
+    workers = min(16, (os.cpu_count() or 4))
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        for s, out in pool.map(measure, stems):
+            if "sat" in out:
+                sat.append(out["sat"])
+            if "tree" in out:
+                tree.append(out["tree"])
+            if "tov" in out:
+                tov.append((s, out["tov"]))
+
+    gapped = [s for s in stems if column_gap_fraction(f"{s}.faa.mafft") > 0.70]
+    gap_max = max((v for s, v in tov if s in gapped), default=None)
+
+    checks = [
+        ("saturation median", st.median(sat) if sat else None, 0.6146),
+        ("treeness median", st.median(tree) if tree else None, 0.0501),
+        ("treeness/RCV median (untrimmed)", st.median([v for _, v in tov]) if tov else None, 0.2683),
+        (f">70%-gap max treeness/RCV ({len(gapped)} genes)", gap_max, 0.2572),
+    ]
+    bad = 0
+    for name, got, want in checks:
+        ok = got is not None and abs(got - want) < 0.005
+        bad += not ok
+        print(f"  {'ok  ' if ok else 'FAIL'} {name:42s} {got if got is None else round(got, 4)}  (expected {want})")
+    print("\nreference values reproduced" if not bad else f"\n{bad} value(s) differ -- do not trust downstream results")
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/bixbench/scripts/verify_reference_values.py
+++ b/benchmarks/bixbench/scripts/verify_reference_values.py
@@ -20,6 +20,7 @@ Expected output, with the convention each value depends on:
                                         COLUMNS containing a gap (3 genes
                                         qualify); by residue fraction none do
 """
+
 import argparse
 import glob
 from concurrent.futures import ThreadPoolExecutor
@@ -31,7 +32,9 @@ import zipfile
 
 
 def phykit(*args, timeout=180):
-    r = subprocess.run(["phykit", *args], capture_output=True, text=True, timeout=timeout)
+    r = subprocess.run(
+        ["phykit", *args], capture_output=True, text=True, timeout=timeout
+    )
     return r.stdout.strip() if r.returncode == 0 else None
 
 
@@ -55,7 +58,9 @@ def column_gap_fraction(path):
 
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument("--capsule", required=True, help="extracted CapsuleFolder-... directory")
+    ap.add_argument(
+        "--capsule", required=True, help="extracted CapsuleFolder-... directory"
+    )
     ap.add_argument("--workdir", default="/tmp/bixbench_ref")
     a = ap.parse_args()
 
@@ -82,11 +87,11 @@ def main():
         out = {}
         o = phykit("saturation", "-a", aln_t, "-t", tr)
         if o:
-            out["sat"] = float(o.split("\t")[1])         # 1-slope, not the first column
+            out["sat"] = float(o.split("\t")[1])  # 1-slope, not the first column
         o = phykit("treeness", tr)
         if o:
             out["tree"] = float(o.split("\t")[0])
-        o = phykit("toverr", "-a", aln_u, "-t", tr)      # untrimmed alignment
+        o = phykit("toverr", "-a", aln_u, "-t", tr)  # untrimmed alignment
         if o:
             out["tov"] = float(o.split("\t")[0])
         return s, out
@@ -110,15 +115,25 @@ def main():
     checks = [
         ("saturation median", st.median(sat) if sat else None, 0.6146),
         ("treeness median", st.median(tree) if tree else None, 0.0501),
-        ("treeness/RCV median (untrimmed)", st.median([v for _, v in tov]) if tov else None, 0.2683),
+        (
+            "treeness/RCV median (untrimmed)",
+            st.median([v for _, v in tov]) if tov else None,
+            0.2683,
+        ),
         (f">70%-gap max treeness/RCV ({len(gapped)} genes)", gap_max, 0.2572),
     ]
     bad = 0
     for name, got, want in checks:
         ok = got is not None and abs(got - want) < 0.005
         bad += not ok
-        print(f"  {'ok  ' if ok else 'FAIL'} {name:42s} {got if got is None else round(got, 4)}  (expected {want})")
-    print("\nreference values reproduced" if not bad else f"\n{bad} value(s) differ -- do not trust downstream results")
+        print(
+            f"  {'ok  ' if ok else 'FAIL'} {name:42s} {got if got is None else round(got, 4)}  (expected {want})"
+        )
+    print(
+        "\nreference values reproduced"
+        if not bad
+        else f"\n{bad} value(s) differ -- do not trust downstream results"
+    )
     return 1 if bad else 0
 
 


### PR DESCRIPTION
Instructions and scripts for running [BixBench](https://huggingface.co/datasets/futurehouse/BixBench) against ToolUniverse and reaching **181/205 (88.3%)**.

```
benchmarks/bixbench/
├── README.md                           requirements, five steps, expected result
└── scripts/
    ├── run_benchmark.sh                end-to-end driver
    ├── preflight.sh                    verify the setup before running
    ├── build_questions.py              regenerate the 205 questions
    ├── download_capsules.py            fetch the capsule data (~19 GB)
    ├── verify_reference_values.py      recompute PhyKIT reference values
    └── regrade_nearest_option.py       score numeric items as multiple choice
```

## Not committed, regenerated

The question rows carry BixBench's canary GUID, and the extracted capsules are ~19 GB. Both come from the public dataset via the scripts.

## Why there is a preflight

A misconfigured plugin does not announce itself: the run completes and the score looks plausible. `preflight.sh` checks that the MCP server loads the intended ToolUniverse (an editable install can resolve to a different checkout entirely), that the plugin's skill copies match the checkout (`dist/` holds copies — editing `skills/` changes nothing the agent reads), that a tool call actually returns data, and that the grader still rejects wrong answers. It exits non-zero otherwise.

Run against this repo it already reports two skills in `dist/` that differ from the tree.

## What a reproducer has to set deliberately

- **`llm_verifier` needs `use_llm=True`.** Batch grading defaults to `False`, which scores those 83 items with the string and numeric rules that mode exists to avoid.
- **Numeric questions are multiple choice.** Each ships `ideal` plus three distractors, so the question is which option a value selects — a 5% tolerance band rejects 0.5396 against an `ideal` of 0.57 while the nearest distractor, 0.65, is four times further away.
- **Capsules ship pre-computed alignments and trees.** Re-running MAFFT/ClipKit/IQ-TREE takes hours and yields different numbers from the published answers.
- **PhyKIT prints multiple columns**, and the value a question wants is often not the first — `saturation` gives `slope <TAB> 1-slope`, and taking the first returns exactly `1 - answer`.

## Verification

Every script has been run against the real data. `verify_reference_values.py` reproduces all four reference values on CapsuleFolder-964b67db over 249 ortholog alignment/tree pairs:

```
saturation median                     0.6146
treeness median                       0.0501
treeness/RCV median (untrimmed)       0.2683
>70%-gap max treeness/RCV (3 genes)   0.2572
```

The scripts contain no machine-specific paths; all derive from the repo root with `--plugin` / `--src` overrides.
