### PR TITLE
Fix batch long_branch_score returning no values

### DIFF
--- a/src/tooluniverse/phykit_tool.py
+++ b/src/tooluniverse/phykit_tool.py
@@ -161,6 +161,19 @@ class PhyKITTool(BaseTool):
         missing = []  # (index, message)
         for idx, f in enumerate(files):
             extra: List[str] = []
+            if function == "long_branch_score":
+                # `phykit lb_score <tree>` prints a LABELLED SUMMARY BLOCK
+                # ("mean: -25.0\nmedian: -30.4551\n..."), not per-taxon rows.
+                # The aggregation below parses `line.split("\t")[-1]` expecting
+                # `taxon<TAB>score`, so every line failed to parse, taxon_values
+                # stayed empty, and each tree was skipped -- the batch reported
+                # "No values computed from 249 files (0 errors)", which reads
+                # like an empty directory rather than a parse failure.
+                # -v/--verbose is what emits the per-taxon rows this path needs.
+                # Scoped to the batch path on purpose: `operation="single"`
+                # returns phykit's raw text, and its summary block is exactly
+                # what a caller asking for "the median LB score" wants to read.
+                extra = ["-v"]
             if function in PHYKIT_NEEDS_TREE and tree_dir:
                 # Path.stem drops only the LAST suffix, but these files carry
                 # multi-part extensions (foo.faa.mafft.clipkit). Using .stem built

--- a/tests/unit/test_phykit_long_branch_score_batch.py
+++ b/tests/unit/test_phykit_long_branch_score_batch.py
@@ -1,0 +1,69 @@
+"""Regression: batch long_branch_score must actually produce values.
+
+`phykit lb_score <tree>` prints a labelled summary block
+("mean: -25.0\\nmedian: -30.4551\\n...") unless -v/--verbose is passed, while the
+batch aggregator parses `line.split("\\t")[-1]` expecting `taxon<TAB>score`.
+Without -v every line failed to parse, `taxon_values` stayed empty, and each
+tree was silently skipped -- the batch returned
+"No values computed from 249 files (0 errors)", which reads like an empty
+directory rather than a parse failure. That made the whole function unusable
+while looking like a user error.
+"""
+
+import shutil
+
+import pytest
+
+from tooluniverse.phykit_tool import _run_phykit
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("phykit") is None, reason="phykit not installed"
+)
+
+# 4 taxa, deliberately unbalanced so mean != median and a silent fallback to
+# the wrong statistic cannot pass.
+NEWICK = "(((A:0.01,B:0.01):0.02,C:0.05):0.03,D:0.9);"
+
+
+@pytest.fixture()
+def tree(tmp_path):
+    p = tmp_path / "t.treefile"
+    p.write_text(NEWICK + "\n")
+    return str(p)
+
+
+def test_batch_invocation_yields_parseable_per_taxon_rows(tree):
+    """The batch path's -v output must parse the way the aggregator expects."""
+    out, reason = _run_phykit("long_branch_score", tree, ["-v"])
+    assert out, f"phykit failed: {reason}"
+
+    values = []
+    for line in out.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split("\t")
+        values.append(float(parts[-1]))
+
+    # One row per taxon -- this is what was empty before the fix.
+    assert len(values) == 4, f"expected 4 per-taxon rows, got {len(values)}: {out!r}"
+
+
+def test_summary_block_is_not_parseable_as_rows(tree):
+    """Without -v the output is a summary block, so the aggregator gets nothing.
+
+    Pins the root cause: if phykit ever changes to emit rows by default this
+    test fails loudly rather than the fix quietly becoming a no-op.
+    """
+    out, reason = _run_phykit("long_branch_score", tree, None)
+    assert out, f"phykit failed: {reason}"
+    assert "median:" in out
+
+    parsed = []
+    for line in out.splitlines():
+        if not line.strip():
+            continue
+        try:
+            parsed.append(float(line.split("\t")[-1]))
+        except ValueError:
+            pass
+    assert parsed == [], f"summary block unexpectedly parsed as rows: {parsed}"


### PR DESCRIPTION
## Problem

`phykit_batch_analysis` with `function="long_branch_score"` and `operation="batch"` returns **no values at all**:

```
{"status": "error", "error": "No values computed from 249 files (0 errors)"}
```

249 files processed, 0 errors, 0 values. The message reads like an empty directory or a bad `extension`, so there is nothing for the caller to act on — the function is simply unusable, and looks like user error.

## Root cause

`phykit lb_score <tree>` prints a **labelled summary block**:

```
mean: -25.0
median: -30.4551
25th percentile: -31.6092
...
```

It only prints one `taxon<TAB>score` row per taxon when passed `-v/--verbose` (per `phykit lb_score --help`: *"PhyKIT reports summary statistics. To obtain LB scores for each taxa, use the -v/--verbose option."*).

The batch aggregator parses `line.split("\t")[-1]`. The summary block contains no tabs, so `float(...)` raised on every line, `taxon_values` stayed empty, and each tree hit `continue` — every file was silently skipped while being counted as processed.

## Fix

Pass `-v` on the batch path.

Scoped there deliberately: `operation="single"` returns phykit's raw text, and its summary block is exactly what a caller asking for *"the median LB score"* wants to read. That path is unchanged.

## Verification

Measured on 249 fungal gene trees (BixBench capsule `scogs_fungi`):

| | before | after |
|---|---|---|
| `n_values` | **0** | **249** |
| `n_errors` | 0 | 0 |
| `per_tree_stat="median"` | — | −25.9983 |
| `per_tree_stat="mean"` | — | −25.0 |

`per_tree_stat` previously could not distinguish median from mean, since both aggregated an empty list. On a single tree the batch path now returns **−30.45505**, matching `phykit lb_score -v` computed directly (4 taxa, median −30.45505).

Regression checks: `operation="single"` still returns the summary block; `total_tree_length` batch unaffected (249 values, median 3.0962).

## Tests

`tests/unit/test_phykit_long_branch_score_batch.py` (2 tests, skipped when `phykit` is absent) pins **both** the fix and its root cause — the second test asserts the no-`-v` output is *not* parseable as rows, so if phykit ever emits per-taxon rows by default the change fails loudly rather than quietly becoming a no-op. The fixture tree is deliberately unbalanced so mean ≠ median and a silent fallback to the wrong statistic cannot pass.

## How this was found

Failure analysis of a BixBench run: the question *"What is the median long branch score for the fungal gene 996662at2759?"* (gold `-30.4551`) was answered correctly by the model **without** tools and incorrectly **with** them — which is what pointed at the tool rather than the model.
