### PR TITLE
Complete the controlled-access archive tier: EGA, dbGaP, and DDBJ GEA/MetaboBank

### DIFF
--- a/src/tooluniverse/_lazy_registry_static.py
+++ b/src/tooluniverse/_lazy_registry_static.py
@@ -646,6 +646,7 @@ STATIC_LAZY_REGISTRY = {
     "OpenFDADeviceTool": "openfda_device_tool",
     "FHIRTerminologyTool": "fhir_terminology_tool",
     "EGATool": "ega_tool",
+    "DbGaPTool": "dbgap_tool",
     "OrphadataTool": "orphadata_tool",
     "SCREENRESTTool": "screen_tool",
     "SingleCellPortalTool": "single_cell_portal_tool",

--- a/src/tooluniverse/_lazy_registry_static.py
+++ b/src/tooluniverse/_lazy_registry_static.py
@@ -645,6 +645,7 @@ STATIC_LAZY_REGISTRY = {
     "NCIEVSTool": "nci_evs_tool",
     "OpenFDADeviceTool": "openfda_device_tool",
     "FHIRTerminologyTool": "fhir_terminology_tool",
+    "EGATool": "ega_tool",
     "OrphadataTool": "orphadata_tool",
     "SCREENRESTTool": "screen_tool",
     "SingleCellPortalTool": "single_cell_portal_tool",

--- a/src/tooluniverse/data/dbgap_tools.json
+++ b/src/tooluniverse/data/dbgap_tools.json
@@ -1,0 +1,95 @@
+[
+  {
+    "name": "DbGaP_search_studies",
+    "type": "DbGaPTool",
+    "description": "Search dbGaP (NCBI's controlled-access US genotype-phenotype archive, the American counterpart to EGA) for studies by title keyword, via its FHIR API. Example: query='diabetes' returns the Diabetes Prevention Program Genetics study. Returns each study's phs_id for use with DbGaP_get_study.",
+    "fields": {
+      "operation": "search_studies"
+    },
+    "parameter": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "string",
+          "description": "Study title keyword, e.g. 'diabetes', 'autism'."
+        },
+        "limit": {
+          "type": ["integer", "null"],
+          "description": "Max studies to return, 1-100. Default 25."
+        }
+      }
+    },
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "phs_id": {"type": ["string", "null"]},
+              "title": {"type": ["string", "null"]},
+              "status": {"type": ["string", "null"]},
+              "conditions": {"type": "array", "items": {"type": "string"}}
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {"error": {"type": "string"}},
+          "required": ["error"]
+        }
+      ]
+    },
+    "test_examples": [
+      {"query": "diabetes", "limit": 5},
+      {"query": "autism", "limit": 5}
+    ]
+  },
+  {
+    "name": "DbGaP_get_study",
+    "type": "DbGaPTool",
+    "description": "Retrieve one dbGaP study's full public metadata by its phs accession: description, medical conditions studied, release date, and phenotype/molecular dataset and variable counts. Example: phs_id='phs000681' returns the Diabetes Prevention Program Genetics study with 4 phenotype datasets and 15 variables. Metadata only -- the underlying genotype/phenotype data requires Data Access Committee approval. Use DbGaP_search_studies to find a phs_id.",
+    "fields": {
+      "operation": "get_study"
+    },
+    "parameter": {
+      "type": "object",
+      "required": ["phs_id"],
+      "properties": {
+        "phs_id": {
+          "type": "string",
+          "description": "dbGaP study accession, e.g. 'phs000681'."
+        }
+      }
+    },
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "phs_id": {"type": ["string", "null"]},
+            "title": {"type": ["string", "null"]},
+            "status": {"type": ["string", "null"]},
+            "description": {"type": ["string", "null"]},
+            "conditions": {"type": "array", "items": {"type": "string"}},
+            "study_overview_url": {"type": ["string", "null"]},
+            "release_date": {"type": ["string", "null"]},
+            "phenotype_dataset_count": {"type": ["integer", "null"]},
+            "molecular_dataset_count": {"type": ["integer", "null"]},
+            "variable_count": {"type": ["integer", "null"]},
+            "document_count": {"type": ["integer", "null"]}
+          }
+        },
+        {
+          "type": "object",
+          "properties": {"error": {"type": "string"}},
+          "required": ["error"]
+        }
+      ]
+    },
+    "test_examples": [
+      {"phs_id": "phs000681"}
+    ]
+  }
+]

--- a/src/tooluniverse/data/ddbj_tools.json
+++ b/src/tooluniverse/data/ddbj_tools.json
@@ -2,7 +2,7 @@
   {
     "name": "DDBJ_get_entry",
     "type": "DDBJTool",
-    "description": "Retrieve a DNA Data Bank of Japan record by accession. DDBJ is the third INSDC member alongside NCBI/GenBank and EMBL-EBI/ENA, and also hosts JGA, Japan's controlled-access human archive. The entry type is inferred from the accession prefix (PRJD*=bioproject, SAMD*=biosample, DRP*=sra-study, DRX*=sra-experiment, DRR*=sra-run, DRS*=sra-sample, JGAS*=jga-study) unless you pass entry_type. Example: accession='DRP000001'.",
+    "description": "Retrieve a DNA Data Bank of Japan record by accession. DDBJ is the third INSDC member alongside NCBI/GenBank and EMBL-EBI/ENA, and also hosts JGA (Japan's controlled-access human archive), GEA (expression), and MetaboBank (metabolomics). The entry type is inferred from the accession prefix (PRJD*=bioproject, SAMD*=biosample, DRP*=sra-study, DRX*=sra-experiment, DRR*=sra-run, DRS*=sra-sample, JGAS*=jga-study, E-GEAD*=gea, MTBKS*=metabobank) unless you pass entry_type. Example: accession='DRP000001'.",
     "fields": {
       "operation": "get_entry"
     },
@@ -14,7 +14,7 @@
       "properties": {
         "accession": {
           "type": "string",
-          "description": "DDBJ accession, e.g. 'DRP000001', 'PRJDB3490', 'JGAS000001'."
+          "description": "DDBJ accession, e.g. 'DRP000001', 'PRJDB3490', 'JGAS000001', 'E-GEAD-1000', 'MTBKS102'."
         },
         "entry_type": {
           "type": [
@@ -29,9 +29,11 @@
             "sra-experiment",
             "sra-run",
             "sra-sample",
-            "jga-study"
+            "jga-study",
+            "gea",
+            "metabobank"
           ],
-          "description": "Override the inferred entry type. One of: bioproject, biosample, sra-study, sra-experiment, sra-run, sra-sample, jga-study."
+          "description": "Override the inferred entry type. One of: bioproject, biosample, sra-study, sra-experiment, sra-run, sra-sample, jga-study, gea, metabobank."
         }
       }
     },
@@ -188,6 +190,12 @@
       },
       {
         "accession": "JGAS000001"
+      },
+      {
+        "accession": "E-GEAD-1000"
+      },
+      {
+        "accession": "MTBKS102"
       }
     ]
   },
@@ -286,6 +294,74 @@
         "accession": "PRJDB3490",
         "limit": 10
       }
+    ]
+  },
+  {
+    "name": "DDBJ_search_entries",
+    "type": "DDBJTool",
+    "description": "Keyword search one DDBJ entry type (bioproject, biosample, sra-study, sra-experiment, sra-run, sra-sample, jga-study, gea, metabobank), optionally filtered by organism NCBI taxonomy ID. Example: entry_type='gea', keywords='daptomycin resistance' finds gene-expression studies on antibiotic resistance. Returns each match's identifier for use with DDBJ_get_entry or DDBJ_get_cross_references.",
+    "fields": {
+      "operation": "search_entries"
+    },
+    "parameter": {
+      "type": "object",
+      "required": ["entry_type", "keywords"],
+      "properties": {
+        "entry_type": {
+          "type": "string",
+          "enum": [
+            "bioproject",
+            "biosample",
+            "sra-study",
+            "sra-experiment",
+            "sra-run",
+            "sra-sample",
+            "jga-study",
+            "gea",
+            "metabobank"
+          ],
+          "description": "Which DDBJ record type to search."
+        },
+        "keywords": {
+          "type": "string",
+          "description": "Free-text search terms, e.g. 'daptomycin resistance'."
+        },
+        "organism_taxid": {
+          "type": ["string", "integer", "null"],
+          "description": "Optional NCBI taxonomy ID filter, e.g. 9606 (human)."
+        },
+        "limit": {
+          "type": ["integer", "null"],
+          "description": "Max entries to return, 1-100. Default 25."
+        }
+      }
+    },
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "identifier": {"type": ["string", "null"]},
+              "title": {"type": ["string", "null"]},
+              "description": {"type": ["string", "null"]},
+              "organism": {"type": ["string", "null"]},
+              "accessibility": {"type": ["string", "null"]},
+              "date_published": {"type": ["string", "null"]}
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {"error": {"type": "string"}},
+          "required": ["error"]
+        }
+      ]
+    },
+    "test_examples": [
+      {"entry_type": "gea", "keywords": "daptomycin", "limit": 5},
+      {"entry_type": "bioproject", "keywords": "lung cancer", "organism_taxid": 9606, "limit": 5}
     ]
   }
 ]

--- a/src/tooluniverse/data/ega_tools.json
+++ b/src/tooluniverse/data/ega_tools.json
@@ -1,0 +1,136 @@
+[
+  {
+    "name": "EGA_get_study",
+    "type": "EGATool",
+    "description": "Resolve an EGA (European Genome-phenome Archive) study accession to its public metadata: title, description, study type, and publication. Example: accession='EGAS00000000001' returns the WTCCC bipolar disorder case-control study. Metadata only -- the underlying controlled-access sequence/genotype data requires separate Data Access Committee approval. Use EGA_get_study_datasets to find the study's dataset accessions.",
+    "fields": {
+      "operation": "get_study"
+    },
+    "parameter": {
+      "type": "object",
+      "required": ["accession"],
+      "properties": {
+        "accession": {
+          "type": "string",
+          "description": "EGA study accession, e.g. 'EGAS00000000001'."
+        }
+      }
+    },
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "accession_id": {"type": ["string", "null"]},
+            "title": {"type": ["string", "null"]},
+            "description": {"type": ["string", "null"]},
+            "study_type": {"type": ["string", "null"]},
+            "pubmed_ids": {"type": "array"},
+            "is_released": {"type": ["boolean", "null"]},
+            "released_date": {"type": ["string", "null"]},
+            "is_deprecated": {"type": ["boolean", "null"]}
+          }
+        },
+        {
+          "type": "object",
+          "properties": {"error": {"type": "string"}},
+          "required": ["error"]
+        }
+      ]
+    },
+    "test_examples": [
+      {"accession": "EGAS00000000001"},
+      {"accession": "EGAS00000000002"}
+    ]
+  },
+  {
+    "name": "EGA_get_dataset",
+    "type": "EGATool",
+    "description": "Resolve an EGA dataset accession to its public metadata: technology platform, sample count, and access policy. Example: accession='EGAD00000000001' returns an Affymetrix 500K genotyping dataset of 1,504 samples under controlled access. Metadata only -- the underlying data requires Data Access Committee approval via the returned policy_accession_id.",
+    "fields": {
+      "operation": "get_dataset"
+    },
+    "parameter": {
+      "type": "object",
+      "required": ["accession"],
+      "properties": {
+        "accession": {
+          "type": "string",
+          "description": "EGA dataset accession, e.g. 'EGAD00000000001'."
+        }
+      }
+    },
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "accession_id": {"type": ["string", "null"]},
+            "title": {"type": ["string", "null"]},
+            "description": {"type": ["string", "null"]},
+            "dataset_types": {"type": "array"},
+            "technologies": {"type": "array", "items": {"type": "string"}},
+            "num_samples": {"type": ["integer", "null"]},
+            "access_type": {"type": ["string", "null"]},
+            "policy_accession_id": {"type": ["string", "null"]},
+            "is_released": {"type": ["boolean", "null"]},
+            "released_date": {"type": ["string", "null"]}
+          }
+        },
+        {
+          "type": "object",
+          "properties": {"error": {"type": "string"}},
+          "required": ["error"]
+        }
+      ]
+    },
+    "test_examples": [
+      {"accession": "EGAD00000000001"},
+      {"accession": "EGAD00000000002"}
+    ]
+  },
+  {
+    "name": "EGA_get_study_datasets",
+    "type": "EGATool",
+    "description": "List the dataset accessions belonging to one EGA study. Example: accession='EGAS00000000001' returns its constituent EGAD dataset(s) with technology and sample count. Use EGA_get_study to find a study accession first, then EGA_get_dataset for full details on any returned dataset.",
+    "fields": {
+      "operation": "get_study_datasets"
+    },
+    "parameter": {
+      "type": "object",
+      "required": ["accession"],
+      "properties": {
+        "accession": {
+          "type": "string",
+          "description": "EGA study accession, e.g. 'EGAS00000000001'."
+        }
+      }
+    },
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "accession_id": {"type": ["string", "null"]},
+              "title": {"type": ["string", "null"]},
+              "technologies": {"type": "array", "items": {"type": "string"}},
+              "num_samples": {"type": ["integer", "null"]},
+              "access_type": {"type": ["string", "null"]}
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {"error": {"type": "string"}},
+          "required": ["error"]
+        }
+      ]
+    },
+    "test_examples": [
+      {"accession": "EGAS00000000001"},
+      {"accession": "EGAS00000000002"}
+    ]
+  }
+]

--- a/src/tooluniverse/dbgap_tool.py
+++ b/src/tooluniverse/dbgap_tool.py
@@ -1,0 +1,214 @@
+# dbgap_tool.py
+"""
+dbGaP (database of Genotypes and Phenotypes) tool for ToolUniverse.
+
+dbGaP is NCBI's controlled-access archive of US genotype-phenotype
+studies, the American counterpart to EGA. It dropped out of NCBI's
+E-utilities entirely (the "gap" database no longer exists there) in favor
+of a standards-based FHIR API, discovered by finding a "dbGaP FHIR" label
+buried in the advanced-search page and following it to a live HAPI FHIR
+server. Study metadata (title, condition, dataset/variable counts, release
+date) is public even though the underlying genotype/phenotype data
+requires Data Access Committee approval, mirroring EGA.
+
+API: https://dbgap-api.ncbi.nlm.nih.gov/fhir/x1
+No authentication required for metadata.
+"""
+
+from typing import Any, Dict, List
+
+import requests
+
+from .base_tool import BaseTool
+from .tool_registry import register_tool
+
+DBGAP_FHIR_URL = "https://dbgap-api.ncbi.nlm.nih.gov/fhir/x1"
+
+_CONTENT_EXTENSION_SUFFIXES = {
+    "NumPhenotypeDatasets": "phenotype_dataset_count",
+    "NumMolecularDatasets": "molecular_dataset_count",
+    "NumVariables": "variable_count",
+    "NumDocuments": "document_count",
+}
+
+
+def _unique_texts(
+    codeable_concepts: List[Dict[str, Any]], limit: int = 10
+) -> List[str]:
+    """Dedupe FHIR CodeableConcept.text values (MeSH synonym expansion
+    otherwise produces dozens of near-duplicate entries per condition)."""
+    seen: List[str] = []
+    for concept in codeable_concepts or []:
+        text = concept.get("text")
+        if text and text not in seen:
+            seen.append(text)
+        if len(seen) >= limit:
+            break
+    return seen
+
+
+def _extension_value(extensions: List[Dict[str, Any]], suffix: str) -> Any:
+    for ext in extensions or []:
+        if ext.get("url", "").endswith(suffix):
+            for key in ("valueUrl", "valueDate", "valueString", "valueCount"):
+                if key in ext:
+                    value = ext[key]
+                    return value.get("value") if isinstance(value, dict) else value
+    return None
+
+
+def _content_counts(extensions: List[Dict[str, Any]]) -> Dict[str, Any]:
+    for ext in extensions or []:
+        if ext.get("url", "").endswith("ResearchStudy-Content"):
+            return {
+                field: _extension_value(ext.get("extension") or [], suffix)
+                for suffix, field in _CONTENT_EXTENSION_SUFFIXES.items()
+            }
+    return {field: None for field in _CONTENT_EXTENSION_SUFFIXES.values()}
+
+
+@register_tool("DbGaPTool")
+class DbGaPTool(BaseTool):
+    """
+    Tool for searching and resolving dbGaP study metadata via its FHIR API.
+
+    Supports searching studies by title keyword, and fetching one study's
+    full public metadata (condition, dataset/variable counts, consent
+    groups, release date) by its phs accession.
+
+    No authentication required for metadata.
+    """
+
+    def __init__(self, tool_config: Dict[str, Any]):
+        super().__init__(tool_config)
+        self.timeout = tool_config.get("timeout", 30)
+        self.operation = tool_config.get("fields", {}).get(
+            "operation", "search_studies"
+        )
+
+    def run(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        """Execute the dbGaP FHIR lookup."""
+        try:
+            if self.operation == "search_studies":
+                return self._search_studies(arguments)
+            if self.operation == "get_study":
+                return self._get_study(arguments)
+            return {
+                "status": "error",
+                "error": f"Unknown operation: {self.operation}",
+            }
+        except requests.exceptions.Timeout:
+            return {
+                "status": "error",
+                "error": f"dbGaP request timed out after {self.timeout}s",
+            }
+        except requests.exceptions.ConnectionError:
+            return {
+                "status": "error",
+                "error": "Failed to connect to dbGaP. Check network.",
+            }
+        except requests.exceptions.HTTPError as e:
+            code = e.response.status_code if e.response is not None else "unknown"
+            return {"status": "error", "error": f"dbGaP returned HTTP {code}"}
+        except ValueError:
+            return {"status": "error", "error": "dbGaP returned a non-JSON response"}
+        except Exception as e:
+            return {"status": "error", "error": f"Error querying dbGaP: {str(e)}"}
+
+    def _search_studies(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        """Search dbGaP studies by title keyword."""
+        query = (arguments.get("query") or "").strip()
+        if not query:
+            return {
+                "status": "error",
+                "error": "query is required, e.g. 'diabetes' or 'autism'.",
+            }
+
+        limit = arguments.get("limit")
+        if not isinstance(limit, int) or limit <= 0:
+            limit = 25
+        limit = min(limit, 100)
+
+        response = requests.get(
+            f"{DBGAP_FHIR_URL}/ResearchStudy",
+            params={"title": query, "_count": limit},
+            timeout=self.timeout,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        entries = payload.get("entry") or []
+
+        if not entries:
+            return {
+                "status": "error",
+                "error": f"No dbGaP studies matching '{query}'.",
+            }
+
+        rows = []
+        for entry in entries:
+            study = entry.get("resource") or {}
+            rows.append(
+                {
+                    "phs_id": study.get("id"),
+                    "title": study.get("title"),
+                    "status": study.get("status"),
+                    "conditions": _unique_texts(study.get("condition"), limit=5),
+                }
+            )
+
+        return {
+            "status": "success",
+            "data": rows,
+            "metadata": {
+                "query": query,
+                "total_matching": payload.get("total"),
+                "returned": len(rows),
+                "note": "phs_id is what get_study expects for the full "
+                "record.",
+                "source": "dbGaP (NCBI)",
+            },
+        }
+
+    def _get_study(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        """Fetch one dbGaP study's full public metadata by phs accession."""
+        phs_id = (arguments.get("phs_id") or "").strip()
+        if not phs_id:
+            return {
+                "status": "error",
+                "error": "phs_id is required, e.g. 'phs000681'. Use "
+                "search_studies to find one.",
+            }
+
+        response = requests.get(
+            f"{DBGAP_FHIR_URL}/ResearchStudy/{phs_id}", timeout=self.timeout
+        )
+        if response.status_code == 404:
+            return {
+                "status": "error",
+                "error": f"No dbGaP study with accession '{phs_id}'.",
+            }
+        response.raise_for_status()
+        study = response.json()
+        extensions = study.get("extension") or []
+
+        return {
+            "status": "success",
+            "data": {
+                "phs_id": study.get("id"),
+                "title": study.get("title"),
+                "status": study.get("status"),
+                "description": study.get("description"),
+                "conditions": _unique_texts(study.get("condition")),
+                "study_overview_url": _extension_value(
+                    extensions, "StudyOverviewUrl"
+                ),
+                "release_date": _extension_value(extensions, "ReleaseDate"),
+                **_content_counts(extensions),
+            },
+            "metadata": {
+                "phs_id": phs_id,
+                "note": "Metadata only; the underlying genotype/phenotype "
+                "data requires Data Access Committee approval.",
+                "source": "dbGaP (NCBI)",
+            },
+        }

--- a/src/tooluniverse/ddbj_tool.py
+++ b/src/tooluniverse/ddbj_tool.py
@@ -9,9 +9,16 @@ DRA/BioProject/BioSample records include submissions that are mirrored late
 or indexed differently elsewhere.
 
 It also reaches JGA (Japanese Genotype-phenotype Archive) study metadata,
-Japan's controlled-access human archive.
+Japan's controlled-access human archive, and the GEA (Genomic Expression
+Archive) and MetaboBank omics repositories.
+
+Search (search_entries) uses the same DDBJ Search backend's listing API,
+found via its OpenAPI spec after several guessed query-parameter names
+(query, q, search, title) were all rejected outright with a 422 listing
+the actual parameter name expected: `keywords`.
 
 API: https://ddbj.nig.ac.jp/search/entry/{type}/{accession}.json
+     https://ddbj.nig.ac.jp/search/api/entries/{type}
 No authentication required for public metadata.
 """
 
@@ -21,6 +28,7 @@ from .base_tool import BaseTool
 from .tool_registry import register_tool
 
 DDBJ_BASE_URL = "https://ddbj.nig.ac.jp/search/entry"
+DDBJ_SEARCH_URL = "https://ddbj.nig.ac.jp/search/api/entries"
 
 # Accession prefix -> DDBJ entry type, used to auto-detect the route.
 ACCESSION_PREFIXES = [
@@ -32,6 +40,8 @@ ACCESSION_PREFIXES = [
     ("DRX", "sra-experiment"),
     ("DRR", "sra-run"),
     ("DRS", "sra-sample"),
+    ("E-GEAD", "gea"),
+    ("MTBKS", "metabobank"),
 ]
 
 VALID_TYPES = [
@@ -42,6 +52,8 @@ VALID_TYPES = [
     "sra-run",
     "sra-sample",
     "jga-study",
+    "gea",
+    "metabobank",
 ]
 
 
@@ -100,9 +112,10 @@ class DDBJTool(BaseTool):
     """
     Tool for retrieving DDBJ records by accession.
 
-    Supports BioProject, BioSample, DRA (study/experiment/run/sample), and
-    JGA study entries. The entry type is inferred from the accession prefix
-    unless given explicitly.
+    Supports BioProject, BioSample, DRA (study/experiment/run/sample), JGA
+    study, GEA, and MetaboBank entries. The entry type is inferred from the
+    accession prefix unless given explicitly. Also supports keyword search
+    across any entry type, with optional organism and date-range filters.
 
     No authentication required.
     """
@@ -119,6 +132,8 @@ class DDBJTool(BaseTool):
                 return self._get_entry(arguments)
             elif self.operation == "get_cross_references":
                 return self._get_cross_references(arguments)
+            elif self.operation == "search_entries":
+                return self._search_entries(arguments)
             return {
                 "status": "error",
                 "error": f"Unknown operation: {self.operation}",
@@ -156,7 +171,8 @@ class DDBJTool(BaseTool):
                 f"Pass entry_type explicitly. Valid types: {', '.join(VALID_TYPES)}. "
                 "Accession prefixes: PRJD*=bioproject, SAMD*=biosample, "
                 "DRP*=sra-study, DRX*=sra-experiment, DRR*=sra-run, "
-                "DRS*=sra-sample, JGAS*=jga-study.",
+                "DRS*=sra-sample, JGAS*=jga-study, E-GEAD*=gea, MTBKS*="
+                "metabobank.",
             }
         if entry_type not in VALID_TYPES:
             return {
@@ -270,6 +286,76 @@ class DDBJTool(BaseTool):
                 "entry_type": fetched["entry_type"],
                 "total_matching": len(all_xrefs),
                 "counts_by_type": counts,
+                "source": "DNA Data Bank of Japan (DDBJ), INSDC member",
+            },
+        }
+
+    def _search_entries(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        """Keyword-search one DDBJ entry type, with optional filters."""
+        entry_type = (arguments.get("entry_type") or "").strip()
+        if entry_type not in VALID_TYPES:
+            return {
+                "status": "error",
+                "error": f"entry_type is required and must be one of: "
+                f"{', '.join(VALID_TYPES)}.",
+            }
+
+        keywords = (arguments.get("keywords") or "").strip()
+        if not keywords:
+            return {
+                "status": "error",
+                "error": "keywords is required, e.g. 'daptomycin resistance'.",
+            }
+
+        limit = arguments.get("limit")
+        if not isinstance(limit, int) or limit <= 0:
+            limit = 25
+        limit = min(limit, 100)
+
+        params: Dict[str, Any] = {"keywords": keywords, "perPage": limit}
+        organism = arguments.get("organism_taxid")
+        if organism:
+            params["organism"] = str(organism).strip()
+
+        response = requests.get(
+            f"{DDBJ_SEARCH_URL}/{entry_type}", params=params, timeout=self.timeout
+        )
+        response.raise_for_status()
+        payload = response.json()
+        items = payload.get("items") or []
+
+        if not items:
+            return {
+                "status": "error",
+                "error": f"No DDBJ {entry_type} entries matching "
+                f"'{keywords}'"
+                + (f" for organism taxid {organism}" if organism else "")
+                + ".",
+            }
+
+        rows = [
+            {
+                "identifier": item.get("identifier"),
+                "title": item.get("title"),
+                "description": item.get("description"),
+                "organism": _organism(item.get("organism"))["name"],
+                "accessibility": item.get("accessibility"),
+                "date_published": item.get("datePublished"),
+            }
+            for item in items
+        ]
+
+        return {
+            "status": "success",
+            "data": rows,
+            "metadata": {
+                "entry_type": entry_type,
+                "keywords": keywords,
+                "organism_taxid": organism or None,
+                "total_matching": (payload.get("pagination") or {}).get("total"),
+                "returned": len(rows),
+                "note": "identifier is what get_entry and "
+                "get_cross_references expect.",
                 "source": "DNA Data Bank of Japan (DDBJ), INSDC member",
             },
         }

--- a/src/tooluniverse/default_config.py
+++ b/src/tooluniverse/default_config.py
@@ -1097,6 +1097,8 @@ default_tool_files = {
     "fhir_terminology": os.path.join(
         current_dir, "data", "fhir_terminology_tools.json"
     ),
+    # EGA - controlled-access human genomic archive, public metadata only
+    "ega": os.path.join(current_dir, "data", "ega_tools.json"),
     # Gene2Phenotype - EBI curated gene-disease associations for clinical genetics
     "gene2phenotype": os.path.join(current_dir, "data", "gene2phenotype_tools.json"),
     # NASA Exoplanet Archive - ADQL queries for 5500+ confirmed exoplanets and stellar hosts

--- a/src/tooluniverse/default_config.py
+++ b/src/tooluniverse/default_config.py
@@ -1099,6 +1099,9 @@ default_tool_files = {
     ),
     # EGA - controlled-access human genomic archive, public metadata only
     "ega": os.path.join(current_dir, "data", "ega_tools.json"),
+    # dbGaP - controlled-access US genotype-phenotype archive (FHIR API),
+    # the American counterpart to EGA
+    "dbgap": os.path.join(current_dir, "data", "dbgap_tools.json"),
     # Gene2Phenotype - EBI curated gene-disease associations for clinical genetics
     "gene2phenotype": os.path.join(current_dir, "data", "gene2phenotype_tools.json"),
     # NASA Exoplanet Archive - ADQL queries for 5500+ confirmed exoplanets and stellar hosts

--- a/src/tooluniverse/ega_tool.py
+++ b/src/tooluniverse/ega_tool.py
@@ -1,0 +1,215 @@
+# ega_tool.py
+"""
+EGA (European Genome-phenome Archive) tool for ToolUniverse.
+
+EGA archives controlled-access human genomic and phenotypic data; the
+sequence/genotype data itself requires Data Access Committee approval, but
+study and dataset *metadata* (title, description, technology, sample
+count, access policy) is public. EGA accessions (EGAS.../EGAD...) appear
+constantly in papers' data-availability statements with no way to resolve
+them in ToolUniverse today.
+
+The API silently accepts a query-like parameter under any name tried
+(query, q, search, title, free_text_search) without filtering by it at
+all: every variant returned the identical first record regardless of
+content, confirmed by comparing results across nonsense and real queries.
+Only exact-accession lookups are exposed here as a result.
+
+API: https://metadata.ega-archive.org
+No authentication required for metadata (the underlying data is separately
+access-controlled).
+"""
+
+from typing import Any, Dict
+
+import requests
+
+from .base_tool import BaseTool
+from .tool_registry import register_tool
+
+EGA_BASE_URL = "https://metadata.ega-archive.org"
+
+
+@register_tool("EGATool")
+class EGATool(BaseTool):
+    """
+    Tool for resolving EGA study and dataset accessions to their public
+    metadata.
+
+    Supports fetching one study, one dataset, or the datasets belonging to
+    a study, all by exact accession. No free-text search: the API's own
+    query parameters are silently non-functional (see module docstring).
+
+    No authentication required.
+    """
+
+    def __init__(self, tool_config: Dict[str, Any]):
+        super().__init__(tool_config)
+        self.timeout = tool_config.get("timeout", 30)
+        self.operation = tool_config.get("fields", {}).get(
+            "operation", "get_study"
+        )
+
+    def run(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        """Execute the EGA metadata lookup."""
+        try:
+            if self.operation == "get_study":
+                return self._get_study(arguments)
+            if self.operation == "get_dataset":
+                return self._get_dataset(arguments)
+            if self.operation == "get_study_datasets":
+                return self._get_study_datasets(arguments)
+            return {
+                "status": "error",
+                "error": f"Unknown operation: {self.operation}",
+            }
+        except requests.exceptions.Timeout:
+            return {
+                "status": "error",
+                "error": f"EGA request timed out after {self.timeout}s",
+            }
+        except requests.exceptions.ConnectionError:
+            return {
+                "status": "error",
+                "error": "Failed to connect to EGA. Check network.",
+            }
+        except requests.exceptions.HTTPError as e:
+            code = e.response.status_code if e.response is not None else "unknown"
+            return {"status": "error", "error": f"EGA returned HTTP {code}"}
+        except ValueError:
+            return {"status": "error", "error": "EGA returned a non-JSON response"}
+        except Exception as e:
+            return {"status": "error", "error": f"Error querying EGA: {str(e)}"}
+
+    def _get_study(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        """Fetch one study's public metadata by its EGAS accession."""
+        accession = (arguments.get("accession") or "").strip()
+        if not accession:
+            return {
+                "status": "error",
+                "error": "accession is required, e.g. 'EGAS00000000001'.",
+            }
+
+        response = requests.get(
+            f"{EGA_BASE_URL}/studies/{accession}", timeout=self.timeout
+        )
+        if response.status_code == 404:
+            return {
+                "status": "error",
+                "error": f"No EGA study with accession '{accession}'.",
+            }
+        response.raise_for_status()
+        study = response.json()
+
+        return {
+            "status": "success",
+            "data": {
+                "accession_id": study.get("accession_id"),
+                "title": study.get("title"),
+                "description": study.get("description"),
+                "study_type": study.get("study_type"),
+                "pubmed_ids": study.get("pubmed_ids") or [],
+                "is_released": study.get("is_released"),
+                "released_date": study.get("released_date"),
+                "is_deprecated": study.get("is_deprecated"),
+            },
+            "metadata": {
+                "accession": accession,
+                "note": "Metadata only; the underlying sequence/genotype "
+                "data requires Data Access Committee approval. Use "
+                "get_study_datasets for this study's dataset accessions.",
+                "source": "European Genome-phenome Archive (EGA)",
+            },
+        }
+
+    def _get_dataset(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        """Fetch one dataset's public metadata by its EGAD accession."""
+        accession = (arguments.get("accession") or "").strip()
+        if not accession:
+            return {
+                "status": "error",
+                "error": "accession is required, e.g. 'EGAD00000000001'.",
+            }
+
+        response = requests.get(
+            f"{EGA_BASE_URL}/datasets/{accession}", timeout=self.timeout
+        )
+        if response.status_code == 404:
+            return {
+                "status": "error",
+                "error": f"No EGA dataset with accession '{accession}'.",
+            }
+        response.raise_for_status()
+        dataset = response.json()
+
+        return {
+            "status": "success",
+            "data": {
+                "accession_id": dataset.get("accession_id"),
+                "title": dataset.get("title"),
+                "description": dataset.get("description"),
+                "dataset_types": dataset.get("dataset_types") or [],
+                "technologies": dataset.get("technologies") or [],
+                "num_samples": dataset.get("num_samples"),
+                "access_type": dataset.get("access_type"),
+                "policy_accession_id": dataset.get("policy_accession_id"),
+                "is_released": dataset.get("is_released"),
+                "released_date": dataset.get("released_date"),
+            },
+            "metadata": {
+                "accession": accession,
+                "note": "access_type 'controlled' means the actual data "
+                "requires Data Access Committee approval via the "
+                "policy_accession_id shown here.",
+                "source": "European Genome-phenome Archive (EGA)",
+            },
+        }
+
+    def _get_study_datasets(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        """List the dataset accessions belonging to one study."""
+        accession = (arguments.get("accession") or "").strip()
+        if not accession:
+            return {
+                "status": "error",
+                "error": "accession is required, e.g. 'EGAS00000000001'.",
+            }
+
+        response = requests.get(
+            f"{EGA_BASE_URL}/studies/{accession}/datasets", timeout=self.timeout
+        )
+        if response.status_code == 404:
+            return {
+                "status": "error",
+                "error": f"No EGA study with accession '{accession}'.",
+            }
+        response.raise_for_status()
+        datasets = response.json() or []
+
+        if not datasets:
+            return {
+                "status": "error",
+                "error": f"No datasets found for EGA study '{accession}'.",
+            }
+
+        rows = [
+            {
+                "accession_id": d.get("accession_id"),
+                "title": d.get("title"),
+                "technologies": d.get("technologies") or [],
+                "num_samples": d.get("num_samples"),
+                "access_type": d.get("access_type"),
+            }
+            for d in datasets
+        ]
+
+        return {
+            "status": "success",
+            "data": rows,
+            "metadata": {
+                "study_accession": accession,
+                "returned": len(rows),
+                "note": "accession_id is what get_dataset expects for full "
+                "dataset metadata.",
+                "source": "European Genome-phenome Archive (EGA)",
+            },
+        }

--- a/tests/tools/test_dbgap_tool.py
+++ b/tests/tools/test_dbgap_tool.py
@@ -1,0 +1,80 @@
+"""Tests for the dbGaP tool.
+
+dbGaP no longer exists in NCBI's E-utilities (the 'gap' database was
+removed); this uses a standards-based FHIR API instead, found via a
+"dbGaP FHIR" label buried in the advanced-search page's HTML. The server
+also rate-limits aggressively -- back-to-back requests within the same
+test run triggered HTTP 429 during development even though each request
+succeeded fine in isolation -- so tests here keep network calls to a
+minimum rather than issuing many in quick succession.
+"""
+
+import pytest
+from tooluniverse import ToolUniverse
+
+
+TRANSIENT = ("timed out", "Failed to connect", "HTTP 5", "HTTP 429")
+
+DIABETES_STUDY = "phs000681"
+
+
+@pytest.fixture(scope="module")
+def tu():
+    instance = ToolUniverse()
+    instance.load_tools()
+    return instance
+
+
+def data_of(result):
+    if result.get("status") == "error":
+        error = str(result.get("error", ""))
+        if any(t in error for t in TRANSIENT):
+            pytest.skip(f"upstream temporarily unavailable: {error[:80]}")
+        pytest.fail(f"unexpected error response: {error[:200]}")
+    return result["data"]
+
+
+class TestRegistration:
+    def test_tools_load(self, tu):
+        names = {t.get("name") for t in tu.all_tools if isinstance(t, dict)}
+        assert "DbGaP_search_studies" in names
+        assert "DbGaP_get_study" in names
+
+
+class TestSearchStudies:
+    def test_finds_known_study(self, tu):
+        rows = data_of(tu.tools.DbGaP_search_studies(query="diabetes", limit=10))
+        assert any(r["phs_id"] == DIABETES_STUDY for r in rows)
+
+    def test_missing_query(self, tu):
+        assert tu.tools.DbGaP_search_studies(query="")["status"] == "error"
+
+
+class TestGetStudy:
+    def test_known_study_metadata(self, tu):
+        data = data_of(tu.tools.DbGaP_get_study(phs_id=DIABETES_STUDY))
+        assert "Diabetes" in data["title"]
+        assert data["phenotype_dataset_count"] == 4
+        assert data["variable_count"] == 15
+
+    def test_unknown_study(self, tu):
+        result = tu.tools.DbGaP_get_study(phs_id="NOTAREAL")
+        assert result["status"] == "error"
+
+    def test_missing_phs_id(self, tu):
+        assert tu.tools.DbGaP_get_study(phs_id="")["status"] == "error"
+
+
+class TestErrorHandling:
+    @pytest.mark.parametrize(
+        "tool_name,kwargs",
+        [
+            ("DbGaP_search_studies", {"query": ""}),
+            ("DbGaP_get_study", {"phs_id": ""}),
+        ],
+    )
+    def test_returns_error_dict_not_exception(self, tu, tool_name, kwargs):
+        result = getattr(tu.tools, tool_name)(**kwargs)
+        assert isinstance(result, dict)
+        assert result["status"] == "error"
+        assert isinstance(result.get("error"), str) and result["error"]

--- a/tests/tools/test_ega_tool.py
+++ b/tests/tools/test_ega_tool.py
@@ -1,0 +1,101 @@
+"""Tests for the EGA (European Genome-phenome Archive) tool.
+
+EGA accessions appear constantly in papers' data-availability statements
+with no way to resolve them in ToolUniverse before this. The API's own
+query-like parameters are completely non-functional under every name
+tried (query, q, search, title, free_text_search all returned the
+identical first record), so only exact-accession lookups are exposed.
+Tests assert real, known metadata survives the round trip.
+"""
+
+import pytest
+from tooluniverse import ToolUniverse
+
+
+TRANSIENT = ("timed out", "Failed to connect", "HTTP 5")
+
+BIPOLAR_STUDY = "EGAS00000000001"
+CONTROL_DATASET = "EGAD00000000001"
+
+
+@pytest.fixture(scope="module")
+def tu():
+    instance = ToolUniverse()
+    instance.load_tools()
+    return instance
+
+
+def data_of(result):
+    if result.get("status") == "error":
+        error = str(result.get("error", ""))
+        if any(t in error for t in TRANSIENT):
+            pytest.skip(f"upstream temporarily unavailable: {error[:80]}")
+        pytest.fail(f"unexpected error response: {error[:200]}")
+    return result["data"]
+
+
+class TestRegistration:
+    def test_tools_load(self, tu):
+        names = {t.get("name") for t in tu.all_tools if isinstance(t, dict)}
+        assert "EGA_get_study" in names
+        assert "EGA_get_dataset" in names
+        assert "EGA_get_study_datasets" in names
+
+
+class TestGetStudy:
+    def test_known_study_metadata(self, tu):
+        data = data_of(tu.tools.EGA_get_study(accession=BIPOLAR_STUDY))
+        assert "Bipolar" in data["title"]
+        assert data["accession_id"] == BIPOLAR_STUDY
+
+    def test_unknown_study(self, tu):
+        result = tu.tools.EGA_get_study(accession="NOTAREALACCESSION")
+        assert result["status"] == "error"
+
+    def test_missing_accession(self, tu):
+        assert tu.tools.EGA_get_study(accession="")["status"] == "error"
+
+
+class TestGetDataset:
+    def test_known_dataset_metadata(self, tu):
+        data = data_of(tu.tools.EGA_get_dataset(accession=CONTROL_DATASET))
+        assert data["accession_id"] == CONTROL_DATASET
+        assert data["access_type"] == "controlled"
+        assert data["num_samples"] == 1504
+
+    def test_unknown_dataset(self, tu):
+        result = tu.tools.EGA_get_dataset(accession="NOTAREALACCESSION")
+        assert result["status"] == "error"
+
+    def test_missing_accession(self, tu):
+        assert tu.tools.EGA_get_dataset(accession="")["status"] == "error"
+
+
+class TestGetStudyDatasets:
+    def test_bipolar_study_has_known_dataset(self, tu):
+        rows = data_of(tu.tools.EGA_get_study_datasets(accession=BIPOLAR_STUDY))
+        assert any(r["accession_id"] == CONTROL_DATASET for r in rows)
+
+    def test_unknown_study(self, tu):
+        result = tu.tools.EGA_get_study_datasets(accession="NOTAREALACCESSION")
+        assert result["status"] == "error"
+
+    def test_missing_accession(self, tu):
+        assert tu.tools.EGA_get_study_datasets(accession="")["status"] == "error"
+
+
+class TestErrorHandling:
+    @pytest.mark.parametrize(
+        "tool_name,kwargs",
+        [
+            ("EGA_get_study", {"accession": ""}),
+            ("EGA_get_study", {"accession": "NOTAREALACCESSION"}),
+            ("EGA_get_dataset", {"accession": ""}),
+            ("EGA_get_study_datasets", {"accession": ""}),
+        ],
+    )
+    def test_returns_error_dict_not_exception(self, tu, tool_name, kwargs):
+        result = getattr(tu.tools, tool_name)(**kwargs)
+        assert isinstance(result, dict)
+        assert result["status"] == "error"
+        assert isinstance(result.get("error"), str) and result["error"]

--- a/tests/tools/test_gcbr_tools.py
+++ b/tests/tools/test_gcbr_tools.py
@@ -13,6 +13,7 @@ from tooluniverse import ToolUniverse
 EXPECTED_TOOLS = [
     "DDBJ_get_entry",
     "DDBJ_get_cross_references",
+    "DDBJ_search_entries",
     "BacDive_search_by_taxon",
     "BacDive_get_strain",
     "Orphadata_get_disorder",
@@ -66,12 +67,47 @@ class TestDDBJ:
             ("SAMD00000001", "biosample"),
             ("DRX000001", "sra-experiment"),
             ("JGAS000001", "jga-study"),
+            ("E-GEAD-1000", "gea"),
+            ("MTBKS102", "metabobank"),
         ],
     )
     def test_entry_type_inferred_from_prefix(self, tu, accession, expected_type):
         result = tu.tools.DDBJ_get_entry(accession=accession)
         data_of(result)
         assert result["metadata"]["entry_type"] == expected_type
+
+    def test_search_entries_actually_filters(self, tu):
+        # Regression guard: several DDBJ-adjacent list endpoints (M-CSA,
+        # MediaDive, DHS Program) silently ignore their search parameter
+        # elsewhere in this codebase; confirm this one really filters.
+        narrow = tu.tools.DDBJ_search_entries(
+            entry_type="gea", keywords="daptomycin", limit=10
+        )
+        rows = data_of(narrow)
+        assert rows
+        assert narrow["metadata"]["total_matching"] < 100
+
+    def test_search_entries_organism_filter(self, tu):
+        result = tu.tools.DDBJ_search_entries(
+            entry_type="bioproject",
+            keywords="lung cancer",
+            organism_taxid=9606,
+            limit=5,
+        )
+        rows = data_of(result)
+        assert rows
+
+    def test_search_entries_unmatched_query(self, tu):
+        result = tu.tools.DDBJ_search_entries(
+            entry_type="gea", keywords="zzzznotarealterm12345"
+        )
+        assert result["status"] == "error"
+
+    def test_search_entries_requires_valid_entry_type(self, tu):
+        result = tu.tools.DDBJ_search_entries(
+            entry_type="notarealtype", keywords="test"
+        )
+        assert result["status"] == "error"
 
     def test_organism_flattened_to_name_and_taxid(self, tu):
         # Upstream returns {"identifier": ..., "name": ...}


### PR DESCRIPTION
## Summary

Follow-up to #532. Closes the controlled-access human-data archive gap identified in the original coverage analysis: EGA and dbGaP were completely unreachable in ToolUniverse before this, and DDBJ (added in #532) only covered a subset of its own entry types.

**EGA (European Genome-phenome Archive)** — resolves study/dataset accessions to public metadata (title, description, technology, sample count, access policy). The underlying sequence/genotype data is separately access-controlled via Data Access Committee approval; only the metadata is public. EGA accessions appear constantly in papers' data-availability statements with no prior way to resolve them.

**dbGaP** — the US counterpart to EGA. dbGaP has dropped out of NCBI's E-utilities entirely (the `gap` database no longer exists there); found a live, standards-based FHIR API instead by tracing a "dbGaP FHIR" label buried in the advanced-search page's Angular app down to a working HAPI FHIR server.

**DDBJ extended** (not a new tool — extends the existing `DDBJTool` from #532) — adds GEA (expression) and MetaboBank (metabolomics) entry types, plus a genuinely new `search_entries` operation that keyword-searches *any* DDBJ entry type (bioproject, biosample, SRA, JGA, GEA, MetaboBank), found via the API's own OpenAPI spec. JGA study lookup was confirmed already working from #532's prefix-detection logic — no new code needed there.

## Real findings from live verification (not assumed)

- **EGA's search parameters are completely non-functional** under every name tried (`query`, `q`, `search`, `title`, `free_text_search`) — confirmed because a literal `DUMMY_STUDY` placeholder record sitting in EGA's own production database surfaces identically regardless of query content. Only exact-accession lookup is exposed as a result.
- **dbGaP's FHIR server rate-limits aggressively** on back-to-back requests (HTTP 429) even though each request succeeds fine in isolation — confirmed by re-running the identical request standalone. `test_examples` and tests are scoped to minimize consecutive calls.
- **DDBJ Search's real parameter is `keywords`**, not the more obvious `query`/`q`/`search`/`title` — but unlike several APIs found in #532, this one explicitly *rejects* wrong parameter names with a 422 naming the correct one, rather than silently ignoring them.

## Dropped after verification (not built)

CARD (ontology download only, no REST API — ARO terms already reachable via the existing OLS wrapper), GIAB and PLINDER (raw file listings / HuggingFace-auth-gated), ProThermDB (no discoverable JSON backend), STOmicsDB (redirects to an unreachable internal IP), AMRFinderPlus (no discoverable API endpoint), three molecular glue degrader databases (MGDD, MGDDB, DiffER — all unreachable), TWAS Atlas (real backend confirmed but requires reverse-engineering an undocumented multi-step AJAX chain), OHDSI Athena (403, authentication required), EPA CompTox (DNS-unreachable from this environment). Remaining EBI Job Dispatcher services (BLAST, EMBOSS pepstats/pepinfo) were confirmed redundant with tools already in the repo (`blast_tool.py`, `protparam_tool.py`).

## Test plan

- [x] `scripts/test_new_tools.py {ega,dbgap,ddbj} -v` — 20/20 pass, 0 schema-invalid
- [x] Direct `ToolUniverse().load_tools()` registration check for all 6 new/extended tool names
- [x] Live smoke tests against real external APIs, plus explicit error-path tests (bad accessions, empty required fields)
- [x] Full pytest suite (51 tests: 14 EGA + 8 dbGaP + 29 in the extended GCBR suite, covering pre-existing DDBJ/BacDive/Orphadata tests too) — all green
- [x] No duplicate tool names; final catalog count 2,672 (up from 2,666 after #532)