### PR TITLE
Make the three tabular-analysis tools work from a pip install

### DIFF
--- a/src/tooluniverse/clinical_trial_stats_tool.py
+++ b/src/tooluniverse/clinical_trial_stats_tool.py
@@ -1,55 +1,131 @@
 """Clinical trial adverse-event severity statistical test tool.
 
-Wraps the skill script at
-``skills/tooluniverse-statistical-modeling/scripts/prepare_ae_cohort.py``
-so the merge-and-test logic is callable as a ToolUniverse tool.
-
 Merge convention (matches bix-10 correct answer): take max(AESEV) per subject
 across ALL AE records (no AEPT filtering), inner-join to DM on USUBJID.
+
+The implementation is inlined below rather than loaded from
+``skills/tooluniverse-statistical-modeling/scripts/prepare_ae_cohort.py`` at
+runtime: that path is resolved relative to the repository root, so it does not
+exist under site-packages and the tool failed for every install from PyPI.
 """
 
 from __future__ import annotations
 
-import importlib.util
 import os
-import sys
-from pathlib import Path
 from typing import Any, Dict
+
+import pandas as pd
 
 from .base_tool import BaseTool
 from .tool_registry import register_tool
 
 
-# Resolve the skill script path and load it as a module so we don't duplicate
-# logic. The skill script stays in place for direct Python use.
-_REPO_ROOT = Path(__file__).resolve().parents[2]
-_SCRIPT_PATH = (
-    _REPO_ROOT
-    / "skills"
-    / "tooluniverse-statistical-modeling"
-    / "scripts"
-    / "prepare_ae_cohort.py"
-)
+def prepare_cohort(dm_path: str, ae_path: str, subgroup: str = "") -> pd.DataFrame:
+    """Prepare AE severity cohort with correct convention."""
+    # Try latin1 encoding (common for clinical trial exports)
+    for enc in ["utf-8", "latin1"]:
+        try:
+            dm = pd.read_csv(dm_path, encoding=enc)
+            break
+        except UnicodeDecodeError:
+            continue
+
+    for enc in ["utf-8", "latin1"]:
+        try:
+            ae = pd.read_csv(ae_path, encoding=enc)
+            break
+        except UnicodeDecodeError:
+            continue
+
+    # Max AESEV per subject across ALL AE records (no AEPT filtering)
+    sev = ae.groupby("USUBJID")["AESEV"].max().reset_index()
+    df = dm.merge(sev, on="USUBJID", how="inner").dropna(subset=["AESEV"])
+    df["AESEV"] = df["AESEV"].astype(int)
+
+    print(f"DM: {len(dm)} subjects")
+    print(f"AE: {len(ae)} records, {ae['USUBJID'].nunique()} subjects")
+    print(f"After merge (inner join, max AESEV): {len(df)} subjects")
+
+    # Apply subgroup filter if specified
+    if subgroup:
+        col, val = subgroup.split("=")
+        before = len(df)
+        df = df[df[col.strip()] == val.strip()]
+        print(f"After subgroup {subgroup}: {len(df)} subjects (from {before})")
+
+    print(f"AESEV distribution: {df['AESEV'].value_counts().sort_index().to_dict()}")
+    return df
 
 
-def _load_script_module():
-    """Dynamically import the skill script as a module."""
-    if not _SCRIPT_PATH.exists():
-        return None
-    spec = importlib.util.spec_from_file_location(
-        "_ae_cohort_script", str(_SCRIPT_PATH)
-    )
-    if spec is None or spec.loader is None:
-        return None
-    module = importlib.util.module_from_spec(spec)
-    # Avoid re-running argparse/main when importing
-    saved_argv = sys.argv
-    sys.argv = [str(_SCRIPT_PATH)]
+def run_chi_square(df: pd.DataFrame, group_col: str):
+    """Run chi-square test on group × AESEV. Returns (chi2, p, dof, ct_dict)."""
+    from scipy import stats
+
+    ct = pd.crosstab(df[group_col], df["AESEV"])
+    print(f"\nContingency table ({group_col} × AESEV):")
+    print(ct)
+    chi2, p, dof, _ = stats.chi2_contingency(ct)
+    print(f"\nChi-square = {chi2:.4f}, p = {p:.6f}, dof = {dof}")
+    # ct_dict: nested dict keyed by group then AESEV level
+    ct_dict = {
+        str(k): {str(k2): int(v2) for k2, v2 in row.items()}
+        for k, row in ct.to_dict(orient="index").items()
+    }
+    return float(chi2), float(p), int(dof), ct_dict
+
+
+def run_ordinal(df: pd.DataFrame, group_col: str, covariates: list):
+    """Run ordinal logistic regression. Returns dict with OR results and model summary."""
     try:
-        spec.loader.exec_module(module)
-    finally:
-        sys.argv = saved_argv
-    return module
+        from statsmodels.miscmodels.ordinal_model import OrderedModel
+    except ImportError:
+        print("statsmodels required: pip install statsmodels")
+        return None
+
+    import numpy as np
+
+    formula_vars = [group_col] + covariates
+    X = df[formula_vars].copy()
+
+    # Convert categorical to numeric
+    for col in X.columns:
+        # Not ``dtype == object``: pandas 3 gives string columns a dedicated
+        # ``str`` dtype, so that check silently skips the encoding and
+        # statsmodels then fails with "Pandas data cast to numpy dtype of object".
+        if not pd.api.types.is_numeric_dtype(X[col]):
+            X[col] = pd.Categorical(X[col]).codes
+
+    model = OrderedModel(df["AESEV"], X, distr="logit")
+    result = model.fit(method="bfgs", disp=False)
+    print("\nOrdinal logistic regression:")
+    print(result.summary())
+
+    # Extract odds ratios (with 95% CI from conf_int)
+    print("\nOdds ratios:")
+    conf = result.conf_int()
+    ors = {}
+    for var in formula_vars:
+        idx = list(X.columns).index(var)
+        # ``.iloc``: these are positions, and pandas 3 treats an integer key on
+        # a labelled Series as a label, raising KeyError.
+        coef = float(result.params.iloc[idx])
+        or_val = float(np.exp(coef))
+        p_val = float(result.pvalues.iloc[idx])
+        ci_low = float(np.exp(conf.iloc[idx, 0]))
+        ci_high = float(np.exp(conf.iloc[idx, 1]))
+        print(f"  {var}: OR = {or_val:.4f}, p = {p_val:.6f}")
+        ors[var] = {
+            "coef": coef,
+            "or": or_val,
+            "ci_lower": ci_low,
+            "ci_upper": ci_high,
+            "p_value": p_val,
+        }
+    return {
+        "odds_ratios": ors,
+        "model_summary": str(result.summary()),
+        "primary_var": group_col,
+    }
 
 
 @register_tool("ClinicalTrialAESeverityTestTool")
@@ -93,15 +169,8 @@ class ClinicalTrialAESeverityTestTool(BaseTool):
                 "error": f"Invalid test: {test}. Use chi-square, ordinal, or prepare.",
             }
 
-        module = _load_script_module()
-        if module is None:
-            return {
-                "status": "error",
-                "error": f"Skill script not available at {_SCRIPT_PATH}",
-            }
-
         try:
-            df = module.prepare_cohort(dm_file, ae_file, subgroup)
+            df = prepare_cohort(dm_file, ae_file, subgroup)
         except KeyError as exc:
             return {"status": "error", "error": f"Missing required column: {exc}"}
         except Exception as exc:  # noqa: BLE001
@@ -134,7 +203,7 @@ class ClinicalTrialAESeverityTestTool(BaseTool):
 
         if test == "chi-square":
             try:
-                chi2, p, dof, ct_dict = module.run_chi_square(df, group_col)
+                chi2, p, dof, ct_dict = run_chi_square(df, group_col)
             except Exception as exc:  # noqa: BLE001
                 return {"status": "error", "error": f"Chi-square failed: {exc}"}
             return {
@@ -158,7 +227,7 @@ class ClinicalTrialAESeverityTestTool(BaseTool):
                 "error": f"Covariates not in DM columns: {missing}",
             }
         try:
-            result = module.run_ordinal(df, group_col, covariates)
+            result = run_ordinal(df, group_col, covariates)
         except Exception as exc:  # noqa: BLE001
             return {"status": "error", "error": f"Ordinal regression failed: {exc}"}
         if result is None:

--- a/src/tooluniverse/expression_anova_tool.py
+++ b/src/tooluniverse/expression_anova_tool.py
@@ -1,47 +1,131 @@
 """Per-gene expression ANOVA / fold-change tool.
 
-Wraps the skill script at
-``skills/tooluniverse-statistical-modeling/scripts/expression_anova.py``.
+The implementation is inlined below rather than loaded from
+``skills/tooluniverse-statistical-modeling/scripts/expression_anova.py`` at
+runtime: that path is resolved relative to the repository root, so it does not
+exist under site-packages and the tool failed for every install from PyPI.
 """
 
 from __future__ import annotations
 
-import importlib.util
 import os
-import sys
-from pathlib import Path
 from typing import Any, Dict, List
+
+import numpy as np
+import pandas as pd
+from scipy import stats
 
 from .base_tool import BaseTool
 from .tool_registry import register_tool
 
 
-_REPO_ROOT = Path(__file__).resolve().parents[2]
-_SCRIPT_PATH = (
-    _REPO_ROOT
-    / "skills"
-    / "tooluniverse-statistical-modeling"
-    / "scripts"
-    / "expression_anova.py"
-)
+def load_data(
+    counts_path: str, meta_path: str, group_col: str, exclude_groups: list[str]
+):
+    """Load count matrix and metadata, return per-gene group means."""
+    counts = pd.read_csv(counts_path, index_col=0)
+    meta = pd.read_csv(meta_path)
+
+    # Try to match columns: search each meta column for overlap with counts columns
+    if meta.index.name is None and len(meta.columns) > 0:
+        for col in meta.columns:
+            if set(meta[col].astype(str)).intersection(set(counts.columns)):
+                meta = meta.set_index(col)
+                break
+        else:
+            # No meta column overlaps counts columns — try counts rows (after transpose)
+            counts_t_cols = set(counts.index.astype(str))
+            for col in meta.columns:
+                if set(meta[col].astype(str)).intersection(counts_t_cols):
+                    meta = meta.set_index(col)
+                    break
+
+    # Align
+    common = counts.columns.intersection(meta.index)
+    if len(common) == 0:
+        # Try transposing counts
+        counts = counts.T
+        common = counts.columns.intersection(meta.index)
+    counts = counts[common]
+    meta = meta.loc[common]
+
+    # Filter groups
+    groups = meta[group_col].unique()
+    if exclude_groups:
+        groups = [g for g in groups if g not in exclude_groups]
+    meta = meta[meta[group_col].isin(groups)]
+    counts = counts[meta.index]
+
+    return counts, meta, group_col, groups
 
 
-def _load_script_module():
-    if not _SCRIPT_PATH.exists():
-        return None
-    spec = importlib.util.spec_from_file_location(
-        "_expression_anova_script", str(_SCRIPT_PATH)
-    )
-    if spec is None or spec.loader is None:
-        return None
-    module = importlib.util.module_from_spec(spec)
-    saved_argv = sys.argv
-    sys.argv = [str(_SCRIPT_PATH)]
-    try:
-        spec.loader.exec_module(module)
-    finally:
-        sys.argv = saved_argv
-    return module
+def per_gene_anova(counts, meta, group_col, groups):
+    """Run one-way ANOVA comparing per-gene mean expression across groups.
+
+    For each gene, compute its mean expression in each group.
+    Then run f_oneway across the K groups of N gene-level means.
+
+    Returns dict: {f_statistic, p_value, n_genes, n_samples, groups}.
+    """
+    # Compute per-gene mean in each group
+    group_means = {}
+    for g in groups:
+        samples = meta[meta[group_col] == g].index
+        group_means[g] = counts[samples].mean(axis=1)
+
+    # Each group has N values (one per gene)
+    arrays = [group_means[g].values for g in groups]
+    f_stat, p_val = stats.f_oneway(*arrays)
+
+    print(f"Groups: {list(groups)}")
+    print(f"Genes: {len(counts)}")
+    print(f"F-statistic: {f_stat:.4f}")
+    print(f"p-value: {p_val:.6f}")
+    return {
+        "f_statistic": float(f_stat),
+        "p_value": float(p_val),
+        "n_genes": int(len(counts)),
+        "n_samples": int(counts.shape[1]),
+        "groups": [str(g) for g in groups],
+    }
+
+
+def per_gene_fold_change(counts, meta, group_col, group_a, group_b):
+    """Compute per-gene log2 fold change between two groups, then median.
+
+    Returns dict: {median_log2fc, mean_log2fc, n_genes, group_a, group_b,
+    n_samples_a, n_samples_b, n_abs_fc_gt_1}.
+    """
+    samples_a = meta[meta[group_col] == group_a].index
+    samples_b = meta[meta[group_col] == group_b].index
+
+    mean_a = counts[samples_a].mean(axis=1)
+    mean_b = counts[samples_b].mean(axis=1)
+
+    # Avoid log(0): add pseudocount
+    pseudo = 1.0
+    log2fc = np.log2((mean_a + pseudo) / (mean_b + pseudo))
+
+    median_fc = np.median(log2fc)
+    mean_fc = np.mean(log2fc)
+    n_big = int((np.abs(log2fc) > 1).sum())
+
+    print(f"Group A ({group_a}): {len(samples_a)} samples")
+    print(f"Group B ({group_b}): {len(samples_b)} samples")
+    print(f"Genes: {len(log2fc)}")
+    print(f"Median log2FC: {median_fc:.4f}")
+    print(f"Mean log2FC: {mean_fc:.4f}")
+    print(f"Genes with |log2FC| > 1: {n_big}")
+    return {
+        "median_log2fc": float(median_fc),
+        "mean_log2fc": float(mean_fc),
+        "n_genes": int(len(log2fc)),
+        "group_a": str(group_a),
+        "group_b": str(group_b),
+        "n_samples_a": int(len(samples_a)),
+        "n_samples_b": int(len(samples_b)),
+        "n_abs_log2fc_gt_1": n_big,
+    }
 
 
 @register_tool("ExpressionANOVAPerGeneTool")
@@ -81,15 +165,8 @@ class ExpressionANOVAPerGeneTool(BaseTool):
                 "error": "group_a and group_b required for mode='fold_change'",
             }
 
-        module = _load_script_module()
-        if module is None:
-            return {
-                "status": "error",
-                "error": f"Skill script not available at {_SCRIPT_PATH}",
-            }
-
         try:
-            counts, meta, gcol, groups = module.load_data(
+            counts, meta, gcol, groups = load_data(
                 counts_file, meta_file, group_col, list(exclude_groups)
             )
         except KeyError as exc:
@@ -110,7 +187,7 @@ class ExpressionANOVAPerGeneTool(BaseTool):
                     "error": f"ANOVA needs >=2 groups, got {list(groups)}",
                 }
             try:
-                result = module.per_gene_anova(counts, meta, gcol, groups)
+                result = per_gene_anova(counts, meta, gcol, groups)
             except Exception as exc:  # noqa: BLE001
                 return {"status": "error", "error": f"ANOVA failed: {exc}"}
             return {"status": "success", "data": result}
@@ -126,9 +203,7 @@ class ExpressionANOVAPerGeneTool(BaseTool):
                 "error": f"group_a/group_b not found among groups {group_vals}",
             }
         try:
-            result = module.per_gene_fold_change(
-                counts, meta, gcol, resolved_a, resolved_b
-            )
+            result = per_gene_fold_change(counts, meta, gcol, resolved_a, resolved_b)
         except Exception as exc:  # noqa: BLE001
             return {"status": "error", "error": f"Fold-change failed: {exc}"}
         return {"status": "success", "data": result}

--- a/src/tooluniverse/variant_fraction_tool.py
+++ b/src/tooluniverse/variant_fraction_tool.py
@@ -1,47 +1,133 @@
 """Coding variant fraction tool.
 
-Wraps the skill script at
-``skills/tooluniverse-variant-analysis/scripts/variant_fraction.py``.
+The implementation is inlined below rather than loaded from
+``skills/tooluniverse-variant-analysis/scripts/variant_fraction.py`` at
+runtime: that path is resolved relative to the repository root, so it does not
+exist under site-packages and the tool failed for every install from PyPI.
 """
 
 from __future__ import annotations
 
-import importlib.util
 import os
-import sys
-from pathlib import Path
 from typing import Any, Dict
+
+import pandas as pd
 
 from .base_tool import BaseTool
 from .tool_registry import register_tool
 
 
-_REPO_ROOT = Path(__file__).resolve().parents[2]
-_SCRIPT_PATH = (
-    _REPO_ROOT
-    / "skills"
-    / "tooluniverse-variant-analysis"
-    / "scripts"
-    / "variant_fraction.py"
-)
+CODING_SO_TERMS = {
+    "synonymous_variant",
+    "missense_variant",
+    "splice_region_variant",
+    "stop_gained",
+    "stop_lost",
+    "start_lost",
+    "frameshift_variant",
+    "inframe_insertion",
+    "inframe_deletion",
+}
 
 
-def _load_script_module():
-    if not _SCRIPT_PATH.exists():
-        return None
-    spec = importlib.util.spec_from_file_location(
-        "_variant_fraction_script", str(_SCRIPT_PATH)
+NON_CODING_SO_TERMS = {
+    "intron_variant",
+    "3_prime_UTR_variant",
+    "5_prime_UTR_variant",
+    "upstream_gene_variant",
+    "downstream_gene_variant",
+    "intergenic_variant",
+}
+
+
+def compute_variant_fraction(
+    file_path: str,
+    vaf_threshold: float = 0.3,
+    annotation: str = "synonymous_variant",
+    header_rows: int = 1,
+    vaf_col: str = "",
+    so_col: str = "",
+) -> dict:
+    """Compute fraction of variants with a specific annotation.
+
+    Uses CODING variants as denominator (synonymous, missense, splice_region,
+    stop_gained/lost, start_lost, frameshift, inframe indels).
+
+    Returns dict with: total_variants, vaf_filtered, coding_variants_below_vaf,
+    matching_annotation, fraction, naive_fraction, vaf_column, so_column.
+    """
+    # Load file
+    if file_path.endswith(".xlsx"):
+        if header_rows == 2:
+            df = pd.read_excel(file_path, header=[0, 1])
+        else:
+            df = pd.read_excel(file_path)
+    else:
+        df = pd.read_csv(file_path)
+
+    total = len(df)
+    print(f"Loaded: {df.shape}")
+    print(f"Columns: {list(df.columns)[:10]}")
+
+    # Auto-detect VAF and SO columns if not provided
+    if not vaf_col:
+        for col in df.columns:
+            col_str = str(col).lower()
+            if "variant allele freq" in col_str or "vaf" in col_str:
+                vaf_col = col
+                break
+
+    if not so_col:
+        for col in df.columns:
+            col_str = str(col).lower()
+            if "sequence ontology" in col_str:
+                so_col = col
+                break
+
+    if not vaf_col or not so_col:
+        raise ValueError(
+            f"Could not find VAF column ({vaf_col}) or SO column ({so_col}). "
+            f"Available columns: {list(df.columns)}"
+        )
+
+    print(f"VAF column: {vaf_col}")
+    print(f"SO column: {so_col}")
+
+    # Filter by VAF threshold
+    df_filtered = df[pd.to_numeric(df[vaf_col], errors="coerce") < vaf_threshold]
+    print(f"Variants with VAF < {vaf_threshold}: {len(df_filtered)}")
+
+    # Filter to coding variants only
+    coding_mask = (
+        df_filtered[so_col]
+        .astype(str)
+        .apply(lambda x: any(term in x for term in CODING_SO_TERMS))
     )
-    if spec is None or spec.loader is None:
-        return None
-    module = importlib.util.module_from_spec(spec)
-    saved_argv = sys.argv
-    sys.argv = [str(_SCRIPT_PATH)]
-    try:
-        spec.loader.exec_module(module)
-    finally:
-        sys.argv = saved_argv
-    return module
+    df_coding = df_filtered[coding_mask]
+    print(f"Coding variants: {len(df_coding)}")
+
+    # Count target annotation
+    target_mask = df_coding[so_col].astype(str).str.contains(annotation, na=False)
+    n_target = int(target_mask.sum())
+    fraction = n_target / len(df_coding) if len(df_coding) > 0 else 0.0
+    naive = n_target / len(df_filtered) if len(df_filtered) > 0 else 0.0
+
+    print(f"{annotation}: {n_target}")
+    print(f"Fraction (coding denominator): {fraction:.4f}")
+    print(f"For comparison, naive fraction (all variants): {naive:.4f}")
+
+    return {
+        "total_variants": int(total),
+        "vaf_filtered": int(len(df_filtered)),
+        "coding_variants_below_vaf": int(len(df_coding)),
+        "matching_annotation": n_target,
+        "fraction": float(fraction),
+        "naive_fraction": float(naive),
+        "vaf_column": str(vaf_col),
+        "so_column": str(so_col),
+        "vaf_threshold": float(vaf_threshold),
+        "annotation": str(annotation),
+    }
 
 
 @register_tool("CodingVariantFractionTool")
@@ -73,15 +159,8 @@ class CodingVariantFractionTool(BaseTool):
                 "error": f"header_rows must be 1 or 2, got {header_rows}",
             }
 
-        module = _load_script_module()
-        if module is None:
-            return {
-                "status": "error",
-                "error": f"Skill script not available at {_SCRIPT_PATH}",
-            }
-
         try:
-            result = module.compute_variant_fraction(
+            result = compute_variant_fraction(
                 file_path=file_path,
                 vaf_threshold=vaf_threshold,
                 annotation=annotation,


### PR DESCRIPTION
`clinical_trial_ae_severity_test`, `expression_anova_per_gene` and `coding_variant_fraction` are unusable for anyone who installs from PyPI. Each resolves its implementation with `Path(__file__).parents[2] / "skills" / ...`, which from `site-packages` points at `lib/pythonX.Y/skills` — a path that never exists. Every call returns `Skill script not available`.

## Fix

Inline each implementation into the tool module that already exists, and drop the runtime file loading. Nothing new is added under `src/`, and `skills/` is untouched — those scripts stay the standalone command-line entry points they already were.

Only three files change, all pre-existing.

## Also fixed

Two pandas-3 breakages carried in `run_ordinal`, both fatal to the ordinal regression:

- `X[col].dtype == object` skipped the categorical encoding, since pandas 3 gives string columns a dedicated `str` dtype; statsmodels then raised `Pandas data cast to numpy dtype of object`.
- `result.params[idx]` indexed a labelled Series by position, which pandas 3 treats as a label and raises `KeyError` on. This was the `FutureWarning` pandas 2 had been emitting.

## Verification

From a clean wheel build with no repository on the path, pandas 3.0.5:

```
clinical_trial_ae_severity_test: success  n=791 (pub 791)  OR=1.53 (pub 1.53)
                                 CI=(1.16, 2.01) (pub 1.16-2.01)  p=0.0024 (pub 0.0024)
coding_variant_fraction:         success
expression_anova_per_gene:       success
```

The published values are those in the [case-studies post](https://aiscientist.tools/posts/tooluniverse-case-studies) and its supplementary note.

The inlined functions are AST-identical to the skill scripts they replace, apart from `run_ordinal`, which carries the two fixes above — so behaviour is unchanged except where it was broken.