### PR TITLE
Fix FAISS and PyTorch import-order crash

### DIFF
--- a/src/tooluniverse/__init__.py
+++ b/src/tooluniverse/__init__.py
@@ -1,41 +1,13 @@
 from importlib.metadata import version, PackageNotFoundError
 import importlib
 import os
-import sys
 from typing import Any, Optional, List
 
-# Force CPU before torch is imported anywhere — prevents MPS (Metal) segfaults
-# in forked subprocesses (uvx MCP server, tu CLI, Claude Code plugin).
+# Configure MPS safeguards before torch is imported anywhere. Individual tools
+# select their own explicit device; changing PyTorch's process-wide default here
+# can break unrelated CPU/GPU tools sharing the same process.
 os.environ.setdefault("PYTORCH_MPS_HIGH_WATERMARK_RATIO", "0.0")
 os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
-
-
-def configure_torch_cpu():
-    """Pin torch to CPU, if and only if torch is already imported.
-
-    Importing torch eagerly here cost ~4 s on *every* process that touches
-    tooluniverse -- the MCP server, each `tu` CLI call, every SDK import --
-    though most never run a model. That start-up cost is what pushed the MCP
-    server past the client's connection timeout, so the server was dropped and
-    the agent silently ran with no ToolUniverse tools at all.
-
-    The MPS protection that actually matters is the two environment variables
-    above, set before anything can import torch. This keeps the remaining
-    `set_default_device("cpu")` guarantee without paying for the import: the
-    modules that genuinely need torch call this right after importing it.
-    """
-    torch_module = sys.modules.get("torch")
-    if torch_module is None:
-        return False
-    try:
-        if hasattr(torch_module, "set_default_device"):
-            torch_module.set_default_device("cpu")
-    except Exception:
-        pass
-    return True
-
-
-configure_torch_cpu()  # no-op unless something upstream already imported torch
 
 
 # Allow installed sub-packages (e.g. tooluniverse-circuit) to contribute

--- a/src/tooluniverse/admetai_tool.py
+++ b/src/tooluniverse/admetai_tool.py
@@ -1,18 +1,9 @@
 import os
 
-# Force CPU before torch is imported anywhere — prevents MPS (Metal) segfaults
-# in forked subprocesses (uvx MCP server, tu CLI, Claude Code plugin).
+# ADMET-AI explicitly selects CUDA when available and CPU otherwise. Keep the
+# MPS safeguards without changing PyTorch's process-wide default device.
 os.environ["PYTORCH_MPS_HIGH_WATERMARK_RATIO"] = "0.0"
 os.environ["PYTORCH_ENABLE_MPS_FALLBACK"] = "1"
-try:
-    import torch
-    from . import configure_torch_cpu as _cfg_cpu
-    _cfg_cpu()
-
-    if hasattr(torch, "set_default_device"):
-        torch.set_default_device("cpu")
-except ImportError:
-    pass
 
 import numpy
 from .base_tool import BaseTool
@@ -27,15 +18,9 @@ if not hasattr(numpy, "VisibleDeprecationWarning"):
 
 
 def _patch_torch_load():
-    """Lazy patch for torch.load to set weights_only=False by default,
-    and force CPU device to avoid MPS segfaults in subprocess."""
+    """Lazy patch for torch.load to set weights_only=False by default."""
     try:
         import torch
-
-        # Force CPU to prevent MPS (Metal) segfaults when running in
-        # forked subprocesses (e.g., uvx MCP server, tu CLI).
-        if hasattr(torch, "set_default_device"):
-            torch.set_default_device("cpu")
 
         if not hasattr(torch.load, "_patched_by_tooluniverse"):
             _original_torch_load = torch.load

--- a/src/tooluniverse/esm_tool.py
+++ b/src/tooluniverse/esm_tool.py
@@ -299,8 +299,6 @@ class ESMTool(BaseTool):
 
             # Compute mean log-prob (pseudo-likelihood) per residue
             import torch
-            from . import configure_torch_cpu as _cfg_cpu
-            _cfg_cpu()
             import torch.nn.functional as F
 
             seq_logits = logits_output.logits.sequence  # (L+2, vocab)

--- a/src/tooluniverse/tool_finder_embedding.py
+++ b/src/tooluniverse/tool_finder_embedding.py
@@ -240,8 +240,6 @@ class ToolFinderEmbedding(BaseTool):
         try:
             from sentence_transformers import SentenceTransformer
             import torch
-            from . import configure_torch_cpu as _cfg_cpu
-            _cfg_cpu()
         except ImportError as e:
             raise ImportError(
                 "ToolFinderEmbedding requires 'sentence-transformers' package. "

--- a/src/tooluniverse/tool_registry.py
+++ b/src/tooluniverse/tool_registry.py
@@ -593,31 +593,41 @@ def _auto_import_subpackages(package_name: str = "tooluniverse"):
     Import all installed sub-packages of ``package_name`` so their
     ``__init__.py`` files run and can self-register configs/tools.
 
-    Only packages that have their own ``__init__.py`` are imported; plain
-    directories (like ``data/``, ``cache/``) are skipped automatically.
-    Errors are logged but never propagated — a broken sub-package must not
-    prevent the main package from starting.
+    The package's own source directory is skipped: importing built-in package
+    initializers defeats lazy discovery and can load optional native libraries
+    such as FAISS during a basic ``import tooluniverse``. Additional namespace
+    paths contributed by separately installed packages are still scanned.
+    Errors are logged but never propagated — a broken external sub-package
+    must not prevent the main package from starting.
     """
     try:
         pkg = importlib.import_module(package_name)
     except ImportError:
         return
 
+    package_file = getattr(pkg, "__file__", None)
+    main_package_dir = (
+        Path(package_file).resolve().parent if package_file is not None else None
+    )
+
     for pkg_dir in pkg.__path__:
         try:
-            base = Path(pkg_dir)
+            base = Path(pkg_dir).resolve()
         except Exception:
+            continue
+        is_main_source = (
+            main_package_dir is not None and base == main_package_dir
+        ) or (
+            (base / "execute_function.py").is_file()
+            and (base / "tool_registry.py").is_file()
+        )
+        if is_main_source:
             continue
         for subpkg in sorted(base.iterdir()):
             if not subpkg.is_dir():
                 continue
             if not (subpkg / "__init__.py").exists():
                 continue
-            # Skip the built-in sub-packages that are part of the main repo
-            # (they register themselves via the standard decorator path).
-            # We only want EXTERNALLY installed sub-packages.
-            # Heuristic: skip directories that are inside the main package dir
-            # that lives in the editable-install source tree.
             full_mod = f"{package_name}.{subpkg.name}"
             if full_mod in sys.modules:
                 continue

--- a/tests/unit/test_torch_device_isolation.py
+++ b/tests/unit/test_torch_device_isolation.py
@@ -1,0 +1,93 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
+SOURCE_ROOT = Path(__file__).parents[2] / "src" / "tooluniverse"
+
+
+def test_tooluniverse_never_mutates_torch_global_default_device():
+    offenders = []
+    for path in SOURCE_ROOT.rglob("*.py"):
+        if "set_default_device(" in path.read_text(encoding="utf-8"):
+            offenders.append(path.relative_to(SOURCE_ROOT).as_posix())
+
+    assert offenders == [], (
+        "ToolUniverse shares one Python process across many tools, so changing "
+        "PyTorch's process-wide default device can crash unrelated tools or mix "
+        f"CPU and GPU tensors. Offending modules: {offenders}"
+    )
+
+
+@pytest.mark.parametrize("light_import", ["true", "false"])
+def test_import_does_not_load_faiss_before_torch(light_import):
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(SOURCE_ROOT.parent)
+    env["TOOLUNIVERSE_LIGHT_IMPORT"] = light_import
+
+    script = """
+import importlib.util
+import sys
+
+import tooluniverse
+
+assert "faiss" not in sys.modules, "faiss was imported eagerly"
+if importlib.util.find_spec("torch") is not None:
+    import torch
+
+    assert torch.zeros(1, 4, 524_288).shape == (1, 4, 524_288)
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_subpackage_discovery_skips_builtins_but_keeps_external_paths(
+    tmp_path, monkeypatch
+):
+    from tooluniverse import tool_registry
+
+    main_root = tmp_path / "main" / "tooluniverse"
+    duplicate_main_root = tmp_path / "installed_main" / "tooluniverse"
+    external_root = tmp_path / "external" / "tooluniverse"
+    for package in (
+        main_root / "builtin",
+        duplicate_main_root / "duplicate_builtin",
+        external_root / "contributed",
+    ):
+        package.mkdir(parents=True)
+        (package / "__init__.py").write_text("", encoding="utf-8")
+    (main_root / "__init__.py").write_text("", encoding="utf-8")
+    (duplicate_main_root / "execute_function.py").write_text("", encoding="utf-8")
+    (duplicate_main_root / "tool_registry.py").write_text("", encoding="utf-8")
+
+    package = SimpleNamespace(
+        __file__=str(main_root / "__init__.py"),
+        __path__=[str(main_root), str(duplicate_main_root), str(external_root)],
+    )
+    imported = []
+
+    def fake_import(name):
+        if name == "example_package":
+            return package
+        imported.append(name)
+        return SimpleNamespace()
+
+    monkeypatch.setattr(tool_registry.importlib, "import_module", fake_import)
+
+    tool_registry._auto_import_subpackages("example_package")
+
+    assert imported == ["example_package.contributed"]


### PR DESCRIPTION
## Summary

- keep built-in ToolUniverse package initializers out of namespace-extension auto-imports while preserving separately installed extension packages
- avoid eager FAISS loading during `import tooluniverse`, including when an editable install contributes a duplicate main-package path
- remove ToolUniverse-wide `torch.set_default_device("cpu")` mutations; model tools continue to choose their own explicit devices and the existing MPS environment safeguards remain
- add regression coverage for normal/light imports, duplicate editable paths, external namespace contributors, and Torch allocation after ToolUniverse import

## Root cause

On Apple Silicon with FAISS 1.12 and PyTorch 2.8, importing FAISS before Torch could make the first tensor allocation exit with signal 11. `_auto_import_subpackages()` documented that built-in packages were skipped, but it actually imported every built-in package initializer. `database_setup` therefore loaded FAISS during a basic ToolUniverse import. Editable worktrees made this worse because the already-installed main checkout appeared as a second namespace path and was treated as an external extension.

The process-wide default-device mutation was also unsafe for a shared tool runtime: it changed later tensor creation in unrelated tools and could conflict with tools that explicitly select CPU or CUDA. ADMET-AI 1.2.0 already chooses CUDA when available and CPU otherwise.

## Validation

- `env -u FDA_API_KEY pytest tests/unit/ tests/integration/ -q --no-cov -n auto -m "not slow and not require_api_keys and not network and not require_gpu"`
- `pytest -q --no-cov -n auto tests/unit/test_remote_ml_tools.py tests/unit/test_torch_device_isolation.py`
- `pytest -q --no-cov tests/unit/test_lazy_load_cache_consistency.py tests/unit/test_dependency_isolation.py tests/unit/test_mcpb_bundle.py`
- `pytest -q --no-cov tests/integration/test_workspace_and_space.py`
- `ruff check` on all changed Python files
- `python -m tooluniverse.doctor`: 2,682 configs loaded, 0 failed

The full local CI-scope run passed with only the repository’s existing skips/xfail. The local FDA key was explicitly removed because that test verifies behavior without an API key.