### PR TITLE
Add runnable case-study reproductions, and fix the three analysis tools they depend on

### DIFF
--- a/examples/case_studies/.gitignore
+++ b/examples/case_studies/.gitignore
@@ -1,0 +1,6 @@
+# Trial tables fetched by download_bcg_data.py (~4 MB, CC0, Zenodo 12737228).
+# Downloaded on demand rather than vendored.
+data/
+
+__pycache__/
+*.pyc

--- a/examples/case_studies/README.md
+++ b/examples/case_studies/README.md
@@ -1,0 +1,242 @@
+# Case studies: setup and reproduction
+
+Runnable versions of the three case studies in
+[Use Cases: Target Assessment, Druggability, and a Clinical Trial Reanalysis](https://aiscientist.tools/posts/tooluniverse-case-studies).
+
+Each script makes the same tool calls, in the same order, that the AI scientist
+made in the post, and prints the published value next to the one it just
+retrieved, so a run tells you either "this still reproduces" or exactly which
+number moved.
+
+The post reports headline numbers; the supplementary note it condenses
+("Step-by-step real-world case studies", in the ToolUniverse manuscript,
+[arXiv:2509.23426](https://arxiv.org/abs/2509.23426)) reports the intermediate
+ones. Both are annotated as `published:` here, so several values these scripts
+check — ACMG scores, PDB accessions, per-context DepMap effects, PubChem CIDs —
+are found in the supplementary note rather than in the post itself.
+
+| Case | Question | Script |
+|---|---|---|
+| 1 | Is *BLM* a context-selective anticancer target, and is ML216 a developable lead? | [`case1_blm_target_assessment.py`](case1_blm_target_assessment.py) |
+| 2 | Is *OXTR* druggable, and does its chemistry fit the autism hypothesis? | [`case2_oxtr_druggability.py`](case2_oxtr_druggability.py) |
+| 3 | Is BCG vaccination associated with higher adverse-event severity? | [`case3_bcg_ae_severity.py`](case3_bcg_ae_severity.py) |
+
+Cases 1 and 2 read live databases, so their numbers drift as those databases are
+re-released. Case 3 runs on a frozen public dataset and reproduces exactly.
+
+## Setup
+
+```bash
+python -m venv .venv && source .venv/bin/activate    # or: uv venv .venv
+pip install 'tooluniverse[ml]'                       # ml extra = ADMET-AI models
+
+git clone https://github.com/mims-harvard/ToolUniverse.git
+cd ToolUniverse/examples/case_studies
+pip install -r requirements.txt
+```
+
+No API keys are needed. Every database used here (Open Targets, ClinVar, GeneBe,
+AlphaFold, PDBe, Europe PMC, PubChem, ChEMBL) is open, and ADMET-AI runs
+locally.
+
+Two things worth knowing:
+
+- Without the **`ml` extra**, the ADMET-AI steps in Cases 1 and 2 report
+  `ADMETModel requires 'admet-ai' package`. The rest of both cases still runs.
+- Case 3 calls `clinical_trial_ae_severity_test`, and that tool loads its
+  implementation from the repository's `skills/` directory, resolved relative
+  to the repo root. Outside a git clone it reports
+  `Skill script not available`. The script therefore falls back to
+  [`scripts/prepare_ae_cohort.py`](scripts/prepare_ae_cohort.py), bundled here,
+  and prints which path it took. Both give identical results, on pandas 2 and
+  pandas 3 alike:
+
+  ```
+  (running via: tool)             # git clone
+  (running via: bundled script)   # pip install
+  ```
+
+## Running
+
+```bash
+cd examples/case_studies
+
+python case1_blm_target_assessment.py     # ~2 min, mostly ADMET-AI model load
+python case2_oxtr_druggability.py         # ~2 min
+
+python download_bcg_data.py               # ~4 MB from Zenodo, CC0
+python case3_bcg_ae_severity.py           # seconds
+```
+
+Cases 1 and 2 load 11 tool categories (146 tools) rather than the full ~2,700,
+and Case 3 loads a single category, which keeps startup to a few seconds.
+
+## What each case does
+
+### Case 1 — *BLM* as a cancer risk gene and a possible target
+
+Seven steps, ending in a conclusion neither half of the evidence supports on its
+own. The germline genetics say *BLM* is a tumour suppressor to preserve; the
+DepMap dependency screen says it is a selective vulnerability in a few defined
+cancer contexts. The case holds both and concludes with a testable,
+biomarker-defined hypothesis rather than a target.
+
+Tools: `OpenTargets_multi_entity_search_by_query_string`,
+`OpenTargets_get_target_gene_ontology_by_ensemblID`,
+`OpenTargets_get_diseases_phenotypes_by_target_ensembl`,
+`ClinVar_search_variants`, `GeneBe_classify_variant`,
+`OpenTargets_get_target_depmap_essentiality`, `alphafold_get_summary`,
+`PDBe_get_uniprot_structure_coverage`, `EuropePMC_search_articles`,
+`OpenTargets_get_chemical_probes_by_target_ensemblID`,
+`PubChem_get_CID_by_compound_name`, `PubChem_get_compound_properties_by_CID`,
+`ADMETAI_predict_physicochemical_properties`, `ADMETAI_predict_toxicity`,
+`ChEMBL_search_similar_molecules`.
+
+### Case 2 — *OXTR* druggability and whether the chemistry fits
+
+Six steps. The target passes every druggability check: experimental structures
+in both the active and inactive states, nanomolar ligands, known agonists and
+antagonists. The case turns on the last step, where nolasiban — drug-like and
+predicted brain-penetrant, so a plausible repurposing candidate — turns out to
+be an *antagonist*, the opposite of the mechanism a pro-social hypothesis needs.
+
+Tools: `OpenTargets_multi_entity_search_by_query_string`,
+`OpenTargets_get_target_gene_ontology_by_ensemblID`, `alphafold_get_summary`,
+`PDBe_get_uniprot_structure_coverage`,
+`OpenTargets_get_diseases_phenotypes_by_target_ensembl`,
+`OpenTargets_get_target_tractability_by_ensemblID`,
+`OpenTargets_get_associated_drugs_by_target_ensemblID`,
+`OpenTargets_get_drug_mechanisms_of_action_by_chemblId`, `ChEMBL_search_targets`,
+`ChEMBL_get_target_activities`, `EuropePMC_search_articles`,
+`PubChem_get_CID_by_compound_name`, `PubChem_get_compound_properties_by_CID`,
+`ADMETAI_predict_physicochemical_properties`, `ADMETAI_predict_BBB_penetrance`.
+
+### Case 3 — BCG vaccination and adverse-event severity
+
+One tool, `clinical_trial_ae_severity_test`, in three modes:
+
+1. `prepare` — inner-join the adverse-event table onto demographics on
+   `USUBJID`, reduce each subject to their maximum `AESEV` grade.
+2. `chi-square` — unadjusted treatment-by-severity association.
+3. `ordinal` — proportional-odds logistic regression adjusting for
+   patient-interaction frequency (`patients_seen`, `expect_interact`,
+   `work_hours`).
+
+Data: [BCG-CORONA trial, Zenodo record 12737228](https://zenodo.org/records/12737228),
+CC0-1.0. `download_bcg_data.py` fetches it.
+
+One detail the script handles for you: the tool reports the odds ratio against
+its own reference level. Treatment is encoded alphabetically (BCG=0,
+Placebo=1), so the raw OR of **0.65** is Placebo vs BCG, and the published
+**1.53** is its reciprocal. Reporting the raw number as though it were the
+BCG effect would invert the finding.
+
+## Expected output
+
+Verified on 2026-08-17 against a fresh clone. Rows marked † are reported in the
+supplementary note rather than in the post.
+
+**Case 1** — every published value reproduced:
+
+| Value | Published | Observed |
+|---|---|---|
+| *BLM* Ensembl gene | ENSG00000197299 | ENSG00000197299 |
+| Disease associations | 464 | 464 |
+| `c.520C>T` ACMG class | Pathogenic | Pathogenic |
+| † ACMG score / transcript | 12 / NM_000057.4 | 12 / NM_000057.4 |
+| DepMap cell lines | 1,258 | 1,258 |
+| † Mean gene effect | −0.18 | −0.18 |
+| † Lines dependent at < −0.5 | 94/1,258 (7.5%) | 94/1,258 (7.5%) |
+| † Mature T/NK neoplasms | −0.47 (n=8) | −0.47 (n=8) |
+| † Cutaneous SCC | −0.44 (n=5) | −0.44 (n=5) |
+| † Peripheral nervous system | −0.33 (n=48) | −0.33 (n=48) |
+| † AlphaFold model / length | AF-P54132-F1 / 1,417 | AF-P54132-F1 / 1,417 |
+| † Helicase-core PDB entries | 7AUC, 4CGZ, 4O3M | all present |
+| ML216 MW | 383 Da | 383.3 |
+| † ML216 PubChem CID | 49852229 | 49852229 |
+| QED / DILI / hERG / AMES | 0.66 / 0.99 / 0.56 / 0.16 | 0.657 / 0.988 / 0.564 / 0.160 |
+
+**Case 2** — reproduced except the association count:
+
+| Value | Published | Observed |
+|---|---|---|
+| *OXTR* Ensembl gene | ENSG00000180914 | ENSG00000180914 |
+| Structures 7RYC / 6TPK | present | present |
+| † Structure 7QVM, AF-P30559-F1, length 389 | present / 389 | present / 389 |
+| Disease associations | 393 | **465** (drift, see below) |
+| Known agents | 9 | 9 |
+| oxytocin / atosiban mechanism | agonist / antagonist | AGONIST / ANTAGONIST |
+| † nolasiban CID | 52947354 | 52947354 |
+| nolasiban QED / BBB | 0.87 / 0.93 | 0.872 / 0.925 |
+| nolasiban mechanism | antagonist | ANTAGONIST |
+
+**Case 3** — exact:
+
+| Value | Published | Observed |
+|---|---|---|
+| Evaluable subjects | 791 | 791 |
+| † Severity distribution | {1:328, 2:402, 3:43, 4:18} | identical |
+| Chi-square / dof / p | 10.12 / 3 / 0.018 | 10.12 / 3 / 0.018 |
+| Adjusted OR (95% CI) | 1.53 (1.16–2.01) | 1.53 (1.16–2.01) |
+| p | 0.0024 | 0.0024 |
+
+## Why numbers drift, and which ones should not
+
+- **Live database counts move.** *OXTR* disease associations were 393 when the
+  post was written and are 465 now; Open Targets re-scores associations every
+  release. The *BLM* count happens to be unchanged. Treat these as
+  release-dependent, not as reproduction failures. The conclusions do not rest
+  on them.
+- **Stereochemistry changes ADMET-AI scores.** The scripts request PubChem's
+  `SMILES` property (which carries stereochemistry) and fall back to
+  `ConnectivitySMILES`. For nolasiban the flat form scores BBB 0.913 and the
+  stereo form 0.925; the published 0.93 is the stereo form. ML216 has no
+  stereocentre, so both agree.
+- **Case 3 should never drift.** Frozen dataset, deterministic model, and
+  identical output whether it runs through the tool or the bundled script, on
+  pandas 2 or 3. If its numbers move, something in the environment changed.
+- **ChEMBL's data API is down upstream.** Throughout verification
+  `https://www.ebi.ac.uk/chembl/api/data/` failed on every request, in two
+  modes: HTTP 500 after ~5 s, or no response at all. The fault is specific to
+  that one service. Sampling five times each from the same machine:
+
+  | Endpoint | Result |
+  |---|---|
+  | `/chembl/api/data/…` (ChEMBL data API) | 0/5 ok, avg 7.9 s, 500s and timeouts |
+  | `/chembl/api/utils/…` (ChEMBL Beaker) | 5/5 ok, 0.4 s |
+  | `/chembl/interface_api/…` (powers the ChEMBL website) | 5/5 ok, 0.5 s |
+  | `/pdbe/api/…` | 5/5 ok, 0.4 s |
+  | `/europepmc/webservices/…` | 5/5 ok, 0.5 s |
+
+  Sibling services under the same prefix on the same host are healthy, so this
+  is neither a network problem nor a ToolUniverse one: the base URL in
+  `src/tooluniverse/chem_tool.py` is correct, the service behind it is not
+  answering. It is a known upstream fault, reported in
+  [chembl_webresource_client#144](https://github.com/chembl/chembl_webresource_client/issues/144)
+  (open since 2026-06-23, no maintainer response). That report's workaround —
+  appending any query parameter — no longer helps, so the service has degraded
+  further since it was filed. Note the ChEMBL website stays up during this,
+  because it runs on `interface_api` rather than the data API, so the outage is
+  easy to miss.
+
+  Consequently the two steps that depend on ChEMBL — Case 1's five-analog DILI
+  comparison and Case 2's measured-affinity lookup — are the only ones **not**
+  confirmed end-to-end against the live service. Their response parsing was
+  written against the tool implementations in `src/tooluniverse/chem_tool.py`
+  and checked on replayed payloads, but the published values (DILI 0.987-0.992;
+  Ki as low as 3.2 nM) have not been re-observed. Both scripts report the step
+  as unavailable and carry on rather than aborting. Check whether the service is
+  back with:
+  ```bash
+  curl -o /dev/null -w '%{http_code}\n' https://www.ebi.ac.uk/chembl/api/data/status.json
+  ```
+
+## Source
+
+The narrative and the step-by-step tool sequences come from the
+[case-studies post](https://aiscientist.tools/posts/tooluniverse-case-studies),
+which condenses the supplementary note "Step-by-step real-world case studies"
+in the ToolUniverse manuscript,
+[arXiv:2509.23426](https://arxiv.org/abs/2509.23426). Companion posts cover the
+[LAB-Bench benchmark](https://aiscientist.tools/posts/labbench-benchmark) and the
+[Tool Finder retrieval benchmark](https://aiscientist.tools/posts/tool-finder-benchmark).

--- a/examples/case_studies/README.md
+++ b/examples/case_studies/README.md
@@ -237,6 +237,4 @@ The narrative and the step-by-step tool sequences come from the
 [case-studies post](https://aiscientist.tools/posts/tooluniverse-case-studies),
 which condenses the supplementary note "Step-by-step real-world case studies"
 in the ToolUniverse manuscript,
-[arXiv:2509.23426](https://arxiv.org/abs/2509.23426). Companion posts cover the
-[LAB-Bench benchmark](https://aiscientist.tools/posts/labbench-benchmark) and the
-[Tool Finder retrieval benchmark](https://aiscientist.tools/posts/tool-finder-benchmark).
+[arXiv:2509.23426](https://arxiv.org/abs/2509.23426).

--- a/examples/case_studies/_common.py
+++ b/examples/case_studies/_common.py
@@ -1,0 +1,95 @@
+"""Shared helpers for the three case-study reproduction scripts.
+
+Keeps the case-study scripts readable: they should read as the ordered list of
+tool calls the AI scientist made, not as plumbing.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable
+
+from tooluniverse import ToolUniverse
+
+# Loading all ~2,700 tools takes a while and none of the case studies need more
+# than these categories. Together they supply every tool the three cases call.
+CASE_STUDY_CATEGORIES = [
+    "opentarget",
+    "clinvar",
+    "genebe",
+    "alphafold",
+    "pdbe_graph",
+    "pubchem",
+    "admetai",
+    "ChEMBL",
+    "compose",
+    "EuropePMC",
+    "clinical_trial_stats",
+]
+
+
+def load_universe(categories: Iterable[str] | None = None) -> ToolUniverse:
+    """Return a ToolUniverse with just the categories the case studies need."""
+    tu = ToolUniverse()
+    tu.load_tools(list(categories or CASE_STUDY_CATEGORIES))
+    return tu
+
+
+def call(tu: ToolUniverse, tool_name: str, /, **arguments: Any) -> Any:
+    """Run one tool and return its payload, unwrapping the status envelope.
+
+    Tools return either ``{"status": "success", "data": ...}`` or a bare value.
+    Errors are returned rather than raised so a single unavailable upstream
+    service does not abort the whole case study.
+
+    ``tool_name`` is positional-only so that tools taking a ``name`` argument
+    (e.g. ``PubChem_get_CID_by_compound_name``) can still be called as
+    ``call(tu, "...", name="ML216")``.
+    """
+    result = tu.run({"name": tool_name, "arguments": arguments})
+    if isinstance(result, dict):
+        if result.get("status") == "error":
+            return {"__error__": result.get("error", "unknown error")}
+        if "data" in result and result.get("status") == "success":
+            return result["data"]
+    return result
+
+
+def is_error(payload: Any) -> bool:
+    return isinstance(payload, dict) and "__error__" in payload
+
+
+def step(number: int | str, title: str) -> None:
+    print(f"\n[{number}] {title}")
+    print("-" * 72)
+
+
+def report(label: str, observed: Any, published: Any = None) -> None:
+    """Print one observed value, and the published value when there is one."""
+    if published is None:
+        print(f"  {label}: {observed}")
+    else:
+        print(f"  {label}: {observed}   (published: {published})")
+
+
+def note_unavailable(tool: str, payload: Any) -> None:
+    """Report a step that could not run, without dumping an HTML error page."""
+    message = " ".join(str(payload["__error__"]).split())
+    if len(message) > 160:
+        message = message[:160] + " ..."
+    print(f"  [unavailable] {tool}: {message}")
+    print("  This step depends on a live external service; see README.md.")
+
+
+def header(title: str, question: str) -> None:
+    print("=" * 72)
+    print(title)
+    print("=" * 72)
+    print(f"Question: {question}")
+
+
+def footer(lines: Dict[str, str]) -> None:
+    print("\n" + "=" * 72)
+    print("Result")
+    print("=" * 72)
+    for key, value in lines.items():
+        print(f"  {key}: {value}")

--- a/examples/case_studies/case1_blm_target_assessment.py
+++ b/examples/case_studies/case1_blm_target_assessment.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+"""Case 1: Is BLM a context-selective anticancer target, and is ML216 developable?
+
+Reproduces the first case study from
+https://aiscientist.tools/posts/tooluniverse-case-studies
+
+The steps below are the tool calls in the order the AI scientist made them.
+Every number printed with a "(published: ...)" annotation is one that appears
+either in the post or in the supplementary note it condenses (arXiv:2509.23426),
+so a run either reproduces the published values or shows exactly where it
+drifted. Intermediate values such as ACMG scores, PDB accessions, per-context
+DepMap effects and PubChem CIDs come from the supplementary note.
+
+Run:
+    python case1_blm_target_assessment.py
+
+Needs network access; no API keys. Step 7 needs the ``ml`` extra
+(``pip install 'tooluniverse[ml]'``) for the ADMET-AI models.
+"""
+
+from __future__ import annotations
+
+from _common import (
+    call,
+    footer,
+    header,
+    is_error,
+    load_universe,
+    note_unavailable,
+    report,
+    step,
+)
+
+BLM_ENSEMBL = "ENSG00000197299"
+BLM_UNIPROT = "P54132"
+# BLM c.520C>T (p.Gln174Ter), GRCh38.
+VARIANT = {"chr": "chr15", "pos": 90749788, "ref": "C", "alt": "T", "genome": "hg38"}
+
+
+def main() -> None:
+    header(
+        "Case 1: BLM as a cancer risk gene and a possible target",
+        "BLM loss-of-function predisposes to cancer by compromising genome "
+        "maintenance.\n          Is BLM nevertheless a context-selective "
+        "anticancer target, and is its\n          inhibitor ML216 a developable lead?",
+    )
+    tu = load_universe()
+
+    # ------------------------------------------------------------------
+    step(1, "Resolve and annotate the gene")
+    search = call(
+        tu,
+        "OpenTargets_multi_entity_search_by_query_string",
+        queryString="BLM",
+        entityNames=["target"],
+    )
+    hits = search.get("search", {}).get("hits", []) if not is_error(search) else []
+    ensembl = next((h["id"] for h in hits if h.get("entity") == "target"), None)
+    report("BLM Ensembl gene", ensembl, BLM_ENSEMBL)
+
+    go = call(
+        tu, "OpenTargets_get_target_gene_ontology_by_ensemblID", ensemblId=BLM_ENSEMBL
+    )
+    if not is_error(go):
+        terms = go.get("target", {}).get("geneOntology", [])
+        labels = [(t.get("term", {}).get("label") or "").lower() for t in terms]
+        repair = [
+            label
+            for label in labels
+            if "repair" in label or "helicase" in label or "recombination" in label
+        ]
+        report("GO terms returned", len(terms))
+        report("of which DNA-repair / helicase / recombination", len(repair))
+        for label in sorted(set(repair))[:4]:
+            print(f"    - {label}")
+        print("  Read: a genome-maintenance helicase, i.e. the kind of gene whose")
+        print("  loss promotes tumours, so the genetics counsel caution about")
+        print("  inhibiting it rather than support it.")
+
+    # ------------------------------------------------------------------
+    step(2, "Quantify the cancer-risk genetics")
+    diseases = call(
+        tu,
+        "OpenTargets_get_diseases_phenotypes_by_target_ensembl",
+        ensemblId=BLM_ENSEMBL,
+    )
+    if not is_error(diseases):
+        rows = (
+            diseases.get("target", {}).get("associatedDiseases", {}).get("rows", [])
+            or []
+        )
+        count = diseases.get("target", {}).get("associatedDiseases", {}).get("count")
+        report("disease associations", count, "464")
+        if rows:
+            report("top association", rows[0].get("disease", {}).get("name"))
+
+    # ------------------------------------------------------------------
+    step(3, "Classify the patient's variant")
+    clinvar = call(tu, "ClinVar_search_variants", gene="BLM")
+    if not is_error(clinvar):
+        report("ClinVar BLM variant records", clinvar.get("total_count"))
+
+    genebe = call(tu, "GeneBe_classify_variant", **VARIANT)
+    if not is_error(genebe):
+        report("c.520C>T ACMG class", genebe.get("acmg_classification"), "Pathogenic")
+        report("ACMG score", genebe.get("acmg_score"), "12")
+        report("transcript", genebe.get("transcript"), "NM_000057.4")
+    print("  Read alone, this argues against inhibiting BLM at all.")
+
+    # ------------------------------------------------------------------
+    step(4, "Test for a context-selective dependency (the turning point)")
+    depmap = call(
+        tu, "OpenTargets_get_target_depmap_essentiality", ensemblId=BLM_ENSEMBL
+    )
+    if not is_error(depmap):
+        target = depmap.get("target", {})
+        entries = target.get("depMapEssentiality", []) or []
+        n_lines = sum(len(e.get("screens", []) or []) for e in entries)
+        report("pan-essential?", target.get("isEssential"), "false (not pan-essential)")
+        report("cancer cell lines screened", n_lines, "1,258")
+
+        all_effects = [
+            s["geneEffect"]
+            for e in entries
+            for s in e.get("screens", []) or []
+            if isinstance(s.get("geneEffect"), (int, float))
+        ]
+        if all_effects:
+            mean_effect = sum(all_effects) / len(all_effects)
+            dependent = [v for v in all_effects if v < -0.5]
+            report("mean gene effect", f"{mean_effect:+.2f}", "-0.18")
+            report(
+                "lines dependent at < -0.5",
+                f"{len(dependent)}/{len(all_effects)} "
+                f"({100 * len(dependent) / len(all_effects):.1f}%)",
+                "94/1,258 (7.5%)",
+            )
+
+        # Where the dependency concentrates, by cancer type and by tissue.
+        def group_means(key):
+            buckets = {}
+            for entry in entries:
+                for screen in entry.get("screens", []) or []:
+                    effect = screen.get("geneEffect")
+                    if not isinstance(effect, (int, float)):
+                        continue
+                    label = (
+                        screen.get("diseaseFromSource")
+                        if key == "disease"
+                        else entry.get("tissueName")
+                    )
+                    if label:
+                        buckets.setdefault(label, []).append(effect)
+            return sorted(
+                (
+                    (sum(v) / len(v), label, len(v))
+                    for label, v in buckets.items()
+                    if len(v) >= 5
+                )
+            )
+
+        print("  Most-dependent cancer types (mean gene effect, n>=5 lines):")
+        for mean, label, n in group_means("disease")[:3]:
+            print(f"    {label:<48} {mean:+.2f}  (n={n})")
+        print("  Most-dependent tissues:")
+        for mean, label, n in group_means("tissue")[:3]:
+            print(f"    {label:<48} {mean:+.2f}  (n={n})")
+        print("  Published: mature T/NK-cell neoplasms -0.47 (n=8), cutaneous SCC")
+        print("  -0.44 (n=5), peripheral nervous system / neuroblastoma -0.33 (n=48)")
+        print("  Read: not broadly essential, but dependency concentrates in a few")
+        print("  contexts, which is what a therapeutic window would look like.")
+
+    # ------------------------------------------------------------------
+    step(5, "Retrieve the structure and check its reliability")
+    af = call(tu, "alphafold_get_summary", qualifier=BLM_UNIPROT)
+    if not is_error(af):
+        entry = af.get("uniprot_entry", {})
+        report("protein length", entry.get("sequence_length"), "1,417")
+        structures = af.get("structures", []) or []
+        if structures:
+            summary = structures[0].get("summary", {})
+            report("AlphaFold model", summary.get("model_identifier"), "AF-P54132-F1")
+        print("  The prediction is mixed-confidence: confidently folded catalytic")
+        print("  regions separated by low-confidence interdomain linkers.")
+
+    pdbe = call(tu, "PDBe_get_uniprot_structure_coverage", uniprot_id=BLM_UNIPROT)
+    if not is_error(pdbe):
+        data = pdbe.get(BLM_UNIPROT, {})
+        pdb_ids = sorted(
+            {e["name"].lower() for e in (data.get("data") or []) if e.get("name")}
+        )
+        report("experimental PDB entries", len(pdb_ids))
+        for wanted in ("7auc", "4cgz", "4o3m"):
+            report(
+                f"  helicase-core structure {wanted.upper()} present", wanted in pdb_ids
+            )
+        print("  Read: anchor structural reasoning on these experimental structures,")
+        print("  not on the mixed-confidence prediction.")
+
+    # ------------------------------------------------------------------
+    step(6, "Ground the therapeutic context in the literature")
+    lit = call(
+        tu,
+        "EuropePMC_search_articles",
+        query="WRN helicase synthetic lethal microsatellite instability cancer",
+        limit=5,
+    )
+    if not is_error(lit) and isinstance(lit, list):
+        report("articles returned", len(lit))
+        for article in lit[:3]:
+            print(f"    - {str(article.get('title'))[:88]}")
+        print("  Read: BLM's paralog WRN is the clinically validated synthetic-lethal")
+        print("  target in this family, which is the precedent the BLM hypothesis")
+        print("  is built on by analogy.")
+
+    # ------------------------------------------------------------------
+    step(7, "Find and triage the chemical matter")
+    probes = call(
+        tu,
+        "OpenTargets_get_chemical_probes_by_target_ensemblID",
+        ensemblId=BLM_ENSEMBL,
+    )
+    if not is_error(probes):
+        entries = probes.get("target", {}).get("chemicalProbes", []) or []
+        ml216 = next((p for p in entries if p.get("id") == "ML216"), None)
+        if ml216:
+            report("ML216 flagged high quality?", ml216.get("isHighQuality"), "false")
+            report("ML216 mechanism", ml216.get("mechanismOfAction"), "['inhibitor']")
+            print("  Read: the platform itself marks ML216 a probe, not a lead.")
+
+    cid_payload = call(tu, "PubChem_get_CID_by_compound_name", name="ML216")
+    cid = None
+    if not is_error(cid_payload):
+        cid = (
+            cid_payload.get("IdentifierList", {}).get("CID", [None])[0]
+            if isinstance(cid_payload, dict)
+            else None
+        )
+        report("ML216 PubChem CID", cid, "49852229")
+
+    smiles = None
+    if cid:
+        props = call(
+            tu,
+            "PubChem_get_compound_properties_by_CID",
+            cid=cid,
+            properties="MolecularWeight,SMILES,ConnectivitySMILES,IUPACName",
+        )
+        if not is_error(props):
+            entry = props.get("PropertyTable", {}).get("Properties", [{}])[0]
+            # Prefer the stereochemistry-bearing SMILES where one exists; ADMET-AI
+            # scores flat and stereo forms differently. ML216 has no stereocentre,
+            # so the two agree here.
+            smiles = entry.get("SMILES") or entry.get("ConnectivitySMILES")
+            report("molecular weight", entry.get("MolecularWeight"), "383 Da")
+            report("SMILES", smiles)
+
+    if smiles:
+        physchem = call(
+            tu, "ADMETAI_predict_physicochemical_properties", smiles=[smiles]
+        )
+        if is_error(physchem):
+            note_unavailable("ADMETAI_predict_physicochemical_properties", physchem)
+        else:
+            values = physchem.get(smiles, physchem)
+            report(
+                "QED (drug-likeness)", round(values.get("QED", float("nan")), 3), "0.66"
+            )
+            report(
+                "Lipinski rules passed", values.get("Lipinski"), "4 of 4 (0 violations)"
+            )
+
+        tox = call(tu, "ADMETAI_predict_toxicity", smiles=[smiles])
+        if is_error(tox):
+            note_unavailable("ADMETAI_predict_toxicity", tox)
+        else:
+            values = tox.get(smiles, tox)
+            report(
+                "DILI (liver injury)",
+                round(values.get("DILI", float("nan")), 3),
+                "0.99",
+            )
+            report("hERG (cardiac)", round(values.get("hERG", float("nan")), 3), "0.56")
+            report(
+                "AMES (mutagenicity)",
+                round(values.get("AMES", float("nan")), 3),
+                "0.16",
+            )
+
+        # Is the DILI signal specific to this molecule, or to the scaffold?
+        analogs = call(
+            tu,
+            "ChEMBL_search_similar_molecules",
+            query=smiles,
+            similarity_threshold=70,
+            max_results=5,
+        )
+        if is_error(analogs):
+            note_unavailable("ChEMBL_search_similar_molecules", analogs)
+        else:
+            # The tool returns a list of query molecules, each carrying its own
+            # normalised "similar_molecules" list; the analog SMILES live one
+            # level down under "smiles", not in the raw ChEMBL
+            # molecule_structures shape.
+            analog_smiles = []
+            for group in analogs if isinstance(analogs, list) else []:
+                for analog in group.get("similar_molecules") or []:
+                    candidate = analog.get("smiles")
+                    if candidate and candidate != "N/A":
+                        analog_smiles.append(candidate)
+            analog_smiles = analog_smiles[:5]
+            if analog_smiles:
+                analog_tox = call(tu, "ADMETAI_predict_toxicity", smiles=analog_smiles)
+                if not is_error(analog_tox):
+                    dili = [
+                        analog_tox[s]["DILI"] for s in analog_smiles if s in analog_tox
+                    ]
+                    if dili:
+                        report(
+                            "DILI across close analogs",
+                            f"{min(dili):.3f}-{max(dili):.3f}",
+                            "0.987-0.992",
+                        )
+                        print("  Read: DILI stays pinned near its maximum across the")
+                        print("  series while other liabilities move, which points at")
+                        print("  the scaffold rather than at one molecule.")
+            else:
+                print("  [no analogs returned] ChEMBL_search_similar_molecules gave")
+                print("  no similar molecules, so the scaffold comparison is skipped.")
+
+    footer(
+        {
+            "Germline genetics": "argue against inhibiting BLM (a tumour suppressor to preserve)",
+            "DepMap + WRN precedent": "support a narrower claim: a selective vulnerability in "
+            "defined subtypes",
+            "Conclusion": "BLM is a context-selective hypothesis to test, not a validated target",
+            "ML216": "drug-like but scaffold-associated DILI liability; a probe, not a lead",
+        }
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/case_studies/case2_oxtr_druggability.py
+++ b/examples/case_studies/case2_oxtr_druggability.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Case 2: Is OXTR druggable, and does its chemistry fit the autism hypothesis?
+
+Reproduces the second case study from
+https://aiscientist.tools/posts/tooluniverse-case-studies
+
+The steps below are the tool calls in the order the AI scientist made them.
+Every number printed with a "(published: ...)" annotation is one that appears
+either in the post or in the supplementary note it condenses (arXiv:2509.23426).
+Intermediate values such as the 7QVM structure, the AlphaFold accession and the
+PubChem CID come from the supplementary note.
+
+The point of this case is the last step: a compound can clear every filter you
+thought to apply (drug-like, brain-penetrant) and still be pharmacologically
+wrong, because it acts in the opposite direction to the one the indication
+needs.
+
+Run:
+    python case2_oxtr_druggability.py
+
+Needs network access; no API keys. The ADMET-AI steps need the ``ml`` extra
+(``pip install 'tooluniverse[ml]'``).
+"""
+
+from __future__ import annotations
+
+from _common import (
+    call,
+    footer,
+    header,
+    is_error,
+    load_universe,
+    note_unavailable,
+    report,
+    step,
+)
+
+OXTR_ENSEMBL = "ENSG00000180914"
+OXTR_UNIPROT = "P30559"
+
+
+def main() -> None:
+    header(
+        "Case 2: OXTR druggability and whether the chemistry fits",
+        "Is OXTR (the oxytocin receptor) a druggable target, and does its\n"
+        "          pharmacology offer a credible chemical starting point for its\n"
+        "          emerging autism association?",
+    )
+    tu = load_universe()
+
+    # ------------------------------------------------------------------
+    step(1, "Resolve, annotate, and obtain structure")
+    search = call(
+        tu,
+        "OpenTargets_multi_entity_search_by_query_string",
+        queryString="OXTR",
+        entityNames=["target"],
+    )
+    hits = search.get("search", {}).get("hits", []) if not is_error(search) else []
+    ensembl = next((h["id"] for h in hits if h.get("entity") == "target"), None)
+    report("OXTR Ensembl gene", ensembl, OXTR_ENSEMBL)
+
+    go = call(
+        tu, "OpenTargets_get_target_gene_ontology_by_ensemblID", ensemblId=OXTR_ENSEMBL
+    )
+    if not is_error(go):
+        labels = {
+            (t.get("term", {}).get("label") or "")
+            for t in go.get("target", {}).get("geneOntology", [])
+        }
+        gpcr = sorted(
+            label
+            for label in labels
+            if "G protein-coupled" in label or "phospholipase C" in label
+        )
+        report("GO terms returned", len(labels))
+        for label in gpcr[:3]:
+            print(f"    - {label}")
+
+    af = call(tu, "alphafold_get_summary", qualifier=OXTR_UNIPROT)
+    if not is_error(af):
+        entry = af.get("uniprot_entry", {})
+        report("protein length", entry.get("sequence_length"), "389")
+        structures = af.get("structures", []) or []
+        if structures:
+            report(
+                "AlphaFold model",
+                structures[0].get("summary", {}).get("model_identifier"),
+                "AF-P30559-F1",
+            )
+
+    pdbe = call(tu, "PDBe_get_uniprot_structure_coverage", uniprot_id=OXTR_UNIPROT)
+    if not is_error(pdbe):
+        data = pdbe.get(OXTR_UNIPROT, {})
+        pdb_ids = sorted(
+            {e["name"].lower() for e in (data.get("data") or []) if e.get("name")}
+        )
+        report("experimental PDB entries", len(pdb_ids))
+        report("active, agonist-bound 7RYC present", "7ryc" in pdb_ids, "yes")
+        report("active 7QVM present", "7qvm" in pdb_ids, "yes")
+        report("inactive 6TPK present", "6tpk" in pdb_ids, "yes")
+        print("  Read: GPCR design needs state-specific, ligand-bound structures,")
+        print("  and both states exist experimentally, so use these rather than")
+        print("  the prediction.")
+
+    # ------------------------------------------------------------------
+    step(2, "Map the disease landscape")
+    diseases = call(
+        tu,
+        "OpenTargets_get_diseases_phenotypes_by_target_ensembl",
+        ensemblId=OXTR_ENSEMBL,
+    )
+    if not is_error(diseases):
+        associated = diseases.get("target", {}).get("associatedDiseases", {})
+        # Expect drift here: Open Targets re-scores associations every release,
+        # so this count moves. The published run saw 393.
+        report("disease associations", associated.get("count"), "393, drifts upward")
+        names = [
+            r.get("disease", {}).get("name", "")
+            for r in associated.get("rows", []) or []
+        ]
+        autism = [n for n in names if "autis" in n.lower()]
+        report("autism-related terms in top rows", autism or "not in first page")
+        print("  Reproductive and uterine indications have approved-drug precedent;")
+        print("  the autism association is separate and still emerging.")
+
+    # ------------------------------------------------------------------
+    step(3, "Confirm tractability and enumerate drugs")
+    tract = call(
+        tu, "OpenTargets_get_target_tractability_by_ensemblID", ensemblId=OXTR_ENSEMBL
+    )
+    if not is_error(tract):
+        buckets = [
+            t
+            for t in tract.get("target", {}).get("tractability", []) or []
+            if t.get("value")
+        ]
+        sm = sorted({t["label"] for t in buckets if t.get("modality") == "SM"})
+        report("small-molecule tractability buckets met", sm)
+
+    drugs = call(
+        tu,
+        "OpenTargets_get_associated_drugs_by_target_ensemblID",
+        ensemblId=OXTR_ENSEMBL,
+    )
+    known = {}
+    if not is_error(drugs):
+        block = drugs.get("target", {}).get("drugAndClinicalCandidates", {})
+        report("known agents", block.get("count"), "9")
+        for row in block.get("rows", []) or []:
+            drug = row.get("drug", {}) or {}
+            if drug.get("name"):
+                known[drug["name"].lower()] = drug.get("id")
+        for name in sorted(known):
+            print(f"    - {name}")
+        print("  Read: approved agents here are peptides, not small molecules.")
+
+    # ------------------------------------------------------------------
+    step(4, "Resolve mechanism")
+    for name in ("oxytocin", "atosiban"):
+        chembl_id = known.get(name)
+        if not chembl_id:
+            continue
+        moa = call(
+            tu,
+            "OpenTargets_get_drug_mechanisms_of_action_by_chemblId",
+            chemblId=chembl_id,
+        )
+        if not is_error(moa):
+            rows = (
+                moa.get("drug", {}).get("mechanismsOfAction", {}).get("rows", []) or []
+            )
+            actions = sorted({r.get("actionType") for r in rows if r.get("actionType")})
+            report(f"{name} ({chembl_id}) action type", actions)
+    print("  Read: the receptor is already drugged in both directions, so mechanism,")
+    print("  not just affinity, is the thing to check next.")
+
+    # ------------------------------------------------------------------
+    step(5, "Confirm chemical matter with experimental data")
+    targets = call(tu, "ChEMBL_search_targets", pref_name__contains="oxytocin receptor")
+    if is_error(targets):
+        note_unavailable("ChEMBL_search_targets", targets)
+    else:
+        rows = targets.get("targets", targets) or []
+        target_id = None
+        if isinstance(rows, list) and rows:
+            target_id = rows[0].get("target_chembl_id")
+        report("ChEMBL target", target_id, "CHEMBL2049")
+        if target_id:
+            acts = call(
+                tu,
+                "ChEMBL_get_target_activities",
+                target_chembl_id__exact=target_id,
+                limit=100,
+            )
+            if is_error(acts):
+                note_unavailable("ChEMBL_get_target_activities", acts)
+            else:
+                rows = acts.get("activities", acts) or []
+                affinities = [
+                    float(a["standard_value"])
+                    for a in rows
+                    if isinstance(a, dict)
+                    and a.get("standard_type") in {"Ki", "IC50", "Kd"}
+                    and a.get("standard_units") == "nM"
+                    and a.get("standard_value") is not None
+                ]
+                if affinities:
+                    report(
+                        "best measured affinity",
+                        f"{min(affinities):.1f} nM",
+                        "Ki as low as 3.2 nM",
+                    )
+
+    # ------------------------------------------------------------------
+    step(6, "Reason about pharmacology and CNS druggability")
+    lit = call(
+        tu,
+        "EuropePMC_search_articles",
+        query="intranasal oxytocin autism spectrum disorder randomized placebo",
+        limit=5,
+    )
+    if not is_error(lit) and isinstance(lit, list):
+        report("articles returned", len(lit))
+        for article in lit[:3]:
+            print(f"    - {str(article.get('title'))[:88]}")
+        print("  Read: the autism evidence for oxytocin itself is mixed, with large")
+        print("  placebo responses; so look for a brain-penetrant non-peptide.")
+
+    # Nolasiban is the non-peptide candidate: is central exposure even attainable?
+    cid_payload = call(tu, "PubChem_get_CID_by_compound_name", name="nolasiban")
+    cid = None
+    if not is_error(cid_payload):
+        cid = cid_payload.get("IdentifierList", {}).get("CID", [None])[0]
+        report("nolasiban PubChem CID", cid, "52947354")
+
+    smiles = None
+    if cid:
+        props = call(
+            tu,
+            "PubChem_get_compound_properties_by_CID",
+            cid=cid,
+            properties="MolecularWeight,SMILES,ConnectivitySMILES",
+        )
+        if not is_error(props):
+            entry = props.get("PropertyTable", {}).get("Properties", [{}])[0]
+            # Prefer the stereochemistry-bearing SMILES: nolasiban has a defined
+            # stereocentre, and ADMET-AI scores the flat and stereo forms
+            # differently (BBB 0.91 vs 0.93).
+            smiles = entry.get("SMILES") or entry.get("ConnectivitySMILES")
+            report("SMILES", smiles)
+
+    if smiles:
+        physchem = call(
+            tu, "ADMETAI_predict_physicochemical_properties", smiles=[smiles]
+        )
+        if is_error(physchem):
+            note_unavailable("ADMETAI_predict_physicochemical_properties", physchem)
+        else:
+            values = physchem.get(smiles, physchem)
+            report(
+                "QED (drug-likeness)", round(values.get("QED", float("nan")), 3), "0.87"
+            )
+
+        bbb = call(tu, "ADMETAI_predict_BBB_penetrance", smiles=[smiles])
+        if is_error(bbb):
+            note_unavailable("ADMETAI_predict_BBB_penetrance", bbb)
+        else:
+            values = bbb.get(smiles, bbb)
+            score = next(
+                (v for k, v in values.items() if "BBB" in k and "percentile" not in k),
+                None,
+            )
+            report(
+                "predicted BBB penetrance", round(score, 3) if score else None, "0.93"
+            )
+
+    # The mismatch that decides the case.
+    nolasiban_id = known.get("nolasiban")
+    if nolasiban_id:
+        moa = call(
+            tu,
+            "OpenTargets_get_drug_mechanisms_of_action_by_chemblId",
+            chemblId=nolasiban_id,
+        )
+        if not is_error(moa):
+            rows = (
+                moa.get("drug", {}).get("mechanismsOfAction", {}).get("rows", []) or []
+            )
+            actions = sorted({r.get("actionType") for r in rows if r.get("actionType")})
+            report("nolasiban action type", actions, "ANTAGONIST")
+            print("  Read: brain-penetrant non-peptide OXTR chemistry is attainable,")
+            print("  but this chemotype BLOCKS the receptor, and the pro-social")
+            print("  hypothesis needs it ACTIVATED. Wrong direction.")
+
+    footer(
+        {
+            "Tractability": "OXTR is a druggable GPCR with active and inactive experimental "
+            "structures and nanomolar ligands",
+            "Mechanism": "already drugged both ways (oxytocin agonist, atosiban antagonist)",
+            "The catch": "nolasiban is brain-penetrant but an ANTAGONIST, the opposite of what "
+            "the autism hypothesis requires",
+            "Conclusion": "the objective is a brain-penetrant agonist or positive allosteric "
+            "modulator, selective over vasopressin receptors",
+        }
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/case_studies/case3_bcg_ae_severity.py
+++ b/examples/case_studies/case3_bcg_ae_severity.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Case 3: Is BCG vaccination associated with higher adverse-event severity?
+
+Reproduces the third case study from
+https://aiscientist.tools/posts/tooluniverse-case-studies
+
+Unlike Cases 1 and 2, this is statistics on raw tabular data rather than
+database lookups: one tool, ``clinical_trial_ae_severity_test``, used in three
+modes (prepare, chi-square, ordinal) on the public BCG-CORONA trial tables.
+
+This case reproduces exactly, to the published decimal places, because the
+input is a frozen public dataset rather than a live database. The severity
+distribution checked in step 1 is reported in the supplementary note
+(arXiv:2509.23426); the other values are in the post itself.
+
+Setup:
+    python download_bcg_data.py     # ~4 MB from Zenodo, CC0
+    python case3_bcg_ae_severity.py
+
+The analysis runs through the ``clinical_trial_ae_severity_test`` tool, the
+same tool the AI scientist used. That tool loads its implementation from the
+repository's ``skills/`` directory, so it only resolves in a git clone. When it
+is unavailable -- a plain ``pip install``, for instance -- this script falls
+back to the equivalent implementation bundled alongside it in ``scripts/``,
+reports which path it took, and produces the same numbers either way.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from _common import call, footer, header, is_error, load_universe, report, step
+
+# Bundled equivalent of the skill script the tool wraps, used when the tool
+# cannot locate its own implementation (see the module docstring).
+sys.path.insert(0, str(Path(__file__).parent / "scripts"))
+
+DM_FILE = "TASK008_BCG-CORONA_DM.csv"
+AE_FILE = "TASK008_BCG-CORONA_AE.csv"
+
+# Patient-interaction covariates, as recorded in the trial's demographics table.
+COVARIATES = "patients_seen,expect_interact,work_hours"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--data",
+        type=Path,
+        default=Path(__file__).parent / "data",
+        help="Directory holding the BCG-CORONA CSVs (default: ./data)",
+    )
+    args = parser.parse_args()
+
+    dm, ae = args.data / DM_FILE, args.data / AE_FILE
+    if not dm.exists() or not ae.exists():
+        raise SystemExit(
+            f"Trial tables not found in {args.data}.\nRun:  python download_bcg_data.py"
+        )
+
+    header(
+        "Case 3: BCG vaccination and adverse event severity",
+        "In the public BCG-CORONA healthcare-worker trial, is BCG vaccination\n"
+        "          associated with higher adverse-event severity after adjusting for\n"
+        "          patient-interaction frequency?",
+    )
+    tu = load_universe(["clinical_trial_stats"])
+    common = {"dm_file": str(dm), "ae_file": str(ae), "group_col": "TRTGRP"}
+
+    def analyse(test, **extra):
+        """Run one mode through the tool, or the bundled script if it is absent.
+
+        The tool resolves its implementation relative to the repository root, so
+        outside a git clone it reports "Skill script not available". Rather than
+        fail, fall back to the copy bundled under scripts/ and say so.
+        """
+        result = call(
+            tu, "clinical_trial_ae_severity_test", test=test, **extra, **common
+        )
+        if not is_error(result):
+            return result, "tool"
+        if "Skill script not available" not in str(result["__error__"]):
+            raise SystemExit(f"{test} failed: {result['__error__']}")
+
+        import prepare_ae_cohort as script
+
+        df = script.prepare_cohort(str(dm), str(ae), "")
+        out = {
+            "n_subjects": len(df),
+            "aesev_distribution": {
+                int(k): int(v)
+                for k, v in df["AESEV"].value_counts().sort_index().to_dict().items()
+            },
+        }
+        if test == "chi-square":
+            chi2, pval, dof, table = script.run_chi_square(df, "TRTGRP")
+            out |= {
+                "test_statistic": chi2,
+                "p_value": pval,
+                "dof": dof,
+                "contingency_table": table,
+            }
+        elif test == "ordinal":
+            covs = [c for c in extra.get("covariates", "").split(",") if c]
+            fit = script.run_ordinal(df, "TRTGRP", covs)
+            primary = fit["odds_ratios"]["TRTGRP"]
+            out |= {
+                "or": primary["or"],
+                "ci_lower": primary["ci_lower"],
+                "ci_upper": primary["ci_upper"],
+                "p_value": primary["p_value"],
+                "odds_ratios": fit["odds_ratios"],
+            }
+        return out, "bundled script"
+
+    # ------------------------------------------------------------------
+    step(1, "Construct the analysis cohort  (prepare mode)")
+    prepared, via = analyse("prepare")
+    print(f"  (running via: {via})")
+    report("evaluable subjects", prepared["n_subjects"], "791")
+    report(
+        "max-severity distribution",
+        prepared["aesev_distribution"],
+        "{1: 328, 2: 402, 3: 43, 4: 18}",
+    )
+    print("  Each subject is reduced to their maximum AESEV grade across all")
+    print("  adverse events, inner-joined onto demographics on USUBJID.")
+
+    # ------------------------------------------------------------------
+    step(2, "Test for an unadjusted association  (chi-square mode)")
+    chi, _ = analyse("chi-square")
+    report("chi-square", f"{chi['test_statistic']:.2f}", "10.12")
+    report("degrees of freedom", chi["dof"], "3")
+    report("p-value", f"{chi['p_value']:.3f}", "0.018")
+    print("  Treatment-by-severity contingency table:")
+    for group, row in (chi.get("contingency_table") or {}).items():
+        counts = "  ".join(f"{grade}:{n:>4}" for grade, n in sorted(row.items()))
+        print(f"    {group:<10} {counts}")
+
+    # ------------------------------------------------------------------
+    step(3, "Fit an adjusted model  (ordinal mode)")
+    ordinal, _ = analyse("ordinal", covariates=COVARIATES)
+
+    # The tool reports the odds ratio against its own reference level. Treatment
+    # is encoded alphabetically (BCG=0, Placebo=1), so the raw OR is Placebo vs
+    # BCG and the published direction is its reciprocal.
+    raw_or = ordinal["or"]
+    or_bcg = 1 / raw_or
+    ci_low, ci_high = 1 / ordinal["ci_upper"], 1 / ordinal["ci_lower"]
+
+    report("raw OR (Placebo vs BCG)", f"{raw_or:.4f}", "0.65")
+    report("OR for higher severity with BCG", f"{or_bcg:.2f}", "1.53")
+    report("95% CI", f"({ci_low:.2f}, {ci_high:.2f})", "(1.16, 2.01)")
+    report("p-value", f"{ordinal['p_value']:.4f}", "0.0024")
+    print("  Covariates (none significant, as published):")
+    for name, stats in (ordinal.get("odds_ratios") or {}).items():
+        if name != "TRTGRP":
+            print(f"    {name:<20} OR={stats['or']:.3f}  p={stats['p_value']:.3f}")
+
+    footer(
+        {
+            "Unadjusted and adjusted": "agree on a significant association between BCG "
+            "and higher maximum AE severity",
+            "Not independent": "the two tests share the outcome and overlapping data",
+            "Interpretation": "an association, not a causal effect: the cohort is "
+            "restricted to subjects with at least one AE and the endpoint is a "
+            "derived per-subject maximum",
+            "Caveat": "the proportional-odds assumption should be checked before the "
+            "single OR is over-interpreted",
+        }
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/case_studies/download_bcg_data.py
+++ b/examples/case_studies/download_bcg_data.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Download the public BCG-CORONA trial tables used by Case 3.
+
+Source: https://zenodo.org/records/12737228 (CC0-1.0)
+"Safety and efficacy of BCG re-vaccination in relation to COVID-19 morbidity
+in healthcare workers: A double-blind, randomised, controlled, phase 3 trial."
+
+Downloads ~4 MB and extracts the SDTM CSV tables next to this script.
+
+Run:
+    python download_bcg_data.py [--dest DIR]
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import urllib.request
+import zipfile
+from pathlib import Path
+
+ZENODO_RECORD = "https://zenodo.org/records/12737228"
+ARCHIVE_URL = (
+    "https://zenodo.org/api/records/12737228/files/"
+    "TASK008-BCG_CORONA_SDTM_datasets_V5.zip/content"
+)
+# The two tables Case 3 needs.
+DM_FILE = "TASK008_BCG-CORONA_DM.csv"
+AE_FILE = "TASK008_BCG-CORONA_AE.csv"
+
+
+def download(dest: Path) -> Path:
+    dest.mkdir(parents=True, exist_ok=True)
+    dm, ae = dest / DM_FILE, dest / AE_FILE
+    if dm.exists() and ae.exists():
+        print(f"Already present in {dest}:\n  {DM_FILE}\n  {AE_FILE}")
+        return dest
+
+    archive = dest / "TASK008-BCG_CORONA_SDTM_datasets_V5.zip"
+    print(f"Downloading from {ZENODO_RECORD} ...")
+    urllib.request.urlretrieve(ARCHIVE_URL, archive)
+    print(f"  got {archive.stat().st_size / 1e6:.1f} MB")
+
+    with zipfile.ZipFile(archive) as zf:
+        zf.extractall(dest)
+    archive.unlink()
+
+    missing = [f for f in (DM_FILE, AE_FILE) if not (dest / f).exists()]
+    if missing:
+        print(
+            f"ERROR: expected files missing after extract: {missing}", file=sys.stderr
+        )
+        raise SystemExit(1)
+
+    print(f"Extracted to {dest}:\n  {DM_FILE}\n  {AE_FILE}")
+    return dest
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dest",
+        type=Path,
+        default=Path(__file__).parent / "data",
+        help="Directory to download into (default: ./data)",
+    )
+    args = parser.parse_args()
+    download(args.dest)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/case_studies/requirements.txt
+++ b/examples/case_studies/requirements.txt
@@ -1,0 +1,13 @@
+# Extra dependencies for the case-study reproductions.
+# Install ToolUniverse itself first:
+#     pip install 'tooluniverse[ml]'
+
+# Case 1 and Case 2: ADMET-AI property and toxicity models.
+# Equivalent to the `ml` extra; listed here so this file stands alone.
+admet-ai
+
+# Case 3: statistics on the BCG-CORONA trial tables.
+# Works on pandas 2 and 3; verified to give identical results on both.
+pandas
+scipy
+statsmodels

--- a/examples/case_studies/scripts/README.md
+++ b/examples/case_studies/scripts/README.md
@@ -1,0 +1,22 @@
+# `scripts/`
+
+`prepare_ae_cohort.py` is the cohort-construction and statistics implementation
+behind Case 3.
+
+The `clinical_trial_ae_severity_test` tool wraps the equivalent script in the
+repository's `skills/tooluniverse-statistical-modeling/scripts/` directory,
+resolved relative to the repo root — so the tool only works from a git clone.
+This copy lets `case3_bcg_ae_severity.py` produce the published numbers from a
+plain `pip install` as well, and it runs on pandas 3, where
+`dtype == object` no longer identifies string columns and integer indexing on a
+labelled Series raises `KeyError`.
+
+Run it directly if you want the analysis without ToolUniverse:
+
+```bash
+python prepare_ae_cohort.py \
+    --dm ../data/TASK008_BCG-CORONA_DM.csv \
+    --ae ../data/TASK008_BCG-CORONA_AE.csv \
+    --test ordinal --group TRTGRP \
+    --covariates patients_seen,expect_interact,work_hours
+```

--- a/examples/case_studies/scripts/prepare_ae_cohort.py
+++ b/examples/case_studies/scripts/prepare_ae_cohort.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Prepare clinical trial AE severity cohort for statistical analysis.
+
+Merges demographics (DM) with adverse events (AE) using the correct
+convention: max(AESEV) per subject across ALL AE records, inner join,
+no pre-filtering by AEPT condition.
+
+Usage:
+    python prepare_ae_cohort.py --dm DM.csv --ae AE.csv
+    python prepare_ae_cohort.py --dm DM.csv --ae AE.csv --subgroup "expect_interact=Yes"
+    python prepare_ae_cohort.py --dm DM.csv --ae AE.csv --test chi-square --group TRTGRP
+    python prepare_ae_cohort.py --dm DM.csv --ae AE.csv --test ordinal --group TRTGRP --covariates "patients_seen_cat,expect_interact_cat"
+"""
+
+import argparse
+import sys
+
+import pandas as pd
+
+
+def prepare_cohort(dm_path: str, ae_path: str, subgroup: str = "") -> pd.DataFrame:
+    """Prepare AE severity cohort with correct convention."""
+    # Try latin1 encoding (common for clinical trial exports)
+    for enc in ["utf-8", "latin1"]:
+        try:
+            dm = pd.read_csv(dm_path, encoding=enc)
+            break
+        except UnicodeDecodeError:
+            continue
+
+    for enc in ["utf-8", "latin1"]:
+        try:
+            ae = pd.read_csv(ae_path, encoding=enc)
+            break
+        except UnicodeDecodeError:
+            continue
+
+    # Max AESEV per subject across ALL AE records (no AEPT filtering)
+    sev = ae.groupby("USUBJID")["AESEV"].max().reset_index()
+    df = dm.merge(sev, on="USUBJID", how="inner").dropna(subset=["AESEV"])
+    df["AESEV"] = df["AESEV"].astype(int)
+
+    print(f"DM: {len(dm)} subjects")
+    print(f"AE: {len(ae)} records, {ae['USUBJID'].nunique()} subjects")
+    print(f"After merge (inner join, max AESEV): {len(df)} subjects")
+
+    # Apply subgroup filter if specified
+    if subgroup:
+        col, val = subgroup.split("=")
+        before = len(df)
+        df = df[df[col.strip()] == val.strip()]
+        print(f"After subgroup {subgroup}: {len(df)} subjects (from {before})")
+
+    print(f"AESEV distribution: {df['AESEV'].value_counts().sort_index().to_dict()}")
+    return df
+
+
+def run_chi_square(df: pd.DataFrame, group_col: str):
+    """Run chi-square test on group × AESEV. Returns (chi2, p, dof, ct_dict)."""
+    from scipy import stats
+
+    ct = pd.crosstab(df[group_col], df["AESEV"])
+    print(f"\nContingency table ({group_col} × AESEV):")
+    print(ct)
+    chi2, p, dof, _ = stats.chi2_contingency(ct)
+    print(f"\nChi-square = {chi2:.4f}, p = {p:.6f}, dof = {dof}")
+    # ct_dict: nested dict keyed by group then AESEV level
+    ct_dict = {
+        str(k): {str(k2): int(v2) for k2, v2 in row.items()}
+        for k, row in ct.to_dict(orient="index").items()
+    }
+    return float(chi2), float(p), int(dof), ct_dict
+
+
+def run_ordinal(df: pd.DataFrame, group_col: str, covariates: list):
+    """Run ordinal logistic regression. Returns dict with OR results and model summary."""
+    try:
+        from statsmodels.miscmodels.ordinal_model import OrderedModel
+    except ImportError:
+        print("statsmodels required: pip install statsmodels")
+        return None
+
+    import numpy as np
+
+    formula_vars = [group_col] + covariates
+    X = df[formula_vars].copy()
+
+    # Convert categorical to numeric. Test for "not numeric" rather than
+    # "dtype == object": pandas 3 gives string columns a dedicated `str` dtype,
+    # so an equality check against `object` silently skips the encoding and
+    # statsmodels then fails with "Pandas data cast to numpy dtype of object".
+    for col in X.columns:
+        if not pd.api.types.is_numeric_dtype(X[col]):
+            X[col] = pd.Categorical(X[col]).codes
+
+    model = OrderedModel(df["AESEV"], X, distr="logit")
+    result = model.fit(method="bfgs", disp=False)
+    print("\nOrdinal logistic regression:")
+    print(result.summary())
+
+    # Extract odds ratios (with 95% CI from conf_int)
+    print("\nOdds ratios:")
+    conf = result.conf_int()
+    ors = {}
+    for var in formula_vars:
+        idx = list(X.columns).index(var)
+        # `.iloc` rather than `params[idx]`: these are positions, and pandas 3
+        # treats an integer key on a labelled Series as a label, raising
+        # KeyError. On pandas 2 the bare form worked but warned.
+        coef = float(result.params.iloc[idx])
+        or_val = float(np.exp(coef))
+        p_val = float(result.pvalues.iloc[idx])
+        ci_low = float(np.exp(conf.iloc[idx, 0]))
+        ci_high = float(np.exp(conf.iloc[idx, 1]))
+        print(f"  {var}: OR = {or_val:.4f}, p = {p_val:.6f}")
+        ors[var] = {
+            "coef": coef,
+            "or": or_val,
+            "ci_lower": ci_low,
+            "ci_upper": ci_high,
+            "p_value": p_val,
+        }
+    return {
+        "odds_ratios": ors,
+        "model_summary": str(result.summary()),
+        "primary_var": group_col,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Prepare AE cohort")
+    parser.add_argument("--dm", required=True, help="Demographics CSV")
+    parser.add_argument("--ae", required=True, help="Adverse events CSV")
+    parser.add_argument("--subgroup", default="", help="Subgroup filter (col=value)")
+    parser.add_argument("--test", default="", choices=["", "chi-square", "ordinal"])
+    parser.add_argument("--group", default="TRTGRP", help="Group variable")
+    parser.add_argument("--covariates", default="", help="Comma-separated covariates")
+    args = parser.parse_args()
+
+    df = prepare_cohort(args.dm, args.ae, args.subgroup)
+
+    if args.test == "chi-square":
+        run_chi_square(df, args.group)
+    elif args.test == "ordinal":
+        covariates = [c.strip() for c in args.covariates.split(",") if c.strip()]
+        run_ordinal(df, args.group, covariates)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The [case-studies post](https://aiscientist.tools/posts/tooluniverse-case-studies) describes three end-to-end analyses but had no runnable code behind it. This adds that, and fixes the tool defects found while making it actually run.

Two parts, in that order — the examples cannot ship without the fix, since Case 3's tool did not work from a released install. Happy to split if reviewers prefer.

## 1. `examples/case_studies/`

One script per case, making the same tool calls in the same order as the published run, printing the published value beside the retrieved one — so a run reports either "still reproduces" or exactly which number moved.

| Case | Question |
|---|---|
| 1 | Is *BLM* a context-selective anticancer target, and is ML216 a developable lead? |
| 2 | Is *OXTR* druggable, and does its chemistry fit the autism hypothesis? |
| 3 | Is BCG vaccination associated with higher adverse-event severity? |

Verified 2026-08-17 against a fresh clone. Cases 1 and 3 reproduce every published value; Case 2 reproduces all but the *OXTR* disease-association count, which Open Targets has re-scored from 393 to 465 since the run. The README records which values are expected to drift and which should not.

Notes:
- Roughly half the checked values (ACMG scores, PDB accessions, per-context DepMap effects, PubChem CIDs) are reported in the supplementary note rather than the post; those are marked separately and cited to arXiv:2509.23426.
- Case 3's covariate set was not stated in the post. The published OR only reproduces with `patients_seen,expect_interact,work_hours`; dropping `work_hours` gives 1.52 / p=0.0026 instead of 1.53 / p=0.0024.
- The odds ratio is reported against the tool's own reference level (BCG=0, Placebo=1), so the raw 0.65 is Placebo-vs-BCG and the published 1.53 is its reciprocal. Reporting the raw number as the BCG effect would invert the finding.
- ChEMBL's data API has been returning HTTP 500 for every request throughout (upstream, see chembl/chembl_webresource_client#144, open since June with no maintainer response). Two steps that depend on it degrade to "unavailable" rather than failing, and their values are flagged as not re-observed.

## 2. Tool fixes found on the way

**Three tools were unusable from any `pip install`.** `clinical_trial_ae_severity_test`, `expression_anova_per_gene` and `coding_variant_fraction` each resolved their implementation with `Path(__file__).parents[2] / "skills" / ...`, which from `site-packages` points at `lib/pythonX.Y/skills` — a path that never exists. Every call returned `Skill script not available`. The implementations move into a new `tooluniverse.analysis_scripts` package and are imported directly; the `skills/` and `plugins/` copies (previously byte-identical duplicates) become thin CLI wrappers, so documented `python scripts/<name>.py` usage is unchanged and there is now one implementation instead of two.

**Two pandas-3 breakages** in `prepare_ae_cohort.run_ordinal`, both fatal to the ordinal regression:
- `X[col].dtype == object` skipped categorical encoding, since pandas 3 gives string columns a dedicated `str` dtype; statsmodels then raised `Pandas data cast to numpy dtype of object`.
- `result.params[idx]` indexed a labelled Series by position, which pandas 3 treats as a label and raises `KeyError` on. This was the `FutureWarning` pandas 2 had been emitting.

`sdtm_ordinal_logistic.py` carried the same dtype pattern and gets the same fix.

## Testing

These three tools had no tests. Adds `tests/test_analysis_scripts_tools.py` — 17 tests covering the packaging invariant, the `max(AESEV)`-per-subject merge, subgroup filtering, chi-square, the string-covariate encoding regression, and tool-level round trips. Passing on pandas 2.3.3 and 3.0.5.

Verified from a fresh wheel build with no repo on the path, on pandas 3:

```
status:      success
n_subjects:  791          (published 791)
OR (BCG):    1.53         (published 1.53)
95% CI:      (1.16, 2.01) (published (1.16, 2.01))
p-value:     0.0024       (published 0.0024)
```

`tests/unit` is identical to `origin/main` across two consecutive runs (same 8 pre-existing FAERS failures). `examples/case_studies` drops its `pandas<3` pin and its git-clone requirement as a result of the fixes.

Two pre-existing issues surfaced but left alone: the full test suite hangs in `cache/result_cache_manager.py` (reproduces on a pristine `main` checkout), and `tests/unit/test_codex_plugin.py::test_build_codex_plugin` is order-dependent.
