### PR TITLE
Safely parse and validate plugin release triggers

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,13 +1,13 @@
 name: Auto-release plugin
 #
 # Auto-bump version + tag + release when plugin files change AND the commit
-# message contains a release marker. This keeps regular plugin merges (typo
+# message subject contains a release marker. This keeps regular plugin merges (typo
 # fixes, doc updates, refactors) from auto-releasing — only deliberate
 # releases fire.
 #
 # How to trigger:
 #
-#   A) Commit-message marker (preferred — automatic on push to main):
+#   A) Commit-subject marker (preferred — automatic on push to main):
 #        git commit -m "Add tooluniverse-foo skill [release:minor]"
 #        git push origin main
 #      This workflow runs scripts/release-plugin.sh minor, which creates a
@@ -54,22 +54,28 @@ jobs:
       - name: Determine release level
         id: level
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "level=${{ inputs.level }}" >> "$GITHUB_OUTPUT"
-            echo "Triggered manually with level=${{ inputs.level }}"
+          LEVEL=""
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            LEVEL=$(jq -r '.inputs.level // ""' "$GITHUB_EVENT_PATH")
+            case "$LEVEL" in
+              major|minor|patch) ;;
+              *) echo "::error::Invalid release level: $LEVEL"; exit 1 ;;
+            esac
+            echo "Triggered manually with level=$LEVEL"
           else
             # Read untrusted commit text as data instead of interpolating it
             # into this shell script. The checkout step intentionally runs only
             # when a release marker is present.
             MSG=$(jq -r '.head_commit.message // ""' "$GITHUB_EVENT_PATH")
-            if   printf '%s\n' "$MSG" | grep -Fq '[release:major]'; then echo "level=major" >> "$GITHUB_OUTPUT"
-            elif printf '%s\n' "$MSG" | grep -Fq '[release:minor]'; then echo "level=minor" >> "$GITHUB_OUTPUT"
-            elif printf '%s\n' "$MSG" | grep -Fq '[release:patch]'; then echo "level=patch" >> "$GITHUB_OUTPUT"
-            else
-              echo "level=" >> "$GITHUB_OUTPUT"
-              echo "No [release:X] marker in commit message; skipping."
-            fi
+            SUBJECT=${MSG%%$'\n'*}
+            case "$SUBJECT" in
+              *'[release:major]'*) LEVEL=major ;;
+              *'[release:minor]'*) LEVEL=minor ;;
+              *'[release:patch]'*) LEVEL=patch ;;
+              *) echo "No [release:X] marker in commit subject; skipping." ;;
+            esac
           fi
+          echo "level=$LEVEL" >> "$GITHUB_OUTPUT"
 
       - name: Stop if no release level
         if: steps.level.outputs.level == ''

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -96,7 +96,9 @@ jobs:
 
       - name: Run release script
         if: steps.level.outputs.level != ''
-        run: bash scripts/release-plugin.sh "${{ steps.level.outputs.level }}"
+        env:
+          RELEASE_LEVEL: ${{ steps.level.outputs.level }}
+        run: bash scripts/release-plugin.sh "$RELEASE_LEVEL"
 
       - name: Summary
         if: steps.level.outputs.level != ''

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -32,6 +32,7 @@ on:
     paths:
       - 'plugin/**'
       - '.claude-plugin/**'
+      - '.github/workflows/auto-release.yml'
   workflow_dispatch:
     inputs:
       level:

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -57,10 +57,13 @@ jobs:
             echo "level=${{ inputs.level }}" >> "$GITHUB_OUTPUT"
             echo "Triggered manually with level=${{ inputs.level }}"
           else
-            MSG=$(git -C "$GITHUB_WORKSPACE" log -1 --format=%B 2>/dev/null || echo "${{ github.event.head_commit.message }}")
-            if   echo "$MSG" | grep -q '\[release:major\]'; then echo "level=major" >> "$GITHUB_OUTPUT"
-            elif echo "$MSG" | grep -q '\[release:minor\]'; then echo "level=minor" >> "$GITHUB_OUTPUT"
-            elif echo "$MSG" | grep -q '\[release:patch\]'; then echo "level=patch" >> "$GITHUB_OUTPUT"
+            # Read untrusted commit text as data instead of interpolating it
+            # into this shell script. The checkout step intentionally runs only
+            # when a release marker is present.
+            MSG=$(jq -r '.head_commit.message // ""' "$GITHUB_EVENT_PATH")
+            if   printf '%s\n' "$MSG" | grep -Fq '[release:major]'; then echo "level=major" >> "$GITHUB_OUTPUT"
+            elif printf '%s\n' "$MSG" | grep -Fq '[release:minor]'; then echo "level=minor" >> "$GITHUB_OUTPUT"
+            elif printf '%s\n' "$MSG" | grep -Fq '[release:patch]'; then echo "level=patch" >> "$GITHUB_OUTPUT"
             else
               echo "level=" >> "$GITHUB_OUTPUT"
               echo "No [release:X] marker in commit message; skipping."


### PR DESCRIPTION
## Summary

- read push commit messages from `$GITHUB_EVENT_PATH` as JSON data
- stop interpolating untrusted commit text directly into the generated shell script
- restrict automatic release markers to the commit subject so a PR body cannot trigger a release accidentally
- parse and allowlist manual patch, minor, and major inputs from the event payload
- run the workflow when its own definition changes so fixes exercise the no-release path immediately after merge

## Root cause

The auto-release workflow determined its release level before checkout. When
`git log` was unavailable, `${{ github.event.head_commit.message }}` was embedded
inside a shell double-quoted fallback. PR #508's multiline merge message
contained shell-sensitive syntax, so the generated script failed before it
could decide that no release was requested. The same interpolation also allowed
commit-message content to alter shell parsing.

Failed run: https://github.com/mims-harvard/ToolUniverse/actions/runs/31526003309

## Validation

- parsed the exact #508 merge commit message without a release marker
- parsed multiline messages containing quotes, backticks, `$()`, and closing
  parentheses without execution or syntax errors
- verified subject-only patch, minor, and major markers, including major-over-patch precedence
- verified that markers in a commit body do not release and invalid manual levels fail closed
- parsed `.github/workflows/auto-release.yml` as YAML
- `git diff --check` passed

This intentionally does not add a release marker. Because the workflow now
listens to its own path, merging this PR should immediately exercise the safe
no-release path without publishing a plugin release.
