### PR TITLE
Make openai and google-genai optional extras (#526)

### DIFF
--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -12,6 +12,14 @@ requires-python = ">=3.10,<3.14"
 # We don't depend on `tooluniverse` from PyPI; the source is bundled inside
 # `src/tooluniverse/` and these are its runtime deps. Keep this list in sync
 # with the root pyproject.toml `dependencies` section.
+#
+# Deliberate exception: `openai` and `google-genai` are optional extras in the
+# root pyproject.toml but stay unconditional here. This bundle is a sealed
+# Claude Desktop runtime — nothing resolves against it, so the downstream
+# resolver problem that made them extras upstream does not apply, and an end
+# user has no way to install an extra into the bundle. Dropping them would just
+# make the Gemini/OpenAI clients permanently unavailable in Desktop. Do not
+# "re-sync" these two away.
 dependencies = [
     "requests>=2.32.0",
     "numpy>=2.2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,9 +19,9 @@ dependencies = [
     "pydantic>=2.11.0",
     "epam.indigo>=1.34.0",
     "networkx>=3.4.0",
-    "openai>=1.107.0",
+    # openai / google-genai are NOT here on purpose: they are optional extras
+    # (`tooluniverse[openai]`, `tooluniverse[gemini]`), both covered by [all].
     "pyyaml>=6.0.0",
-    "google-genai>=1.36.0",
     "mcp[cli]>=1.29.0,<2.0.0",
     "fastmcp>=3.4.5,<4.0.0",
     "xmltodict>=1.0.0",
@@ -68,6 +68,22 @@ pdf = [
     # it in implicitly.
     "pymupdf>=1.24.3",
 ]
+# LLM provider SDKs. Both are imported lazily inside the client constructors in
+# llm_clients.py (AzureOpenAIClient, OpenAICompatibleClient, OpenRouterClient,
+# VLLMClient, GeminiClient) and in database_setup/embedder.py — never at module
+# scope — so tooluniverse imports and runs fine without them, and a constructor
+# reached without its extra raises a clear RuntimeError. Unlike `pdf` these ARE
+# in the aggregate `all` extra, so `tooluniverse[all]` keeps today's behavior.
+# They are separate extras rather than one combined group so that an
+# OpenAI-only user is not subjected to google-genai's `websockets` upper bound,
+# which is the constraint that can push a downstream universal resolver onto a
+# much older tooluniverse instead of reporting a conflict (issue #526).
+openai = [
+    "openai>=1.107.0",
+]
+gemini = [
+    "google-genai>=1.36.0",
+]
 client = [
     "requests>=2.32.0",
     "pydantic>=2.11.0",
@@ -92,6 +108,10 @@ dev = [
     "pytest-html>=3.0",
     "requests-mock>=1.12.1",
     "ruff>=0.14.5",
+    # tests/unit/test_gemini_client.py constructs a real google.genai Client, so
+    # the provider SDKs stay part of `[dev]` now that they left the base set.
+    # This keeps `pip install -e .[dev] && pytest` green, as CI runs exactly that.
+    "tooluniverse[openai,gemini]",
 ]
 docs = [
     "sphinx>=4.0",
@@ -150,7 +170,7 @@ bioinformatics = [
 ]
 # circuit: install manually with `pip install git+https://github.com/tooluniverse/circuit.git`
 all = [
-    "tooluniverse[dev,docs,graph,visualization,space,embedding,ml,bioinformatics]",
+    "tooluniverse[dev,docs,graph,visualization,space,embedding,ml,bioinformatics,openai,gemini]",
 ]
 build = [
     "pyinstaller>=6.0.0",

--- a/src/tooluniverse/extras.py
+++ b/src/tooluniverse/extras.py
@@ -71,6 +71,15 @@ EXTRA_PACKAGES: dict[str, dict[str, str]] = {
         "smolagents": "smolagents",
         "gradio": "gradio",
     },
+    # LLM provider SDKs. Lazily imported by the llm_clients.py client
+    # constructors, so a missing one loads fine and only fails when an agentic
+    # tool actually calls that provider -- exactly the gap this module reports.
+    "openai": {
+        "openai": "openai",
+    },
+    "gemini": {
+        "google.genai": "google-genai",
+    },
 }
 
 # Extras NOT covered by ``tooluniverse[all]`` — worth telling users about,

--- a/tests/unit/test_packaging_dependencies.py
+++ b/tests/unit/test_packaging_dependencies.py
@@ -54,6 +54,17 @@ KNOWN_MCPB_OMISSIONS = {
     "openpyxl",
 }
 
+# Dependencies the bundle declares on purpose that the root list leaves to an
+# extra. The bundle is a sealed Claude Desktop runtime: the end user cannot
+# install an extra into it, so anything optional upstream must be unconditional
+# here or the feature is simply unreachable in Desktop.
+KNOWN_MCPB_ADDITIONS = {
+    # Optional root extras `openai` / `gemini` (see issue #526). They stay
+    # unconditional in the bundle so the OpenAI and Gemini clients keep working.
+    "openai",
+    "google-genai",
+}
+
 
 def _load_pyproject(pyproject_path):
     with open(pyproject_path, "rb") as fh:
@@ -127,10 +138,31 @@ def test_mcpb_dependencies_mirror_root():
         f"KNOWN_MCPB_OMISSIONS with a reason."
     )
 
-    extra = mcpb - root
+    extra = mcpb - root - KNOWN_MCPB_ADDITIONS
     assert not extra, (
         f"mcpb/pyproject.toml declares dependencies absent from the root "
-        f"pyproject.toml: {sorted(extra)}."
+        f"pyproject.toml: {sorted(extra)}. Add them to the root list, or record "
+        f"them in KNOWN_MCPB_ADDITIONS with a reason."
+    )
+
+    # A bundle-only dependency must still track the constraint of the root
+    # extra it mirrors, so the two cannot drift apart silently.
+    root_extra_requirements = {
+        _distribution_name(requirement): requirement
+        for requirements in _load_pyproject(ROOT_PYPROJECT)[
+            "optional-dependencies"
+        ].values()
+        for requirement in requirements
+    }
+    drifted = {
+        name: (root_extra_requirements[name], mcpb_requirements[name])
+        for name in KNOWN_MCPB_ADDITIONS & mcpb
+        if name in root_extra_requirements
+        and root_extra_requirements[name] != mcpb_requirements[name]
+    }
+    assert not drifted, (
+        "mcpb/pyproject.toml pins a bundle-only dependency differently from the "
+        f"root extra that declares it: {drifted}."
     )
 
     mismatched = {

--- a/uv.lock
+++ b/uv.lock
@@ -2097,7 +2097,7 @@ name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [
@@ -2660,7 +2660,7 @@ name = "macholib"
 version = "1.16.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "altgraph" },
+    { name = "altgraph", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/95/ee/af1a3842bdd5902ce133bd246eb7ffd4375c38642aeb5dc0ae3a0329dfa2/macholib-1.16.3.tar.gz", hash = "sha256:07ae9e15e8e4cd9a788013d81f5908b3609aa76f9b1421bae9c4d7606ec86a30", size = 59309, upload-time = "2023-09-25T09:10:16.155Z" }
 wheels = [
@@ -3289,7 +3289,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -3300,7 +3300,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -3327,9 +3327,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
+    { name = "nvidia-cusparse-cu12", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -3340,7 +3340,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
@@ -4156,10 +4156,10 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "annotated-types" },
-    { name = "pydantic-core", version = "2.33.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "typing-extensions" },
-    { name = "typing-inspection" },
+    { name = "annotated-types", marker = "python_full_version < '3.14'" },
+    { name = "pydantic-core", version = "2.33.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
+    { name = "typing-inspection", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ff/5d/09a551ba512d7ca404d785072700d3f6727a02f6f3c24ecfd081c7cf0aa8/pydantic-2.11.9.tar.gz", hash = "sha256:6b8ffda597a14812a7975c90b82a8a2e777d9257aba3453f973acd3c032a18e2", size = 788495, upload-time = "2025-09-13T11:26:39.325Z" }
 wheels = [
@@ -4168,7 +4168,7 @@ wheels = [
 
 [package.optional-dependencies]
 email = [
-    { name = "email-validator" },
+    { name = "email-validator", marker = "python_full_version < '3.14'" },
 ]
 
 [[package]]
@@ -4180,10 +4180,10 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "annotated-types" },
-    { name = "pydantic-core", version = "2.46.4", source = { registry = "https://pypi.org/simple" } },
-    { name = "typing-extensions" },
-    { name = "typing-inspection" },
+    { name = "annotated-types", marker = "python_full_version >= '3.14'" },
+    { name = "pydantic-core", version = "2.46.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.14'" },
+    { name = "typing-inspection", marker = "python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
 wheels = [
@@ -4192,7 +4192,7 @@ wheels = [
 
 [package.optional-dependencies]
 email = [
-    { name = "email-validator" },
+    { name = "email-validator", marker = "python_full_version >= '3.14'" },
 ]
 
 [[package]]
@@ -4207,7 +4207,7 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ad/88/5f2260bdfae97aabf98f1778d43f69574390ad787afb646292a638c923d4/pydantic_core-2.33.2.tar.gz", hash = "sha256:7cb8bc3605c29176e1b105350d2e6474142d7c1bd1d9327c4a9bdb46bf827acc", size = 435195, upload-time = "2025-04-23T18:33:52.104Z" }
 wheels = [
@@ -4298,7 +4298,7 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
 wheels = [
@@ -5462,8 +5462,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
+    { name = "jeepney", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -5990,8 +5990,8 @@ name = "standard-aifc"
 version = "3.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "audioop-lts" },
-    { name = "standard-chunk" },
+    { name = "audioop-lts", marker = "python_full_version >= '3.13'" },
+    { name = "standard-chunk", marker = "python_full_version >= '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c4/53/6050dc3dde1671eb3db592c13b55a8005e5040131f7509cef0215212cb84/standard_aifc-3.13.0.tar.gz", hash = "sha256:64e249c7cb4b3daf2fdba4e95721f811bde8bdfc43ad9f936589b7bb2fae2e43", size = 15240, upload-time = "2024-10-30T16:01:31.772Z" }
 wheels = [
@@ -6231,7 +6231,6 @@ dependencies = [
     { name = "fastapi" },
     { name = "fastmcp" },
     { name = "flask" },
-    { name = "google-genai" },
     { name = "graphql-core" },
     { name = "huggingface-hub" },
     { name = "jsonpath-ng" },
@@ -6241,7 +6240,6 @@ dependencies = [
     { name = "mcp", extra = ["cli"] },
     { name = "networkx" },
     { name = "numpy" },
-    { name = "openai" },
     { name = "openpyxl" },
     { name = "pandas" },
     { name = "pdfplumber" },
@@ -6269,6 +6267,7 @@ all = [
     { name = "flask" },
     { name = "freesasa" },
     { name = "furo" },
+    { name = "google-genai" },
     { name = "huggingface-hub" },
     { name = "jinja2" },
     { name = "kaleido" },
@@ -6276,6 +6275,7 @@ all = [
     { name = "matplotlib" },
     { name = "myst-parser" },
     { name = "networkx" },
+    { name = "openai" },
     { name = "plotly" },
     { name = "pre-commit" },
     { name = "py3dmol" },
@@ -6321,6 +6321,8 @@ client = [
     { name = "requests" },
 ]
 dev = [
+    { name = "google-genai" },
+    { name = "openai" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -6353,6 +6355,9 @@ embedding = [
     { name = "huggingface-hub" },
     { name = "sentence-transformers" },
 ]
+gemini = [
+    { name = "google-genai" },
+]
 graph = [
     { name = "flask" },
     { name = "jinja2" },
@@ -6368,6 +6373,9 @@ ml = [
     { name = "faiss-cpu" },
     { name = "huggingface-hub" },
     { name = "sentence-transformers" },
+]
+openai = [
+    { name = "openai" },
 ]
 pdf = [
     { name = "pymupdf" },
@@ -6418,7 +6426,7 @@ requires-dist = [
     { name = "flask", marker = "extra == 'graph'", specifier = ">=2.0.0" },
     { name = "freesasa", marker = "extra == 'bioinformatics'", specifier = ">=2.2.0" },
     { name = "furo", marker = "extra == 'docs'", specifier = ">=2024.8.6" },
-    { name = "google-genai", specifier = ">=1.36.0" },
+    { name = "google-genai", marker = "extra == 'gemini'", specifier = ">=1.36.0" },
     { name = "gradio", marker = "extra == 'smolagents'", specifier = ">=4.0.0" },
     { name = "graphql-core", specifier = ">=3.2.0" },
     { name = "huggingface-hub", specifier = ">=0.34.0" },
@@ -6439,7 +6447,7 @@ requires-dist = [
     { name = "networkx", specifier = ">=3.4.0" },
     { name = "networkx", marker = "extra == 'visualization'", specifier = ">=3.4.0" },
     { name = "numpy", specifier = ">=2.2.0" },
-    { name = "openai", specifier = ">=1.107.0" },
+    { name = "openai", marker = "extra == 'openai'", specifier = ">=1.107.0" },
     { name = "openpyxl", specifier = ">=3.1.0" },
     { name = "pandas", specifier = ">=2.2.3" },
     { name = "pdfplumber", specifier = ">=0.11.0" },
@@ -6493,12 +6501,13 @@ requires-dist = [
     { name = "sphinx-tabs", marker = "extra == 'docs'", specifier = ">=3.5.0" },
     { name = "sympy", specifier = ">=1.12.0" },
     { name = "tiledbsoma", marker = "extra == 'singlecell'", specifier = ">=1.15.3" },
-    { name = "tooluniverse", extras = ["dev", "docs", "graph", "visualization", "space", "embedding", "ml", "bioinformatics"], marker = "extra == 'all'", editable = "." },
+    { name = "tooluniverse", extras = ["dev", "docs", "graph", "visualization", "space", "embedding", "ml", "bioinformatics", "openai", "gemini"], marker = "extra == 'all'", editable = "." },
+    { name = "tooluniverse", extras = ["openai", "gemini"], marker = "extra == 'dev'", editable = "." },
     { name = "uvicorn", specifier = ">=0.36.0" },
     { name = "werkzeug", marker = "extra == 'graph'", specifier = ">=2.0.0" },
     { name = "xmltodict", specifier = ">=1.0.0" },
 ]
-provides-extras = ["pdf", "client", "smolagents", "singlecell", "dev", "docs", "embedding", "ml", "graph", "visualization", "space", "bioinformatics", "all", "build"]
+provides-extras = ["pdf", "openai", "gemini", "client", "smolagents", "singlecell", "dev", "docs", "embedding", "ml", "graph", "visualization", "space", "bioinformatics", "all", "build"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "tooluniverse", extras = ["dev", "embedding"], editable = "." }]
@@ -6592,7 +6601,7 @@ name = "triton"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "setuptools" },
+    { name = "setuptools", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/ee/0ee5f64a87eeda19bbad9bc54ae5ca5b98186ed00055281fd40fb4beb10e/triton-3.4.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7ff2785de9bc02f500e085420273bb5cc9c9bb767584a4aa28d6e360cec70128", size = 155430069, upload-time = "2025-07-30T19:58:21.715Z" },


### PR DESCRIPTION
Fixes #526.

`openai` and `google-genai` are used exclusively behind lazy, function-scope imports, so they don't need to be unconditional base dependencies. Carrying them forces google-genai's `websockets` upper bound onto every consumer's resolution, which can make a universal resolver silently fall back to a much older `tooluniverse` instead of reporting a conflict.

**No library code changes** — packaging only, plus keeping the existing packaging guards honest.

## Design calls, pre-answered

- **Two extras, not one.** `[openai]` and `[gemini]` are separate so an OpenAI-only consumer isn't subjected to the google-genai `websockets` bound — that bound is the actual trigger in #526. Verified: `.[openai]` pulls no websockets pin; `.[gemini]` drops it to 16.1.1.
- **Both are in `all`.** Unlike `pdf` (excluded for AGPL reasons) these are permissively licensed and were previously unconditional, so `tooluniverse[all]` installs exactly what it does today.
- **`[dev]` pulls both.** `tests/unit/test_gemini_client.py` constructs a real `google.genai` Client and CI runs `uv pip install -e .[dev]`. Without this, 5+ tests fail. Doing it in the extra rather than in the workflow keeps `weekly-tool-healthcheck.yml` working too.
- **`mcpb` keeps them unconditional.** The bundle is a sealed Claude Desktop runtime: nothing resolves against it, so #526's failure mode doesn't apply, and a user has no way to install an extra into it. Making them optional there would only make the OpenAI/Gemini clients unreachable. `test_mcpb_dependencies_mirror_root` records this as an allowlisted divergence and gains a new check that the bundle pin cannot drift from the root extra's pin.
- **`extras.py`** registers both groups so `tooluniverse-doctor` reports them as missing with an install hint, consistent with every other runtime-gating extra.

## Verification

In a clean venv with neither package installed:

```
OK import tooluniverse -> 1.4.1
RuntimeError GeminiClient            -> google-genai not available
RuntimeError AzureOpenAIClient       -> openai AzureOpenAI client is not available
RuntimeError OpenAICompatibleClient  -> openai client is not available
RuntimeError OpenRouterClient        -> openai client is not available
RuntimeError VLLMClient              -> openai package not available for vLLM client
doctor missing_extras -> {'openai': ['openai'], 'gemini': ['google-genai']}
install_hints -> ["pip install 'tooluniverse[openai]'", "pip install 'tooluniverse[gemini]'"]
```

That base install resolved `websockets 17.0.1` — above google-genai's `<17.0` bound, which is direct evidence of the mechanism described in the issue.

Full unit suite: 4937 passed, 28 skipped, 1 failure (`test_codex_plugin`, which fails identically on pristine `main` because the subprocess lacks `yaml` — unrelated). Ruff check and format clean.

`uv.lock` regenerated with uv 0.10.3. `uv lock` is a no-op on pristine `main`, so the incidental `marker=` churn on a few transitive packages is a genuine consequence of the fork-graph change rather than version drift. No version changes.

## One note

`database_setup/embedder.py` imports `openai` lazily but without a `try/except`, so it raises `ModuleNotFoundError: No module named 'openai'` rather than a `RuntimeError` like the `llm_clients.py` sites. The message is already clear, so I left it alone to keep this packaging-only — happy to add a guard if you'd prefer consistency.
