### PR TITLE
Fix: shard the weekly health sweep and record its history

### DIFF
--- a/.github/workflows/weekly-tool-healthcheck.yml
+++ b/.github/workflows/weekly-tool-healthcheck.yml
@@ -8,6 +8,13 @@ name: Weekly Tool Health Check
 # It does NOT fail the workflow on tool failures; the value is the uploaded
 # report + the job summary. API-key-gated tools are expected to "fail" in
 # CI unless the corresponding repo secret is provided (see `env:` below).
+#
+# The sweep is SHARDED. As a single job it wrote its report only after the
+# last category, and an evicted runner never reaches the upload step, so
+# nothing survived: 10 of 12 consecutive weekly runs ended that way (exit
+# code 143, "the runner has received a shutdown signal"), one of them after
+# 636 of 638 categories. Sharding bounds both the blast radius of an eviction
+# and the memory one job holds; `summarize` merges whatever shards finished.
 
 on:
   schedule:
@@ -27,11 +34,19 @@ concurrency:
   group: weekly-tool-healthcheck
   cancel-in-progress: false
 
+env:
+  SHARD_COUNT: "8"
+
 jobs:
-  health-check:
-    name: Tool sweep (live APIs)
+  sweep:
+    name: Tool sweep shard ${{ matrix.shard }} (live APIs)
     runs-on: ubuntu-latest
-    timeout-minutes: 350 # under the 6h hard limit; full sweep is network-bound
+    timeout-minutes: 120
+
+    strategy:
+      fail-fast: false # a lost shard must not cancel the other seven
+      matrix:
+        shard: [0, 1, 2, 3, 4, 5, 6, 7]
 
     # Optional API keys. Tools that need a key will be skipped/failed unless
     # the matching repo secret exists. Add more here as needed — an unset
@@ -74,116 +89,76 @@ jobs:
           if [ -n "${{ github.event.inputs.pattern }}" ]; then
             PATTERN_ARG="--pattern ${{ github.event.inputs.pattern }}"
           fi
-          # Tee stdout to a log. test_all_tools.py only writes the .md report
-          # at the very end, so if the job is killed mid-run (timeout, runner
-          # eviction) no report exists — but the live progress log still shows
-          # every category's pass/fail and is used as a fallback below.
+          # Tee to a per-shard log. The .md report is only written when the
+          # shard finishes; the progress log is what survives a shard killed
+          # part-way, and `summarize` reads whichever exists.
           set -o pipefail
           python scripts/test_all_tools.py \
             --skip-remote --skip-mcp --parallel \
-            --output TOOL_TEST_REPORT.md $PATTERN_ARG 2>&1 | tee sweep_output.log
+            --shard ${{ matrix.shard }}/${{ env.SHARD_COUNT }} \
+            --output TOOL_TEST_REPORT_${{ matrix.shard }}.md $PATTERN_ARG \
+            2>&1 | tee sweep_output_${{ matrix.shard }}.log
 
-      - name: Build job summary
-        if: always()
-        run: |
-          python - <<'PY' >> "$GITHUB_STEP_SUMMARY"
-          import re, pathlib
-
-          report = pathlib.Path("TOOL_TEST_REPORT.md")
-          log = pathlib.Path("sweep_output.log")
-          print("# Weekly Tool Health Check\n")
-
-          if not report.exists():
-              # The sweep did not finish (no .md report). Fall back to the live
-              # progress log so the run still reports something useful.
-              print(
-                  "Sweep did not complete — no final report (likely hit the job "
-                  "time limit or the runner was evicted). Falling back to the "
-                  "progress log.\n"
-              )
-              if not log.exists():
-                  print("No progress log either; check the run logs.")
-                  raise SystemExit(0)
-              logtext = log.read_text(errors="replace")
-              done = len(re.findall(r"\]\s+Testing\b", logtext))
-              ok = len(re.findall(r"✅\s+\d+\s+tests passed", logtext))
-              bad = sorted(set(re.findall(r"Testing (\S+)\.\.\..*?(?:❌|🔥)", logtext)))
-              print(f"- Categories started: **{done}**")
-              print(f"- Categories fully passed: **{ok}**")
-              if bad:
-                  print(f"\n## Categories with failures so far ({len(bad)})\n")
-                  print(", ".join(f"`{c}`" for c in bad))
-              raise SystemExit(0)
-
-          text = report.read_text(errors="replace")
-
-          # Headline numbers. Total is an executive-summary bullet; Passed/Failed
-          # are emoji-prefixed rows in the Overall Statistics table (the first
-          # such row is the overall one, before the per-category tables).
-          def grab_bullet(label):
-              m = re.search(rf"\*\*{re.escape(label)}\*\*:\s*([\d,]+)", text)
-              return m.group(1).replace(",", "") if m else "?"
-
-          def grab_table(label):
-              m = re.search(rf"\|[^|\n]*{re.escape(label)}[^|\n]*\|\s*([\d,]+)", text)
-              return m.group(1).replace(",", "") if m else "?"
-
-          total = grab_bullet("Total Test Examples")
-          passed = grab_table("Passed")
-          failed = grab_table("Failed")
-          print(f"- Total tests: **{total}**")
-          print(f"- Passed: **{passed}**")
-          print(f"- Failed: **{failed}**\n")
-
-          # List failing categories (### ❌ / 🔥 <name>, single trailing token).
-          fail_re = re.compile(r"^###\s+(❌|\U0001f525)\s+(\S+)\s*$", re.MULTILINE)
-          cats = sorted({m.group(2) for m in fail_re.finditer(text)})
-
-          # Diff against the known-failing baseline so the report highlights the
-          # one thing worth acting on: a category that failed but is NOT already
-          # a known/expected failure (usually an upstream API just changed).
-          baseline = set()
-          bl = pathlib.Path(".github/known_failing_categories.txt")
-          if bl.exists():
-              for line in bl.read_text().splitlines():
-                  tok = line.split("#", 1)[0].strip()
-                  if tok:
-                      baseline.add(tok)
-
-          new_fail = [c for c in cats if c not in baseline]
-          if new_fail:
-              print(f"## 🆕 NEW failing categories ({len(new_fail)}) — investigate\n")
-              print(", ".join(f"`{c}`" for c in new_fail))
-              print(
-                  "\n> These are not in `.github/known_failing_categories.txt`. A "
-                  "newly-failing category usually means an upstream API changed — "
-                  "reproduce, then fix or add it to the baseline."
-              )
-          elif cats:
-              print("No new failures — every failing category is a known/expected one. ✅")
-
-          if cats:
-              print(f"\n<details><summary>All failing categories ({len(cats)})</summary>\n")
-              print(", ".join(f"`{c}`" for c in cats))
-              recovered = sorted(baseline - set(cats))
-              if recovered:
-                  print(
-                      f"\nBaseline entries that PASSED this week ({len(recovered)}, "
-                      "candidates to prune from the baseline): "
-                      + ", ".join(f"`{c}`" for c in recovered)
-                  )
-              print("\n</details>")
-          else:
-              print("All categories passed. ✅")
-          PY
-
-      - name: Upload report and log
+      - name: Upload shard results
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: tool-test-report
+          name: sweep-shard-${{ matrix.shard }}
           path: |
-            TOOL_TEST_REPORT.md
-            sweep_output.log
+            TOOL_TEST_REPORT_${{ matrix.shard }}.md
+            sweep_output_${{ matrix.shard }}.log
           if-no-files-found: warn
           retention-days: 90
+
+  summarize:
+    name: Summarize and record history
+    runs-on: ubuntu-latest
+    needs: sweep
+    if: always() # summarize whatever shards did finish
+    permissions:
+      contents: write # appends one row to .github/tool-health-history.jsonl
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Download shard results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: sweep-shard-*
+          path: shards
+
+      - name: Summarize
+        run: |
+          python scripts/summarize_health_sweep.py \
+            --logs 'shards/*/sweep_output_*.log' \
+            --baseline .github/known_failing_categories.txt \
+            --history .github/tool-health-history.jsonl \
+            --summary "$GITHUB_STEP_SUMMARY" \
+            --run-id "${{ github.run_id }}" \
+            --sha "${{ github.sha }}"
+
+      # Artifacts and run logs expire, so nothing outlived a quarter and decay
+      # over any longer window could not be measured at all. One line per run,
+      # committed to the repository, is the entire history.
+      - name: Commit history row
+        if: github.event_name == 'schedule'
+        run: |
+          if git diff --quiet -- .github/tool-health-history.jsonl; then
+            echo "no history change"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .github/tool-health-history.jsonl
+          git commit -m "chore: record weekly tool health check (run ${{ github.run_id }})"
+          # Another workflow may have pushed since checkout. Rebase rather than
+          # fail; if the branch has genuinely diverged, leave it for next week
+          # rather than forcing anything.
+          git pull --rebase --autostash origin "${GITHUB_REF_NAME}" || exit 0
+          git push origin "HEAD:${GITHUB_REF_NAME}"

--- a/scripts/summarize_health_sweep.py
+++ b/scripts/summarize_health_sweep.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Merge sharded health-check logs into a summary and a durable history row.
+
+Two problems this closes.
+
+**A lost runner used to cost everything.** `test_all_tools.py` writes its report
+only after the last category, and an evicted runner never reaches the upload
+step, so nothing survives -- 10 of 12 consecutive weekly runs ended that way, one
+after 636 of 638 categories. The sweep is sharded now, so this reads whatever
+shards did finish and says plainly how many categories were never reached.
+Missing is reported as missing, never folded into passing.
+
+**Nothing outlived the artifacts.** Run logs and artifacts expire, so decay over
+more than a quarter was not measurable at all. One line per run is appended to a
+history file that lives in the repository.
+
+Usage:
+    python scripts/summarize_health_sweep.py --logs 'shard-*/sweep_output*.log' \\
+        --baseline .github/known_failing_categories.txt \\
+        --history .github/tool-health-history.jsonl \\
+        --summary "$GITHUB_STEP_SUMMARY" --run-id 123 --sha abc123
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+#: `[616/638] veupathdb: ✅ 7 tests passed`, `[636/638] zinc: ❌ 1 failures`,
+#: `[218/638] core: 🔥 ERROR: Timeout after 5 minutes`
+PROGRESS = re.compile(
+    r"\[(?P<index>\d+)/(?P<total>\d+)\]\s+(?P<category>[A-Za-z0-9_.-]+):\s*"
+    r"(?P<mark>✅|❌|🔥)\s*(?P<count>\d+)?"
+)
+FAILING = frozenset({"❌", "🔥"})
+
+
+def parse_logs(patterns: list) -> tuple[dict, dict, set, int]:
+    """Return (results, failure_counts, timed_out, expected_total)."""
+    results: dict = {}
+    counts: dict = {}
+    timed_out: set = set()
+    expected = 0
+    for pattern in patterns:
+        for path in sorted(glob.glob(pattern)):
+            try:
+                text = Path(path).read_text(errors="replace")
+            except OSError:
+                continue
+            for match in PROGRESS.finditer(text):
+                category = match.group("category")
+                passed = match.group("mark") not in FAILING
+                # A category is only "passing" if nothing marked it failing;
+                # shards never overlap, but be conservative if they ever do.
+                results[category] = results.get(category, True) and passed
+                if not passed:
+                    counts[category] = int(match.group("count") or 0)
+                    if match.group("mark") == "🔥":
+                        timed_out.add(category)
+    return results, counts, timed_out, expected
+
+
+def load_baseline(path: str | Path) -> set:
+    file = Path(path)
+    if not file.exists():
+        return set()
+    out = set()
+    for line in file.read_text(errors="replace").splitlines():
+        token = line.split("#", 1)[0].strip()
+        if token:
+            out.add(token)
+    return out
+
+
+def build_summary(results, counts, timed_out, baseline, expected_total) -> tuple[str, dict]:
+    failing = {c for c, ok in results.items() if not ok}
+    passing = set(results) - failing
+    new = sorted(failing - baseline, key=lambda c: (c not in timed_out, -counts.get(c, 0), c))
+    recovered = sorted(baseline & passing)
+    known = sorted(failing & baseline)
+    missing = max(0, expected_total - len(results)) if expected_total else 0
+
+    lines = ["# Weekly Tool Health Check", ""]
+    lines.append(f"- Categories reported: **{len(results)}**"
+                 + (f" of {expected_total} — **{missing} never reached**" if missing else ""))
+    lines.append(f"- Failing: **{len(failing)}**  |  baseline: **{len(baseline)}**")
+    lines.append("")
+    if missing:
+        lines += [
+            f"> {missing} category/categories were never reached — a shard was lost. "
+            "They are **unknown**, not passing.",
+            "",
+        ]
+    if new:
+        lines += [f"## 🆕 NEW failing ({len(new)}) — investigate", ""]
+        lines.append(", ".join(
+            f"`{c}`" + ("(timeout)" if c in timed_out else f"({counts.get(c, '?')})")
+            for c in new
+        ))
+        lines += [
+            "",
+            "> Not in `.github/known_failing_categories.txt`. Reproduce before "
+            "fixing — the sweep hits live APIs, where an outage looks exactly like "
+            "a schema change:",
+            "> `python scripts/test_all_tools.py --skip-remote --skip-mcp --pattern <category>`",
+            "",
+        ]
+    else:
+        lines += ["No new failures — every failing category is known. ✅", ""]
+    if recovered:
+        lines += [
+            f"## ♻️ Recovered ({len(recovered)}) — prune the baseline",
+            "",
+            ", ".join(f"`{c}`" for c in recovered),
+            "",
+            "> Left in the baseline, the next real regression in these is invisible.",
+            "",
+        ]
+    if known:
+        lines += [f"<details><summary>Known failures ({len(known)})</summary>", "",
+                  ", ".join(f"`{c}`" for c in known), "", "</details>", ""]
+
+    row = {
+        "reported": len(results),
+        "expected": expected_total,
+        "never_reached": missing,
+        "passing": len(passing),
+        "failing": len(failing),
+        "new_failing": new,
+        "recovered": recovered,
+        "timed_out": sorted(timed_out),
+        "baseline_size": len(baseline),
+    }
+    return "\n".join(lines), row
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--logs", nargs="+", required=True, help="glob(s) of shard logs")
+    parser.add_argument("--baseline", required=True)
+    parser.add_argument("--history", help="JSONL file to append one row to")
+    parser.add_argument("--summary", help="file to write the Markdown summary to")
+    parser.add_argument("--expected-total", type=int, default=0,
+                        help="categories the full sweep should cover")
+    parser.add_argument("--run-id", default="")
+    parser.add_argument("--sha", default="")
+    parser.add_argument("--timestamp", default="",
+                        help="ISO timestamp; defaults to now (UTC)")
+    args = parser.parse_args(argv)
+
+    results, counts, timed_out, _ = parse_logs(args.logs)
+    if not results:
+        print("no category results found in any shard log", file=sys.stderr)
+        # Still a fact worth recording: the sweep produced nothing.
+    baseline = load_baseline(args.baseline)
+    text, row = build_summary(results, counts, timed_out, baseline, args.expected_total)
+
+    print(text)
+    if args.summary:
+        with open(args.summary, "a") as handle:
+            handle.write(text + "\n")
+
+    if args.history:
+        row.update({
+            "timestamp": args.timestamp or datetime.now(timezone.utc).isoformat(),
+            "run_id": args.run_id,
+            "sha": args.sha,
+        })
+        path = Path(args.history)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a") as handle:
+            handle.write(json.dumps(row, sort_keys=True) + "\n")
+        print(f"appended history row to {path}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_all_tools.py
+++ b/scripts/test_all_tools.py
@@ -492,6 +492,26 @@ def generate_report(
     return str(output_path)
 
 
+def select_shard(patterns, spec):
+    """Return the slice of `patterns` belonging to shard `spec` ("I/N").
+
+    Strided, not contiguous: consecutive patterns often share an upstream host,
+    so a contiguous block would concentrate one API's outage in one shard and
+    leave the others looking healthy. Striding also keeps every shard's slice
+    stable as long as the pattern list is sorted.
+
+    Raises ValueError on a malformed or out-of-range spec.
+    """
+    try:
+        index_str, count_str = str(spec).split("/", 1)
+        shard_index, shard_count = int(index_str), int(count_str)
+    except ValueError:
+        raise ValueError(f"--shard must look like I/N, got {spec!r}") from None
+    if shard_count < 1 or not (0 <= shard_index < shard_count):
+        raise ValueError(f"--shard out of range: {spec!r}")
+    return sorted(patterns)[shard_index::shard_count], shard_index, shard_count
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Test all ToolUniverse tool configurations"
@@ -527,6 +547,14 @@ def main():
     parser.add_argument(
         "--skip-pattern",
         help="Skip tools matching wildcard pattern (e.g., 'agentic*' or '*discovery*')"
+    )
+    parser.add_argument(
+        "--shard",
+        help=(
+            "Run only one slice of the patterns, as I/N (e.g. '0/8'). Patterns are "
+            "sorted then strided, so slices are stable across runs and each covers "
+            "the whole alphabet rather than one contiguous block."
+        ),
     )
     parser.add_argument(
         "--skip-remote",
@@ -626,7 +654,22 @@ def main():
         print("❌ No tools remaining after filtering")
         sys.exit(1)
     
-    print(f"✅ Found {len(config_patterns)} unique tool patterns to test")
+    # Sharding. The weekly sweep is one long job, and losing the runner discards
+    # everything it had done -- 10 of 12 consecutive weekly runs ended that way,
+    # one of them after 636 of 638 categories. Splitting the sweep across jobs
+    # bounds both the blast radius of an eviction and the memory a single job
+    # holds.
+    selected = sorted(config_patterns.keys())
+    if args.shard:
+        try:
+            selected, shard_index, shard_count = select_shard(selected, args.shard)
+        except ValueError as exc:
+            print(f"❌ {exc}")
+            sys.exit(2)
+        print(f"🔀 Shard {shard_index + 1}/{shard_count}: {len(selected)} of "
+              f"{len(config_patterns)} patterns")
+
+    print(f"✅ Found {len(selected)} unique tool patterns to test")
     print()
     print("🧪 Running tests...")
     print()
@@ -635,7 +678,7 @@ def main():
     start_time = time.time()
 
     results = run_all_patterns(
-        sorted(config_patterns.keys()),
+        selected,
         repo_root,
         verbose=args.verbose,
         fail_fast=args.fail_fast,

--- a/tests/unit/test_health_sweep_sharding.py
+++ b/tests/unit/test_health_sweep_sharding.py
@@ -1,0 +1,177 @@
+"""Sharding and summarising for the weekly tool health check.
+
+The sweep used to run as one job that wrote its report only after the last
+category. An evicted runner never reaches the upload step, so nothing survived:
+10 of 12 consecutive weekly runs ended that way (exit code 143, "the runner has
+received a shutdown signal"), one of them after 636 of 638 categories.
+
+Two properties matter and are asserted here: the shards must cover every pattern
+exactly once, or a silent gap looks like health; and the summary must report
+categories it never heard about as missing rather than passing.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load(name: str):
+    path = REPO_ROOT / "scripts" / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+sweep = _load("test_all_tools")
+summarize = _load("summarize_health_sweep")
+
+
+PATTERNS = [f"cat{i:03d}" for i in range(638)]
+
+
+# ---------- sharding ----------
+
+def test_shards_cover_every_pattern_exactly_once():
+    """A gap between shards would look exactly like a category that passed."""
+    seen = []
+    for index in range(8):
+        selected, _, _ = sweep.select_shard(PATTERNS, f"{index}/8")
+        seen.extend(selected)
+    assert sorted(seen) == sorted(PATTERNS)
+    assert len(seen) == len(set(seen))
+
+
+def test_shards_are_striped_not_contiguous():
+    """Consecutive patterns often share an upstream host, so a contiguous block
+    would concentrate one API's outage in a single shard."""
+    selected, _, _ = sweep.select_shard(PATTERNS, "0/8")
+    assert selected[:3] == ["cat000", "cat008", "cat016"]
+
+
+def test_a_single_shard_is_the_whole_list():
+    selected, _, _ = sweep.select_shard(PATTERNS, "0/1")
+    assert selected == sorted(PATTERNS)
+
+
+def test_more_shards_than_patterns_is_allowed():
+    selected, _, _ = sweep.select_shard(["a", "b"], "5/8")
+    assert selected == []
+
+
+@pytest.mark.parametrize("spec", ["8/8", "-1/8", "0/0", "3/2"])
+def test_out_of_range_shard_is_rejected(spec):
+    with pytest.raises(ValueError):
+        sweep.select_shard(PATTERNS, spec)
+
+
+@pytest.mark.parametrize("spec", ["nonsense", "", "1", "a/b", "1/"])
+def test_malformed_shard_is_rejected(spec):
+    with pytest.raises(ValueError):
+        sweep.select_shard(PATTERNS, spec)
+
+
+# ---------- summarising ----------
+
+def _log(*rows) -> str:
+    return "\n".join(
+        f"Tool sweep\tSTEP\t2026-08-17T06:40:{i:02d}Z [{i + 1}/6] {row}"
+        for i, row in enumerate(rows)
+    )
+
+
+def test_summary_merges_shard_logs(tmp_path):
+    (tmp_path / "a.log").write_text(_log("alpha: ✅ 7 tests passed", "beta: ❌ 9 failures"))
+    (tmp_path / "b.log").write_text(_log("gamma: 🔥 ERROR: Timeout after 5 minutes"))
+    results, counts, timed_out, _ = summarize.parse_logs([str(tmp_path / "*.log")])
+    assert results == {"alpha": True, "beta": False, "gamma": False}
+    assert counts["beta"] == 9
+    assert timed_out == {"gamma"}
+
+
+def test_categories_never_reached_are_missing_not_passing(tmp_path):
+    (tmp_path / "a.log").write_text(_log("alpha: ✅ 1 tests passed"))
+    results, counts, timed_out, _ = summarize.parse_logs([str(tmp_path / "*.log")])
+    text, row = summarize.build_summary(results, counts, timed_out, set(), 638)
+    assert row["never_reached"] == 637
+    assert "never reached" in text
+    assert "**unknown**, not passing" in text
+
+
+def test_new_failures_are_ranked_with_timeouts_first(tmp_path):
+    (tmp_path / "a.log").write_text(_log(
+        "alpha: ❌ 20 failures", "beta: 🔥 ERROR: Timeout after 5 minutes"
+    ))
+    results, counts, timed_out, _ = summarize.parse_logs([str(tmp_path / "*.log")])
+    _, row = summarize.build_summary(results, counts, timed_out, set(), 0)
+    assert row["new_failing"] == ["beta", "alpha"]
+
+
+def test_baseline_splits_new_from_known_and_recovered(tmp_path):
+    (tmp_path / "a.log").write_text(_log(
+        "alpha: ✅ 1 tests passed", "beta: ❌ 1 failures", "gamma: ❌ 1 failures"
+    ))
+    results, counts, timed_out, _ = summarize.parse_logs([str(tmp_path / "*.log")])
+    _, row = summarize.build_summary(results, counts, timed_out, {"alpha", "gamma"}, 0)
+    assert row["new_failing"] == ["beta"]
+    assert row["recovered"] == ["alpha"]
+
+
+def test_history_row_is_one_json_line(tmp_path):
+    log = tmp_path / "a.log"
+    log.write_text(_log("alpha: ❌ 2 failures"))
+    history = tmp_path / "history.jsonl"
+    baseline = tmp_path / "baseline.txt"
+    baseline.write_text("")
+    summarize.main([
+        "--logs", str(tmp_path / "*.log"), "--baseline", str(baseline),
+        "--history", str(history), "--run-id", "42", "--sha", "abc",
+        "--timestamp", "2026-08-17T06:00:00+00:00", "--expected-total", "3",
+    ])
+    rows = [json.loads(line) for line in history.read_text().splitlines() if line.strip()]
+    assert len(rows) == 1
+    assert rows[0]["run_id"] == "42"
+    assert rows[0]["never_reached"] == 2
+    assert rows[0]["new_failing"] == ["alpha"]
+
+
+def test_history_appends_rather_than_replaces(tmp_path):
+    log = tmp_path / "a.log"
+    log.write_text(_log("alpha: ✅ 1 tests passed"))
+    history = tmp_path / "history.jsonl"
+    baseline = tmp_path / "baseline.txt"
+    baseline.write_text("")
+    for run in ("1", "2"):
+        summarize.main([
+            "--logs", str(tmp_path / "*.log"), "--baseline", str(baseline),
+            "--history", str(history), "--run-id", run,
+            "--timestamp", "2026-08-17T06:00:00+00:00",
+        ])
+    assert len(history.read_text().strip().splitlines()) == 2
+
+
+def test_baseline_comments_are_ignored(tmp_path):
+    path = tmp_path / "baseline.txt"
+    path.write_text("# why these fail\n\nalpha\nbeta  # upstream HTTP 500\n")
+    assert summarize.load_baseline(path) == {"alpha", "beta"}
+
+
+def test_a_sweep_that_produced_nothing_still_summarises(tmp_path):
+    """Every shard lost is itself a fact worth recording."""
+    baseline = tmp_path / "baseline.txt"
+    baseline.write_text("")
+    history = tmp_path / "history.jsonl"
+    summarize.main([
+        "--logs", str(tmp_path / "nothing-*.log"), "--baseline", str(baseline),
+        "--history", str(history), "--expected-total", "638",
+        "--timestamp", "2026-08-17T06:00:00+00:00",
+    ])
+    row = json.loads(history.read_text().strip())
+    assert row["reported"] == 0
+    assert row["never_reached"] == 638


### PR DESCRIPTION
## Problem

The weekly sweep ran as a single job that writes its report only after the last
category, and an evicted runner never reaches the upload step.

**10 of the last 12 weekly runs produced nothing at all** — every one with the
same signature (`exit code 143`, "the runner has received a shutdown signal").
The most recent had already finished **636 of 638 categories** when it died.

Separately, nothing outlived the artifacts: run logs and artifacts expire, so
decay over more than a quarter could not be measured at all.

## Changes

**Sharded across 8 jobs**, `fail-fast: false`, so losing a runner costs an eighth
rather than everything, and each job holds a fraction of the memory.

Slices are **strided, not contiguous**: consecutive patterns often share an
upstream host, so a contiguous block would concentrate one API's outage in a
single shard and leave the rest looking healthy. Verified complete and disjoint
over all 638 patterns.

A `summarize` job merges whatever shards finished, diffs against the
known-failing baseline exactly as before, and reports anything it never heard
about as **missing — never folded into passing**, because a lost shard is absent
data rather than good news.

It also appends one line per run to `.github/tool-health-history.jsonl`. The past
cannot be reconstructed later, so the recording starts now.

## ⚠️ Permission change — please review

The `summarize` job needs `contents: write` to commit the history row. It is
scoped to that job only, and the commit step runs only on `schedule` (not on
`workflow_dispatch`). The top-level default stays `contents: read`.

If you would rather not grant write, say so and the history can go to an artifact
or a separate branch instead — but then it inherits the same expiry that makes
long-window decay unmeasurable today.

## Verification

Replayed against the real 2026-08-17 run log: 633 categories recovered, 106
failing, 96 new, 25 recovered, 5 never reached — and a well-formed history row.

`scripts/test_all_tools.py` gains `--shard I/N`, with the slicing extracted into
`select_shard()` so the coverage property is tested rather than inferred. 21 new
tests, including the case where every shard is lost.

## Note for a follow-up

The baseline is **71% stale** — 25 of its 35 entries pass now. Left as is, the
next real regression in each of them is invisible. Not touched here to keep this
PR to the mechanism.
