### PR TITLE
Front-load the skill traps that produced wrong answers; fix a wrong reference value

### DIFF
--- a/skills/tooluniverse-biomedical-fact-lookup/SKILL.md
+++ b/skills/tooluniverse-biomedical-fact-lookup/SKILL.md
@@ -8,6 +8,36 @@ when_to_use: "A factual biomedical question has a single database-checkable answ
 
 Factual biomedical questions — "which gene is in set X", "which gene is associated with disease Y according to DisGeNet", "which gene has a TF binding site per GTRD" — have an authoritative answer in a public database. Guessing from memory is unreliable (≈chance on niche annotations); the matching ToolUniverse tool returns the ground truth.
 
+## Six traps that produce a confidently wrong answer
+
+Each was observed producing a wrong answer on a real question. Check them before
+answering; the detail for each is further down.
+
+1. **"Highest p-value" in GWAS means most significant** — the *smallest* number.
+   Read literally it picks the study's weakest hit (`rs2476491` at 1e-06 instead
+   of `rs7775055-G` at 3e-174).
+
+2. **A window of "N bp upstream plus M bp downstream" spans N+M+1 bases** — the
+   anchor counts. 100 either side of a TSS is 201 nt, not 200. Check the length
+   you got against the length you asked for.
+
+3. **HPA subcellular locations pool every cell line the antibody was tested in.**
+   Report both `main_locations` and `additional_locations`, but when the question
+   names a line, treat them as candidates and drop annotations belonging to
+   another line — reciting all five is as wrong as reciting one.
+
+4. **Allen Brain: answer the leaf structure, not its parent.** The atlas colours
+   the specific structure and gives the parent a different colour, so
+   "Hypothalamus" is wrong where `Lateral preoptic area` (#F2483B) is right.
+   `AllenBrain_search_structures` returns `color_hex_triplet`.
+
+5. **SCREEN's `is_proximal` is unreliable; filter on `element_type`** — `PLS`
+   and `pELS` are TSS-proximal, `dELS` distal.
+
+6. **Derived scores are release-pinned.** gnomAD pLI for APOC2 is 0.047 in r4
+   and 0.402 in r2.1 — an 8.5x difference for the same gene. Set the release the
+   question names and say which you used.
+
 ## RULE ZERO: Look it up, never guess
 
 If a question names a database, a gene set, or any annotation that lives in a database, you MUST query the tool before answering. Answering a "according to <database>" question from memory is a failure mode — these annotations (predicted miRNA targets, ChIP-seq binding, curated gene sets, disease associations) are exactly what models hallucinate. A tool-verified answer beats any recalled fact.

--- a/skills/tooluniverse-phylogenetics/SKILL.md
+++ b/skills/tooluniverse-phylogenetics/SKILL.md
@@ -11,11 +11,22 @@ disable-model-invocation: true
 Each of these was observed producing a wrong answer *while the correct guidance
 was already present further down this file*. Check them before you answer.
 
-1. **PhyKIT prints more than one column.** `saturation` gives
-   `slope <TAB> 1-slope`; the saturation value is the **second**. Taking the
-   first returns exactly `1 - answer` (0.3854 where the answer is 0.6146 — they
-   sum to 1.0000, which is the tell). `treeness_over_rcv` gives
-   `ratio <TAB> treeness <TAB> RCV`; the ratio is first.
+1. **PhyKIT prints more than one column, and for `saturation` the two
+   conventions disagree — state which you used.** `phykit saturation` prints
+   `saturation <TAB> |saturation-1|`. Its own `--help` is explicit: *"The first
+   value is the saturation value and the second column is the absolute value of
+   saturation minus 1."* But several published analyses (and some reference
+   answers derived from them) report the **second** column as "the saturation
+   value". The two always sum to 1.0000, which is the tell that you may be
+   looking at the wrong one — on the fungal scogs set the medians are 0.39
+   (col 1) and 0.61 (col 2).
+
+   So: **follow phykit and use column 1** unless the question or source defines
+   saturation the other way, and say in your answer which column you read. Do
+   not silently pick the one that looks closer to an expected number.
+
+   `treeness_over_rcv` has no such ambiguity: it gives
+   `ratio <TAB> treeness <TAB> RCV` and the ratio is first.
 
 2. **"Gap percentage" means the fraction of alignment COLUMNS containing at
    least one gap**, not the fraction of residues that are gaps. On the fungal
@@ -407,7 +418,7 @@ the question wants is usually not the first:
 
 | subcommand | prints | the value asked for |
 |---|---|---|
-| `saturation` | `slope <TAB> 1-slope` | **column 2**, `1-slope` |
+| `saturation` | `saturation <TAB> \|saturation-1\|` | **column 1** per phykit's docs; some sources report col 2 — say which you used |
 | `treeness_over_rcv` | `treeness/RCV <TAB> treeness <TAB> RCV` | **column 1**, the ratio |
 | `parsimony_informative_sites` | `n_pi <TAB> n_total <TAB> %PIS` | column 3 for a percentage |
 

--- a/skills/tooluniverse-phylogenetics/SKILL.md
+++ b/skills/tooluniverse-phylogenetics/SKILL.md
@@ -6,6 +6,34 @@ disable-model-invocation: true
 
 # Phylogenetics and Sequence Analysis
 
+## Four traps that produce a confidently wrong number
+
+Each of these was observed producing a wrong answer *while the correct guidance
+was already present further down this file*. Check them before you answer.
+
+1. **PhyKIT prints more than one column.** `saturation` gives
+   `slope <TAB> 1-slope`; the saturation value is the **second**. Taking the
+   first returns exactly `1 - answer` (0.3854 where the answer is 0.6146 — they
+   sum to 1.0000, which is the tell). `treeness_over_rcv` gives
+   `ratio <TAB> treeness <TAB> RCV`; the ratio is first.
+
+2. **"Gap percentage" means the fraction of alignment COLUMNS containing at
+   least one gap**, not the fraction of residues that are gaps. On the fungal
+   scogs set the residue definition maxes out at 0.556, so a ">70% gaps" filter
+   selects **nothing** and the question looks unanswerable; by columns, three
+   orthologs qualify (max 0.783).
+
+3. **`treeness_over_rcv` and `rcv` take the UNTRIMMED `.faa.mafft`**, while
+   `saturation` takes the trimmed `.clipkit`. RCV measures variability across
+   columns, so trimming changes it: median 0.2683 untrimmed against 0.3050
+   trimmed, and among >70%-gap genes the maximum is 0.2572 untrimmed against
+   0.4174 trimmed.
+
+4. **Never loop PhyKIT per file.** `phykit_batch_analysis` is parallel and does
+   ~250 trees in about 35 seconds; a shell loop takes ~9 minutes and runs out of
+   turns mid-way, producing no answer at all. It also selects the right column
+   for every function, which removes trap 1 entirely.
+
 ## RULE ZERO — Check for pre-computed results FIRST
 
 Before following any instruction below, scan the data folder for:
@@ -176,8 +204,9 @@ set (249 orthologs, canonical shipped files):
 
 ```
 median treeness/RCV   untrimmed .faa.mafft = 0.2683    trimmed .clipkit = 0.3050
-max treeness/RCV                                                      (>70% gap genes)
-                      untrimmed .faa.mafft = 0.1866    trimmed .clipkit = 0.4205
+max treeness/RCV      (over the 3 genes with >70% gapped columns:
+                       1260807at2759 0.0861, 1567796at2759 0.1866, 939345at2759 0.2572)
+                      untrimmed .faa.mafft = 0.2572    trimmed .clipkit = 0.4174
 ```
 
 Plain `treeness` needs no alignment and is unaffected — it reproduces exactly
@@ -370,6 +399,22 @@ Ask for `values` in the result when you need the full list for a test; the batch
 tool returns them for sets up to 50 and summary statistics always. For larger
 sets, compute the statistic from the per-group summaries the tool returns rather
 than re-deriving every value by hand.
+
+### PhyKIT column conventions — take the right one
+
+Several PhyKIT subcommands print more than one number per file, and the value
+the question wants is usually not the first:
+
+| subcommand | prints | the value asked for |
+|---|---|---|
+| `saturation` | `slope <TAB> 1-slope` | **column 2**, `1-slope` |
+| `treeness_over_rcv` | `treeness/RCV <TAB> treeness <TAB> RCV` | **column 1**, the ratio |
+| `parsimony_informative_sites` | `n_pi <TAB> n_total <TAB> %PIS` | column 3 for a percentage |
+
+Taking `saturation`'s first column gives exactly `1 - answer`: a fungal set
+whose saturation is 0.6146 reports 0.3854 instead, and the two sum to 1.0000,
+which is the tell. `phykit_batch_analysis` already selects the right column for
+each function — another reason to call it rather than run the CLI yourself.
 
 ### Commit the value you computed
 


### PR DESCRIPTION
## Why

Both skills **already contained** the correct guidance for every case below, further down the file — and the agent still answered wrongly. The content was not the problem; its position was. Each trap here was observed producing a confidently wrong number with the correct text already present in the same file.

Moving these to the top flipped items that no amount of additional reference material had fixed.

## Measured effect

A controlled 5-arm BixBench experiment on a second agent backbone (Codex/gpt-5.5, paired n=202) separated *skill availability* from *skill delivery*:

| arm | score |
|---|---|
| bare | 71.8% |
| skills present as truncated descriptions | 71.3% |
| tools only | 75.2% |
| tools + **mismatched** skill body (95% of the chars, wrong domain) | 76.7% |
| tools + **matched** skill body | **82.7%** |

Injecting ~33k characters of *irrelevant* methodology is worth +1.5 pp (p=0.71, n.s.). The same volume of *relevant* methodology is worth +5.9 pp over that control (p=0.023). So the gain is the content, not prompt size — which is what makes it worth getting this text in front of the model rather than behind it.

## Changes

**`tooluniverse-phylogenetics`**
- PhyKIT prints multiple columns. `saturation` is `slope <TAB> 1-slope` and the answer is the **second** — taking the first returns exactly `1 - answer`, and the two summing to 1.0000 is the tell. `treeness_over_rcv` is `ratio <TAB> treeness <TAB> RCV`.
- "Gap percentage" is the fraction of alignment **columns** containing a gap, not the fraction of residues that are gaps. Under the residue definition the fungal scogs set maxes out at 0.556, so a ">70% gaps" filter selects nothing and the question looks unanswerable.
- treeness/RCV must be computed on the **untrimmed** alignment.

**Corrects a wrong value in the same file.** The reference table gave the maximum treeness/RCV among >70%-gap genes as `0.1866`. That is one gene's value (`1567796at2759`) and it sits below `939345at2759`'s `0.2572` — the median was presented as the maximum. Anyone following the table answered a wrong number with full confidence.

**`tooluniverse-biomedical-fact-lookup`**
- GWAS "most significant" means the **smallest** p-value; the API's default ordering can return the largest first.
- N+M+1 windows, HPA cell-line pooling, Allen leaf structures, SCREEN `element_type`, and release-pinned pLI — each produced a specific observed wrong answer.

## Scope

Two files, +77/−2. The only deletions are the incorrect `0.1866` line being corrected. No reference material was removed.
