### PR TITLE
Fix: resolve MCP-shortened tool names back to their registered name

### DIFF
--- a/src/tooluniverse/execute_function.py
+++ b/src/tooluniverse/execute_function.py
@@ -376,6 +376,11 @@ class ToolUniverse:
 
         self.name_mapper = ToolNameMapper()
         self.enable_name_shortening = enable_name_shortening
+        # The mapper only learns short->original for names it has shortened
+        # itself. A client that received shortened names from a *different*
+        # process calls back with names this mapper has never seen, so the
+        # reverse index is primed from the registry on the first miss.
+        self._name_mapper_primed = False
 
         if enable_name_shortening:
             self.logger.debug("Name shortening enabled for MCP compatibility")
@@ -3007,6 +3012,13 @@ class ToolUniverse:
             str: Resolved tool name (primary identifier in all_tool_dict)
         """
         if function_name:
+            # Prime before resolving, not after. `resolve()` calls
+            # `get_shortened(name)` on a miss, which caches a short name as its
+            # own original; the real original then collides on priming and is
+            # pushed to a `_2` suffix, so the round trip silently breaks for
+            # exactly the names that need it.
+            if function_name not in self.all_tool_dict:
+                self._prime_name_mapper()
             # Let the mapper handle all resolution (aliases, original->short, etc.)
             resolved = self.name_mapper.resolve(
                 function_name, max_length=self.MAX_TOOL_NAME_LENGTH
@@ -3014,7 +3026,42 @@ class ToolUniverse:
             # Only return resolved name if it exists in all_tool_dict
             if resolved in self.all_tool_dict:
                 return resolved
+            # Shortened -> original. `resolve()` covers alias->primary and
+            # original->short but never the reverse, and MCP clients only ever
+            # see the shortened name, so calling back with it failed with
+            # "not found even after loading tools" -- confirmed live for
+            # OpenTargets_get_dise_phen_by_targ_ense (shortened form of
+            # OpenTargets_get_diseases_phenotypes_by_target_ensembl).
+            original = self._resolve_shortened_name(function_name)
+            if original:
+                return original
         return function_name
+
+    def _prime_name_mapper(self) -> None:
+        """Populate the mapper's short->original index from the registry.
+
+        Idempotent and cheap (pure string work, once per instance). Skipped
+        entirely until a lookup actually misses.
+        """
+        if self._name_mapper_primed:
+            return
+        for name in list(self.all_tool_dict.keys()):
+            self.name_mapper.get_shortened(name, self.MAX_TOOL_NAME_LENGTH)
+        self._name_mapper_primed = True
+
+    def _resolve_shortened_name(self, function_name: str) -> str | None:
+        """Map a shortened tool name back to the registered name, or None.
+
+        Collision suffixes (`_2`, `_3`) are assigned in registry iteration
+        order, so a colliding pair could in principle resolve to the other
+        member. Names that do not collide -- the overwhelming majority -- round
+        trip exactly, and the alternative is the current total failure.
+        """
+        self._prime_name_mapper()
+        original = self.name_mapper.get_original(function_name)
+        if original != function_name and original in self.all_tool_dict:
+            return original
+        return None
 
     def run_one_function(
         self, function_call_json, stream_callback=None, use_cache=False, validate=True

--- a/tests/unit/test_tool_name_shortening.py
+++ b/tests/unit/test_tool_name_shortening.py
@@ -117,3 +117,75 @@ class TestMCPCompatibility:
         
         # SMCP should automatically enable name shortening
         assert server.tooluniverse.name_mapper is not None
+
+
+class TestShortenedNameResolution:
+    """Round-tripping a shortened name back to the registered tool.
+
+    MCP clients only ever see the shortened name -- it is what the server
+    advertises -- and call back with it. `ToolNameMapper.resolve()` covers
+    alias->primary and original->short but never short->original, and its
+    short->original index is only populated for names the *same process* has
+    shortened. A client talking to a separately-started server therefore sent a
+    name the mapper had never seen, and every such call failed with
+    "not found even after loading tools".
+    """
+
+    @staticmethod
+    def _universe(names):
+        """A ToolUniverse with a fake registry and no tool loading."""
+        from tooluniverse.execute_function import ToolUniverse
+
+        tu = ToolUniverse.__new__(ToolUniverse)
+        from tooluniverse.tool_name_utils import ToolNameMapper
+
+        tu.name_mapper = ToolNameMapper()
+        tu._name_mapper_primed = False
+        tu.MAX_TOOL_NAME_LENGTH = 45
+        tu.all_tool_dict = {n: {"name": n} for n in names}
+        return tu
+
+    LONG = "OpenTargets_get_diseases_phenotypes_by_target_ensembl"
+
+    def test_shortened_name_resolves_to_registered_name(self):
+        tu = self._universe([self.LONG])
+        short = shorten_tool_name(self.LONG, 45)
+        assert short != self.LONG
+        assert tu._resolve_tool_name(short) == self.LONG
+
+    def test_priming_happens_before_speculative_shortening(self):
+        """resolve() caches a short name as its own original on a miss; if that
+        runs before priming, the real original collides and is pushed to a _2
+        suffix, silently breaking exactly the names that need the round trip."""
+        tu = self._universe([self.LONG])
+        short = shorten_tool_name(self.LONG, 45)
+        tu._resolve_tool_name(short)  # first call must not poison the cache
+        assert tu._resolve_tool_name(short) == self.LONG
+
+    def test_registered_name_is_returned_unchanged(self):
+        tu = self._universe([self.LONG, "ChEMBL_search_mechanisms"])
+        assert tu._resolve_tool_name("ChEMBL_search_mechanisms") == "ChEMBL_search_mechanisms"
+        assert tu._resolve_tool_name(self.LONG) == self.LONG
+
+    def test_unknown_name_is_returned_unchanged(self):
+        tu = self._universe([self.LONG])
+        assert tu._resolve_tool_name("NoSuchToolAtAll") == "NoSuchToolAtAll"
+
+    def test_empty_name_is_returned_unchanged(self):
+        assert self._universe([self.LONG])._resolve_tool_name("") == ""
+
+    def test_priming_is_skipped_for_a_direct_hit(self):
+        """The fast path must not pay for priming."""
+        tu = self._universe(["ChEMBL_search_mechanisms"])
+        tu._resolve_tool_name("ChEMBL_search_mechanisms")
+        assert tu._name_mapper_primed is False
+
+    def test_priming_runs_once(self):
+        tu = self._universe([self.LONG])
+        tu._resolve_tool_name("miss_one")
+        assert tu._name_mapper_primed is True
+        calls = []
+        original = tu.name_mapper.get_shortened
+        tu.name_mapper.get_shortened = lambda *a, **k: (calls.append(1), original(*a, **k))[1]
+        tu._resolve_tool_name("miss_two")
+        assert len(calls) <= 1  # resolve()'s own lookup only, no re-priming

--- a/tests/unit/test_tool_name_shortening.py
+++ b/tests/unit/test_tool_name_shortening.py
@@ -189,3 +189,35 @@ class TestShortenedNameResolution:
         tu.name_mapper.get_shortened = lambda *a, **k: (calls.append(1), original(*a, **k))[1]
         tu._resolve_tool_name("miss_two")
         assert len(calls) <= 1  # resolve()'s own lookup only, no re-priming
+
+
+class TestWholeCatalogueRoundTrip:
+    """Every tool whose MCP name differs from its registered name must resolve.
+
+    96 of 2,602 registered tools (3.7%) are shortened for MCP -- 37 OpenTargets,
+    29 FDA, 12 drugbank. Each was intermittently unreachable: the round trip
+    only worked when the resolving process happened to be the one that did the
+    shortening, which is why 3 of 7 observed calls succeeded and 12 of 15
+    failed.
+    """
+
+    @pytest.mark.slow
+    def test_every_shortened_name_resolves_to_its_registered_name(self):
+        pytest.importorskip("tooluniverse.execute_function")
+        from tooluniverse.execute_function import ToolUniverse
+
+        tu = ToolUniverse()
+        tu.load_tools()
+        if not tu.all_tool_dict:
+            pytest.skip("No tools loaded")
+
+        limit = tu.MAX_TOOL_NAME_LENGTH
+        broken = []
+        for full in tu.all_tool_dict:
+            short = shorten_tool_name(full, limit)
+            if short == full:
+                continue
+            if tu._resolve_tool_name(short) != full:
+                broken.append((short, full))
+
+        assert not broken, f"{len(broken)} shortened names do not resolve: {broken[:5]}"


### PR DESCRIPTION
## Problem

Calling a tool by the name the MCP surface advertises fails:

```
tu.run({'name': 'OpenTargets_get_dise_phen_by_targ_ense', ...})
-> Tool 'OpenTargets_get_dise_phen_by_targ_ense' not found even after loading tools
```

That name is not invented. It is exactly
`shorten_tool_name('OpenTargets_get_diseases_phenotypes_by_target_ensembl', 45)` —
what the server advertises, so a client has no other name to call back with.

`ToolNameMapper.resolve()` covers alias→primary and original→shortened but never
shortened→original, and its reverse index is only populated for names the *same
process* shortened. A client talking to a separately-started server therefore
sends a name that mapper has never seen.

## Scope

**96 of 2,602 registered tools (3.7%)** have an MCP name that differs from their
registered name — 37 OpenTargets, 29 FDA, 12 drugbank. Every one was
intermittently unreachable: the round trip only worked when the resolving
process happened to be the one that did the shortening. That nondeterminism is
why it was never pinned down — in observed traffic, 7 distinct shortened names
were called 15 times and 12 of those failed while 3 succeeded.

## Fix

`_resolve_tool_name()` primes the reverse index from the registry on a miss and
translates.

Priming must happen **before** `resolve()`, not after: `resolve()` caches a short
name as its own original on a miss, and the real original then collides on
priming and is pushed to a `_2` suffix — silently breaking exactly the names that
need the round trip. Direct hits skip priming entirely.

## Verification

- All 96 shortened names now resolve to their registered name (new catalogue-wide
  test, marked `slow` to stay out of the default run per `pytest.ini`).
- `run()` with a shortened name returns data (TP53, 5,638 associated diseases).
- Registered names, unknown names and empty names are unchanged.
- 7 targeted tests including the priming-order regression and that the fast path
  does not pay for priming.
