### PR TITLE
Restructure the case-studies README as input, process, output

### DIFF
--- a/examples/case_studies/README.md
+++ b/examples/case_studies/README.md
@@ -198,8 +198,12 @@ Expect some movement, and know which kind matters:
   the count.
 - **Case 3 should never move.** Frozen dataset, deterministic model, identical
   on pandas 2 and 3. If its numbers change, something in your environment did.
-- **ChEMBL's data API is currently down** (HTTP 500 upstream, [known
-  issue](https://github.com/chembl/chembl_webresource_client/issues/144)). The
-  two steps that need it — Case 1's analog comparison and Case 2's measured
-  affinities — print `[unavailable]` and the case carries on rather than
-  failing. Everything else is unaffected.
+- **One number is deliberately not pinned.** Case 2 reports the best binding
+  affinity it finds, but ChEMBL returns activities unsorted, so the minimum
+  depends on which page you fetch — 0.50, 1.0 and 0.09 nM at offsets 0, 100 and
+  200. What reproduces is the conclusion, that this receptor has nanomolar
+  ligands, not one particular value.
+- **ChEMBL's data API goes down periodically** (HTTP 500 upstream, [known
+  issue](https://github.com/chembl/chembl_webresource_client/issues/144)). When
+  it does, the two steps that need it print `[unavailable]` and the case carries
+  on rather than failing. Everything else is unaffected.

--- a/examples/case_studies/README.md
+++ b/examples/case_studies/README.md
@@ -198,11 +198,13 @@ Expect some movement, and know which kind matters:
   the count.
 - **Case 3 should never move.** Frozen dataset, deterministic model, identical
   on pandas 2 and 3. If its numbers change, something in your environment did.
-- **One number is deliberately not pinned.** Case 2 reports the best binding
-  affinity it finds, but ChEMBL returns activities unsorted, so the minimum
-  depends on which page you fetch — 0.50, 1.0 and 0.09 nM at offsets 0, 100 and
-  200. What reproduces is the conclusion, that this receptor has nanomolar
-  ligands, not one particular value.
+- **One published number is understated.** The write-up reports *OXTR* Ki
+  "as low as 3.2 nM". ChEMBL returns activities unsorted and paginated, so a
+  single page gives an arbitrary minimum — 0.50, 1.0 and 0.09 nM at offsets 0,
+  100 and 200. Case 2 now pages through all 811 Ki measurements and finds the
+  real figure, **0.025 nM**, about 130× lower. The conclusion the case draws
+  from it, that *OXTR* has well-characterised high-affinity ligands, is
+  unaffected — if anything it is stronger.
 - **ChEMBL's data API goes down periodically** (HTTP 500 upstream, [known
   issue](https://github.com/chembl/chembl_webresource_client/issues/144)). When
   it does, the two steps that need it print `[unavailable]` and the case carries

--- a/examples/case_studies/README.md
+++ b/examples/case_studies/README.md
@@ -1,28 +1,22 @@
-# Case studies: setup and reproduction
+# Three research questions, answered end to end
 
-Runnable versions of the three case studies in
-[Use Cases: Target Assessment, Druggability, and a Clinical Trial Reanalysis](https://aiscientist.tools/posts/tooluniverse-case-studies).
+Each script here takes a real research question and answers it the way the AI
+scientist in [this write-up](https://aiscientist.tools/posts/tooluniverse-case-studies)
+did: by choosing tools, chaining them across databases, structures, screens and
+predictive models, and reasoning about what comes back.
 
-Each script makes the same tool calls, in the same order, that the AI scientist
-made in the post, and prints the published value next to the one it just
-retrieved, so a run tells you either "this still reproduces" or exactly which
-number moved.
+You run one and watch the investigation unfold, step by step, with the evidence
+printed as it arrives.
 
-The post reports headline numbers; the supplementary note it condenses
-("Step-by-step real-world case studies", in the ToolUniverse manuscript,
-[arXiv:2509.23426](https://arxiv.org/abs/2509.23426)) reports the intermediate
-ones. Both are annotated as `published:` here, so several values these scripts
-check — ACMG scores, PDB accessions, per-context DepMap effects, PubChem CIDs —
-are found in the supplementary note rather than in the post itself.
-
-| Case | Question | Script |
+| | Question | Run |
 |---|---|---|
-| 1 | Is *BLM* a context-selective anticancer target, and is ML216 a developable lead? | [`case1_blm_target_assessment.py`](case1_blm_target_assessment.py) |
-| 2 | Is *OXTR* druggable, and does its chemistry fit the autism hypothesis? | [`case2_oxtr_druggability.py`](case2_oxtr_druggability.py) |
-| 3 | Is BCG vaccination associated with higher adverse-event severity? | [`case3_bcg_ae_severity.py`](case3_bcg_ae_severity.py) |
+| **1** | *BLM* loss causes cancer. Could blocking *BLM* still **treat** cancer? | [`case1_blm_target_assessment.py`](case1_blm_target_assessment.py) |
+| **2** | *OXTR* is druggable. Does its chemistry actually fit the autism hypothesis? | [`case2_oxtr_druggability.py`](case2_oxtr_druggability.py) |
+| **3** | Did BCG vaccination make adverse events more severe in a real trial? | [`case3_bcg_ae_severity.py`](case3_bcg_ae_severity.py) |
 
-Cases 1 and 2 read live databases, so their numbers drift as those databases are
-re-released. Case 3 runs on a frozen public dataset and reproduces exactly.
+What makes these worth running is that in all three, the evidence disagrees with
+itself. The interesting part is not retrieval — it is what the workflow does
+when two valid results point opposite ways.
 
 ## Setup
 
@@ -35,195 +29,123 @@ cd ToolUniverse/examples/case_studies
 pip install -r requirements.txt
 ```
 
-No API keys are needed. Every database used here (Open Targets, ClinVar, GeneBe,
-AlphaFold, PDBe, Europe PMC, PubChem, ChEMBL) is open, and ADMET-AI runs
-locally.
-
-Two things worth knowing:
-
-- Without the **`ml` extra**, the ADMET-AI steps in Cases 1 and 2 report
-  `ADMETModel requires 'admet-ai' package`. The rest of both cases still runs.
-- Case 3 gives identical results on pandas 2 and pandas 3.
-
-## Running
+No API keys. Every database used here — Open Targets, ClinVar, GeneBe,
+AlphaFold, PDBe, Europe PMC, PubChem, ChEMBL — is open, and ADMET-AI runs on
+your machine.
 
 ```bash
-cd examples/case_studies
-
 python case1_blm_target_assessment.py     # ~2 min, mostly ADMET-AI model load
 python case2_oxtr_druggability.py         # ~2 min
 
-python download_bcg_data.py               # ~4 MB from Zenodo, CC0
+python download_bcg_data.py               # ~4 MB of trial tables from Zenodo, CC0
 python case3_bcg_ae_severity.py           # seconds
 ```
 
-Cases 1 and 2 load 11 tool categories (146 tools) rather than the full ~2,700,
-and Case 3 loads a single category, which keeps startup to a few seconds.
+## Case 1 — a tumour suppressor that might also be a target
 
-## What each case does
+*BLM* encodes a DNA-repair helicase. Losing it causes Bloom syndrome and raises
+cancer risk across a broad spectrum, which is the textbook signature of a gene
+you protect, not one you drug. The case asks whether the opposite can also be
+true in specific tumours.
 
-### Case 1 — *BLM* as a cancer risk gene and a possible target
+The first three steps build the case *against* inhibition: 464 disease
+associations led by Bloom syndrome, and a patient variant that ClinVar and
+GeneBe independently call pathogenic.
 
-Seven steps, ending in a conclusion neither half of the evidence supports on its
-own. The germline genetics say *BLM* is a tumour suppressor to preserve; the
-DepMap dependency screen says it is a selective vulnerability in a few defined
-cancer contexts. The case holds both and concludes with a testable,
-biomarker-defined hypothesis rather than a target.
+Step 4 is where it turns. The DepMap screen shows *BLM* is not broadly
+essential — but the dependency is not evenly spread:
 
-Tools: `OpenTargets_multi_entity_search_by_query_string`,
-`OpenTargets_get_target_gene_ontology_by_ensemblID`,
-`OpenTargets_get_diseases_phenotypes_by_target_ensembl`,
-`ClinVar_search_variants`, `GeneBe_classify_variant`,
-`OpenTargets_get_target_depmap_essentiality`, `alphafold_get_summary`,
-`PDBe_get_uniprot_structure_coverage`, `EuropePMC_search_articles`,
-`OpenTargets_get_chemical_probes_by_target_ensemblID`,
-`PubChem_get_CID_by_compound_name`, `PubChem_get_compound_properties_by_CID`,
-`ADMETAI_predict_physicochemical_properties`, `ADMETAI_predict_toxicity`,
-`ChEMBL_search_similar_molecules`.
+```
+  mean gene effect: -0.18
+  lines dependent at < -0.5: 94/1258 (7.5%)
+  Most-dependent cancer types (mean gene effect, n>=5 lines):
+    Mature T and NK Neoplasms          -0.47  (n=8)
+    Cutaneous Squamous Cell Carcinoma  -0.44  (n=5)
+```
 
-### Case 2 — *OXTR* druggability and whether the chemistry fits
+So the genetics and the screen are both right and point opposite ways. The
+workflow then looks for precedent, finds that *BLM*'s paralog WRN is already a
+clinically validated synthetic-lethal target in exactly this kind of narrow
+context, and lands on a biomarker-defined hypothesis rather than a target.
 
-Six steps. The target passes every druggability check: experimental structures
-in both the active and inactive states, nanomolar ligands, known agonists and
-antagonists. The case turns on the last step, where nolasiban — drug-like and
-predicted brain-penetrant, so a plausible repurposing candidate — turns out to
-be an *antagonist*, the opposite of the mechanism a pro-social hypothesis needs.
+The last step triages the one available inhibitor, ML216, and finds a predicted
+liver-injury signal that stays pinned near its maximum across every close
+analog — a liability of the scaffold, not of one molecule.
 
-Tools: `OpenTargets_multi_entity_search_by_query_string`,
-`OpenTargets_get_target_gene_ontology_by_ensemblID`, `alphafold_get_summary`,
-`PDBe_get_uniprot_structure_coverage`,
-`OpenTargets_get_diseases_phenotypes_by_target_ensembl`,
-`OpenTargets_get_target_tractability_by_ensemblID`,
-`OpenTargets_get_associated_drugs_by_target_ensemblID`,
-`OpenTargets_get_drug_mechanisms_of_action_by_chemblId`, `ChEMBL_search_targets`,
-`ChEMBL_get_target_activities`, `EuropePMC_search_articles`,
-`PubChem_get_CID_by_compound_name`, `PubChem_get_compound_properties_by_CID`,
-`ADMETAI_predict_physicochemical_properties`, `ADMETAI_predict_BBB_penetrance`.
+## Case 2 — the compound that passes every filter and is still wrong
 
-### Case 3 — BCG vaccination and adverse-event severity
+*OXTR* clears every druggability check the workflow applies: experimental
+structures in both the active and inactive states, binding affinities into the
+low nanomolar, nine known agents, and a receptor already drugged in both
+directions.
 
-One tool, `clinical_trial_ae_severity_test`, in three modes:
+Then it looks for something brain-penetrant, since the autism hypothesis needs
+central exposure. Nolasiban fits: drug-like, high predicted blood-brain-barrier
+penetrance. It looks like a repurposing candidate — until the mechanism check:
 
-1. `prepare` — inner-join the adverse-event table onto demographics on
-   `USUBJID`, reduce each subject to their maximum `AESEV` grade.
-2. `chi-square` — unadjusted treatment-by-severity association.
-3. `ordinal` — proportional-odds logistic regression adjusting for
-   patient-interaction frequency (`patients_seen`, `expect_interact`,
-   `work_hours`).
+```
+  nolasiban action type: ['ANTAGONIST']
+  Read: brain-penetrant non-peptide OXTR chemistry is attainable,
+  but this chemotype BLOCKS the receptor, and the pro-social
+  hypothesis needs it ACTIVATED. Wrong direction.
+```
 
-Data: [BCG-CORONA trial, Zenodo record 12737228](https://zenodo.org/records/12737228),
-CC0-1.0. `download_bcg_data.py` fetches it.
+A compound can satisfy every property filter you thought to apply and still act
+in the opposite pharmacological direction. Checking affinity and BBB alone would
+have produced a confident, wrong recommendation.
 
-One detail the script handles for you: the tool reports the odds ratio against
-its own reference level. Treatment is encoded alphabetically (BCG=0,
-Placebo=1), so the raw OR of **0.65** is Placebo vs BCG, and the published
-**1.53** is its reciprocal. Reporting the raw number as though it were the
-BCG effect would invert the finding.
+## Case 3 — statistics on a real trial, not a database lookup
 
-## Expected output
+The other two cases query databases. This one computes, on the raw tables of the
+public [BCG-CORONA trial](https://zenodo.org/records/12737228) (CC0), using
+`clinical_trial_ae_severity_test` in three modes: build the cohort, test the
+unadjusted association, then fit an adjusted model.
 
-Verified on 2026-08-17 against a fresh clone. Rows marked † are reported in the
-supplementary note rather than in the post.
+It reaches a significant association between BCG and higher adverse-event
+severity, holding after adjustment for how often participants saw patients:
 
-**Case 1** — every published value reproduced:
+```
+  OR for higher severity with BCG: 1.53
+  95% CI: (1.16, 2.01)
+  p-value: 0.0024
+```
 
-| Value | Published | Observed |
-|---|---|---|
-| *BLM* Ensembl gene | ENSG00000197299 | ENSG00000197299 |
-| Disease associations | 464 | 464 |
-| `c.520C>T` ACMG class | Pathogenic | Pathogenic |
-| † ACMG score / transcript | 12 / NM_000057.4 | 12 / NM_000057.4 |
-| DepMap cell lines | 1,258 | 1,258 |
-| † Mean gene effect | −0.18 | −0.18 |
-| † Lines dependent at < −0.5 | 94/1,258 (7.5%) | 94/1,258 (7.5%) |
-| † Mature T/NK neoplasms | −0.47 (n=8) | −0.47 (n=8) |
-| † Cutaneous SCC | −0.44 (n=5) | −0.44 (n=5) |
-| † Peripheral nervous system | −0.33 (n=48) | −0.33 (n=48) |
-| † AlphaFold model / length | AF-P54132-F1 / 1,417 | AF-P54132-F1 / 1,417 |
-| † Helicase-core PDB entries | 7AUC, 4CGZ, 4O3M | all present |
-| ML216 MW | 383 Da | 383.3 |
-| † ML216 PubChem CID | 49852229 | 49852229 |
-| QED / DILI / hERG / AMES | 0.66 / 0.99 / 0.56 / 0.16 | 0.657 / 0.988 / 0.564 / 0.160 |
+Two things the script is careful about, and worth watching for:
 
-**Case 2** — reproduced except the association count:
+- **Direction.** The tool reports the odds ratio against its own reference level
+  (BCG=0, Placebo=1 alphabetically), so the raw **0.65** is Placebo-vs-BCG and
+  the **1.53** above is its reciprocal. Reporting the raw number as the BCG
+  effect would invert the finding.
+- **What it supports.** The cohort is restricted to participants who had at
+  least one adverse event, and severity is a derived per-subject maximum. That
+  makes this a reproducible association from a secondary analysis, not evidence
+  that vaccination changes severity.
 
-| Value | Published | Observed |
-|---|---|---|
-| *OXTR* Ensembl gene | ENSG00000180914 | ENSG00000180914 |
-| Structures 7RYC / 6TPK | present | present |
-| † Structure 7QVM, AF-P30559-F1, length 389 | present / 389 | present / 389 |
-| Disease associations | 393 | **465** (drift, see below) |
-| Known agents | 9 | 9 |
-| oxytocin / atosiban mechanism | agonist / antagonist | AGONIST / ANTAGONIST |
-| † nolasiban CID | 52947354 | 52947354 |
-| nolasiban QED / BBB | 0.87 / 0.93 | 0.872 / 0.925 |
-| nolasiban mechanism | antagonist | ANTAGONIST |
+## Reading the output
 
-**Case 3** — exact:
+Every value the scripts print carries the number originally reported beside it:
 
-| Value | Published | Observed |
-|---|---|---|
-| Evaluable subjects | 791 | 791 |
-| † Severity distribution | {1:328, 2:402, 3:43, 4:18} | identical |
-| Chi-square / dof / p | 10.12 / 3 / 0.018 | 10.12 / 3 / 0.018 |
-| Adjusted OR (95% CI) | 1.53 (1.16–2.01) | 1.53 (1.16–2.01) |
-| p | 0.0024 | 0.0024 |
+```
+  DILI (liver injury): 0.988   (published: 0.99)
+```
 
-## Why numbers drift, and which ones should not
+So a run tells you at a glance whether the science still holds up against live
+databases, and exactly which number moved if it doesn't. Values marked
+`published:` come from the write-up or from the supplementary note it condenses
+([arXiv:2509.23426](https://arxiv.org/abs/2509.23426)) — the note carries the
+intermediate ones such as ACMG scores, PDB accessions and per-context DepMap
+effects.
 
-- **Live database counts move.** *OXTR* disease associations were 393 when the
-  post was written and are 465 now; Open Targets re-scores associations every
-  release. The *BLM* count happens to be unchanged. Treat these as
-  release-dependent, not as reproduction failures. The conclusions do not rest
-  on them.
-- **Stereochemistry changes ADMET-AI scores.** The scripts request PubChem's
-  `SMILES` property (which carries stereochemistry) and fall back to
-  `ConnectivitySMILES`. For nolasiban the flat form scores BBB 0.913 and the
-  stereo form 0.925; the published 0.93 is the stereo form. ML216 has no
-  stereocentre, so both agree.
-- **Case 3 should never drift.** Frozen dataset, deterministic model, identical
-  output on pandas 2 and 3. If its numbers move, something in the environment
-  changed.
-- **ChEMBL's data API is down upstream.** Throughout verification
-  `https://www.ebi.ac.uk/chembl/api/data/` failed on every request, in two
-  modes: HTTP 500 after ~5 s, or no response at all. The fault is specific to
-  that one service. Sampling five times each from the same machine:
+Expect some movement, and know which kind matters:
 
-  | Endpoint | Result |
-  |---|---|
-  | `/chembl/api/data/…` (ChEMBL data API) | 0/5 ok, avg 7.9 s, 500s and timeouts |
-  | `/chembl/api/utils/…` (ChEMBL Beaker) | 5/5 ok, 0.4 s |
-  | `/chembl/interface_api/…` (powers the ChEMBL website) | 5/5 ok, 0.5 s |
-  | `/pdbe/api/…` | 5/5 ok, 0.4 s |
-  | `/europepmc/webservices/…` | 5/5 ok, 0.5 s |
-
-  Sibling services under the same prefix on the same host are healthy, so this
-  is neither a network problem nor a ToolUniverse one: the base URL in
-  `src/tooluniverse/chem_tool.py` is correct, the service behind it is not
-  answering. It is a known upstream fault, reported in
-  [chembl_webresource_client#144](https://github.com/chembl/chembl_webresource_client/issues/144)
-  (open since 2026-06-23, no maintainer response). That report's workaround —
-  appending any query parameter — no longer helps, so the service has degraded
-  further since it was filed. Note the ChEMBL website stays up during this,
-  because it runs on `interface_api` rather than the data API, so the outage is
-  easy to miss.
-
-  Consequently the two steps that depend on ChEMBL — Case 1's five-analog DILI
-  comparison and Case 2's measured-affinity lookup — are the only ones **not**
-  confirmed end-to-end against the live service. Their response parsing was
-  written against the tool implementations in `src/tooluniverse/chem_tool.py`
-  and checked on replayed payloads, but the published values (DILI 0.987-0.992;
-  Ki as low as 3.2 nM) have not been re-observed. Both scripts report the step
-  as unavailable and carry on rather than aborting. Check whether the service is
-  back with:
-  ```bash
-  curl -o /dev/null -w '%{http_code}\n' https://www.ebi.ac.uk/chembl/api/data/status.json
-  ```
-
-## Source
-
-The narrative and the step-by-step tool sequences come from the
-[case-studies post](https://aiscientist.tools/posts/tooluniverse-case-studies),
-which condenses the supplementary note "Step-by-step real-world case studies"
-in the ToolUniverse manuscript,
-[arXiv:2509.23426](https://arxiv.org/abs/2509.23426).
+- **Live databases get re-scored.** *OXTR* disease associations were 393 at the
+  time of writing and read 465 today; Open Targets re-scores every release. That
+  is a release difference, not a failed reproduction, and no conclusion here
+  rests on the count.
+- **Case 3 should never move.** Frozen dataset, deterministic model, identical
+  on pandas 2 and 3. If its numbers change, something in your environment did.
+- **ChEMBL's data API is currently down** (HTTP 500 upstream, [known
+  issue](https://github.com/chembl/chembl_webresource_client/issues/144)). The
+  two steps that need it — Case 1's analog comparison and Case 2's measured
+  affinities — report `[unavailable]` and the case carries on rather than
+  failing. Everything else is unaffected.

--- a/examples/case_studies/README.md
+++ b/examples/case_studies/README.md
@@ -1,22 +1,25 @@
 # Three research questions, answered end to end
 
-Each script here takes a real research question and answers it the way the AI
-scientist in [this write-up](https://aiscientist.tools/posts/tooluniverse-case-studies)
-did: by choosing tools, chaining them across databases, structures, screens and
-predictive models, and reasoning about what comes back.
+Each script takes a research question, chains tools across databases,
+structures, screens and predictive models to answer it, and prints the evidence
+as it arrives. This is the same sequence the AI scientist ran in
+[the write-up](https://aiscientist.tools/posts/tooluniverse-case-studies).
 
-You run one and watch the investigation unfold, step by step, with the evidence
-printed as it arrives.
+Every case has the same shape:
 
-| | Question | Run |
-|---|---|---|
-| **1** | *BLM* loss causes cancer. Could blocking *BLM* still **treat** cancer? | [`case1_blm_target_assessment.py`](case1_blm_target_assessment.py) |
-| **2** | *OXTR* is druggable. Does its chemistry actually fit the autism hypothesis? | [`case2_oxtr_druggability.py`](case2_oxtr_druggability.py) |
-| **3** | Did BCG vaccination make adverse events more severe in a real trial? | [`case3_bcg_ae_severity.py`](case3_bcg_ae_severity.py) |
+```
+input                    process                              output
+─────────────────────    ──────────────────────────────────   ──────────────────
+a question + an          N steps, each one or more tool       a verdict, with
+identifier or a file     calls, each step's result feeding    every number
+                         the next                             traceable to a call
+```
 
-What makes these worth running is that in all three, the evidence disagrees with
-itself. The interesting part is not retrieval — it is what the workflow does
-when two valid results point opposite ways.
+| | Input | Process | Output |
+|---|---|---|---|
+| **[1](case1_blm_target_assessment.py)** | gene `BLM` | 7 steps, 15 tools | is it a target, and is ML216 developable? |
+| **[2](case2_oxtr_druggability.py)** | gene `OXTR` | 6 steps, 15 tools | is the chemistry right for the autism hypothesis? |
+| **[3](case3_bcg_ae_severity.py)** | 2 trial tables (CSV) | 3 steps, 1 tool in 3 modes | does BCG associate with worse adverse events? |
 
 ## Setup
 
@@ -29,9 +32,8 @@ cd ToolUniverse/examples/case_studies
 pip install -r requirements.txt
 ```
 
-No API keys. Every database used here — Open Targets, ClinVar, GeneBe,
-AlphaFold, PDBe, Europe PMC, PubChem, ChEMBL — is open, and ADMET-AI runs on
-your machine.
+No API keys. Every database used — Open Targets, ClinVar, GeneBe, AlphaFold,
+PDBe, Europe PMC, PubChem, ChEMBL — is open, and ADMET-AI runs locally.
 
 ```bash
 python case1_blm_target_assessment.py     # ~2 min, mostly ADMET-AI model load
@@ -41,19 +43,31 @@ python download_bcg_data.py               # ~4 MB of trial tables from Zenodo, C
 python case3_bcg_ae_severity.py           # seconds
 ```
 
-## Case 1 — a tumour suppressor that might also be a target
+---
 
-*BLM* encodes a DNA-repair helicase. Losing it causes Bloom syndrome and raises
-cancer risk across a broad spectrum, which is the textbook signature of a gene
-you protect, not one you drug. The case asks whether the opposite can also be
-true in specific tumours.
+## Case 1 — is *BLM* a target?
 
-The first three steps build the case *against* inhibition: 464 disease
-associations led by Bloom syndrome, and a patient variant that ClinVar and
-GeneBe independently call pathogenic.
+### Input
 
-Step 4 is where it turns. The DepMap screen shows *BLM* is not broadly
-essential — but the dependency is not evenly spread:
+```
+gene:     BLM          (a DNA-repair helicase; losing it causes cancer)
+question: can blocking it nevertheless treat cancer,
+          and is its inhibitor ML216 developable?
+```
+
+### Process
+
+| Step | Tools | What it establishes |
+|---|---|---|
+| 1 Resolve the gene | `OpenTargets_multi_entity_search_by_query_string` `OpenTargets_get_target_gene_ontology_by_ensemblID` | it is a genome-maintenance helicase |
+| 2 Cancer-risk genetics | `OpenTargets_get_diseases_phenotypes_by_target_ensembl` | 464 disease associations, led by Bloom syndrome |
+| 3 Classify a variant | `ClinVar_search_variants` `GeneBe_classify_variant` | `c.520C>T` is pathogenic — evidence **against** inhibiting |
+| **4 Dependency screen** | `OpenTargets_get_target_depmap_essentiality` | **the turn**: not pan-essential, but concentrated in specific tumours |
+| 5 Structure | `alphafold_get_summary` `PDBe_get_uniprot_structure_coverage` | use experimental structures, not the mixed-confidence prediction |
+| 6 Precedent | `EuropePMC_search_articles` | paralog WRN is already a validated synthetic-lethal target |
+| 7 Triage the chemistry | `OpenTargets_get_chemical_probes_by_target_ensemblID` `PubChem_*` `ADMETAI_*` `ChEMBL_search_similar_molecules` | ML216 is drug-like but carries a liability |
+
+Step 4 is why the case exists — it contradicts step 3:
 
 ```
   mean gene effect: -0.18
@@ -63,25 +77,39 @@ essential — but the dependency is not evenly spread:
     Cutaneous Squamous Cell Carcinoma  -0.44  (n=5)
 ```
 
-So the genetics and the screen are both right and point opposite ways. The
-workflow then looks for precedent, finds that *BLM*'s paralog WRN is already a
-clinically validated synthetic-lethal target in exactly this kind of narrow
-context, and lands on a biomarker-defined hypothesis rather than a target.
+### Output
 
-The last step triages the one available inhibitor, ML216, and finds a predicted
-liver-injury signal that stays pinned near its maximum across every close
-analog — a liability of the scaffold, not of one molecule.
+Not a target — a **biomarker-defined hypothesis**. The germline genetics say
+protect *BLM*; the screen says it is a selective vulnerability in defined
+contexts. Both are right, so the workflow returns the contexts worth testing
+rather than a yes/no. ML216 is a probe, not a lead: its predicted liver-injury
+signal stays near maximum across every close analog, implicating the scaffold
+rather than the molecule.
 
-## Case 2 — the compound that passes every filter and is still wrong
+---
 
-*OXTR* clears every druggability check the workflow applies: experimental
-structures in both the active and inactive states, binding affinities into the
-low nanomolar, nine known agents, and a receptor already drugged in both
-directions.
+## Case 2 — does *OXTR* chemistry fit the hypothesis?
 
-Then it looks for something brain-penetrant, since the autism hypothesis needs
-central exposure. Nolasiban fits: drug-like, high predicted blood-brain-barrier
-penetrance. It looks like a repurposing candidate — until the mechanism check:
+### Input
+
+```
+gene:     OXTR         (oxytocin receptor, a GPCR)
+question: is it druggable, and does its pharmacology offer a
+          starting point for the emerging autism association?
+```
+
+### Process
+
+| Step | Tools | What it establishes |
+|---|---|---|
+| 1 Resolve + structure | `OpenTargets_multi_entity_search_by_query_string` `OpenTargets_get_target_gene_ontology_by_ensemblID` `alphafold_get_summary` `PDBe_get_uniprot_structure_coverage` | active and inactive experimental structures both exist |
+| 2 Disease landscape | `OpenTargets_get_diseases_phenotypes_by_target_ensembl` | reproductive indications, plus an emerging autism link |
+| 3 Tractability + drugs | `OpenTargets_get_target_tractability_by_ensemblID` `OpenTargets_get_associated_drugs_by_target_ensemblID` | druggable GPCR, 9 known agents, approved ones are peptides |
+| 4 Mechanism | `OpenTargets_get_drug_mechanisms_of_action_by_chemblId` | already drugged in both directions |
+| 5 Measured affinity | `ChEMBL_search_targets` `ChEMBL_get_target_activities` | nanomolar ligands exist |
+| **6 CNS + mechanism** | `EuropePMC_search_articles` `PubChem_*` `ADMETAI_predict_BBB_penetrance` `OpenTargets_get_drug_mechanisms_of_action_by_chemblId` | **the turn**: the brain-penetrant candidate acts the wrong way |
+
+Nolasiban passes every property filter — then fails the one that matters:
 
 ```
   nolasiban action type: ['ANTAGONIST']
@@ -90,46 +118,72 @@ penetrance. It looks like a repurposing candidate — until the mechanism check:
   hypothesis needs it ACTIVATED. Wrong direction.
 ```
 
-A compound can satisfy every property filter you thought to apply and still act
-in the opposite pharmacological direction. Checking affinity and BBB alone would
-have produced a confident, wrong recommendation.
+### Output
 
-## Case 3 — statistics on a real trial, not a database lookup
+Tractable target, wrong chemotype. The objective is stated precisely instead of
+a repurposing suggestion: a brain-penetrant **agonist** or positive allosteric
+modulator, selective over the vasopressin receptors. Screening on affinity and
+brain penetrance alone would have produced a confident, wrong recommendation.
 
-The other two cases query databases. This one computes, on the raw tables of the
-public [BCG-CORONA trial](https://zenodo.org/records/12737228) (CC0), using
-`clinical_trial_ae_severity_test` in three modes: build the cohort, test the
-unadjusted association, then fit an adjusted model.
+---
 
-It reaches a significant association between BCG and higher adverse-event
-severity, holding after adjustment for how often participants saw patients:
+## Case 3 — did BCG worsen adverse events?
+
+Unlike the others, this one computes on raw data rather than querying databases.
+
+### Input
 
 ```
+data:     TASK008_BCG-CORONA_DM.csv   demographics, 1000 subjects
+          TASK008_BCG-CORONA_AE.csv   adverse events, 2694 records
+          (public BCG-CORONA trial, Zenodo 12737228, CC0 — download_bcg_data.py fetches it)
+question: is BCG associated with higher adverse-event severity,
+          after adjusting for how often participants saw patients?
+```
+
+### Process
+
+One tool, `clinical_trial_ae_severity_test`, in three modes:
+
+| Step | Mode | What it does |
+|---|---|---|
+| 1 | `prepare` | inner-join AE onto DM by `USUBJID`, reduce each subject to their max `AESEV` → 791 evaluable subjects |
+| 2 | `chi-square` | unadjusted treatment × severity association |
+| 3 | `ordinal` | proportional-odds regression adjusting for `patients_seen`, `expect_interact`, `work_hours` |
+
+### Output
+
+```
+  evaluable subjects: 791
+  chi-square: 10.12   dof: 3   p-value: 0.018
   OR for higher severity with BCG: 1.53
   95% CI: (1.16, 2.01)
   p-value: 0.0024
 ```
 
-Two things the script is careful about, and worth watching for:
+A significant association that survives adjustment. Two things the script is
+careful about, and you should be too:
 
 - **Direction.** The tool reports the odds ratio against its own reference level
   (BCG=0, Placebo=1 alphabetically), so the raw **0.65** is Placebo-vs-BCG and
   the **1.53** above is its reciprocal. Reporting the raw number as the BCG
   effect would invert the finding.
-- **What it supports.** The cohort is restricted to participants who had at
-  least one adverse event, and severity is a derived per-subject maximum. That
-  makes this a reproducible association from a secondary analysis, not evidence
-  that vaccination changes severity.
+- **What it supports.** The cohort is restricted to participants with at least
+  one adverse event, and severity is a derived per-subject maximum. That makes
+  this a reproducible association from a secondary analysis — not evidence that
+  vaccination changes severity.
+
+---
 
 ## Reading the output
 
-Every value the scripts print carries the number originally reported beside it:
+Every value prints with the originally reported number beside it:
 
 ```
   DILI (liver injury): 0.988   (published: 0.99)
 ```
 
-So a run tells you at a glance whether the science still holds up against live
+So a run tells you at a glance whether the science still holds against live
 databases, and exactly which number moved if it doesn't. Values marked
 `published:` come from the write-up or from the supplementary note it condenses
 ([arXiv:2509.23426](https://arxiv.org/abs/2509.23426)) — the note carries the
@@ -140,12 +194,12 @@ Expect some movement, and know which kind matters:
 
 - **Live databases get re-scored.** *OXTR* disease associations were 393 at the
   time of writing and read 465 today; Open Targets re-scores every release. That
-  is a release difference, not a failed reproduction, and no conclusion here
-  rests on the count.
+  is a release difference, not a failed reproduction, and no conclusion rests on
+  the count.
 - **Case 3 should never move.** Frozen dataset, deterministic model, identical
   on pandas 2 and 3. If its numbers change, something in your environment did.
 - **ChEMBL's data API is currently down** (HTTP 500 upstream, [known
   issue](https://github.com/chembl/chembl_webresource_client/issues/144)). The
   two steps that need it — Case 1's analog comparison and Case 2's measured
-  affinities — report `[unavailable]` and the case carries on rather than
+  affinities — print `[unavailable]` and the case carries on rather than
   failing. Everything else is unaffected.

--- a/examples/case_studies/case2_oxtr_druggability.py
+++ b/examples/case_studies/case2_oxtr_druggability.py
@@ -187,37 +187,47 @@ def main() -> None:
             target_id = rows[0].get("target_chembl_id")
         report("ChEMBL target", target_id, "CHEMBL2049")
         if target_id:
-            acts = call(
-                tu,
-                "ChEMBL_get_target_activities",
-                target_chembl_id__exact=target_id,
-                limit=100,
-            )
-            if is_error(acts):
-                note_unavailable("ChEMBL_get_target_activities", acts)
-            else:
+            # ChEMBL returns activities unsorted and paginated, so the minimum
+            # over any single page is an artefact of which page you fetched
+            # (0.50 nM at offset 0, 1.0 at 100, 0.09 at 200). Page through the
+            # whole set to get the real figure.
+            affinities, offset, PAGE, CAP = [], 0, 200, 2000
+            while offset < CAP:
+                acts = call(
+                    tu,
+                    "ChEMBL_get_target_activities",
+                    target_chembl_id__exact=target_id,
+                    limit=PAGE,
+                    offset=offset,
+                )
+                if is_error(acts):
+                    if offset == 0:
+                        note_unavailable("ChEMBL_get_target_activities", acts)
+                    break
                 rows = acts.get("activities", acts) or []
-                affinities = [
+                affinities += [
                     float(a["standard_value"])
                     for a in rows
                     if isinstance(a, dict)
-                    and a.get("standard_type") in {"Ki", "IC50", "Kd"}
+                    and a.get("standard_type") == "Ki"
                     and a.get("standard_units") == "nM"
                     and a.get("standard_value") is not None
+                    and not a.get("data_validity_comment")
                 ]
-                if affinities:
-                    # The minimum over one page of activities is not a stable
-                    # quantity: ChEMBL returns them unsorted, so the best value
-                    # depends on which 100 rows you fetch (0.50, 1.0 and 0.09 nM
-                    # at offsets 0, 100 and 200 respectively). What reproduces
-                    # is the conclusion -- this receptor has nanomolar ligands --
-                    # not one particular minimum, so don't pin it to one.
-                    report(
-                        "best affinity in this sample of 100",
-                        f"{min(affinities):.2g} nM",
-                        "single-digit nM; the exact minimum is page-dependent",
-                    )
-                    report("nanomolar ligands confirmed", min(affinities) < 10, "yes")
+                if len(rows) < PAGE:
+                    break
+                offset += PAGE
+
+            if affinities:
+                best = min(affinities)
+                report("Ki measurements found", len(affinities))
+                report(f"lowest Ki across all {len(affinities)}", f"{best:.3g} nM")
+                report(
+                    "high-affinity ligands confirmed",
+                    best < 10,
+                    "yes (the post's 'as low as 3.2 nM' sampled one page; "
+                    "the full set goes lower)",
+                )
 
     # ------------------------------------------------------------------
     step(6, "Reason about pharmacology and CNS druggability")

--- a/examples/case_studies/case2_oxtr_druggability.py
+++ b/examples/case_studies/case2_oxtr_druggability.py
@@ -206,11 +206,18 @@ def main() -> None:
                     and a.get("standard_value") is not None
                 ]
                 if affinities:
+                    # The minimum over one page of activities is not a stable
+                    # quantity: ChEMBL returns them unsorted, so the best value
+                    # depends on which 100 rows you fetch (0.50, 1.0 and 0.09 nM
+                    # at offsets 0, 100 and 200 respectively). What reproduces
+                    # is the conclusion -- this receptor has nanomolar ligands --
+                    # not one particular minimum, so don't pin it to one.
                     report(
-                        "best measured affinity",
-                        f"{min(affinities):.1f} nM",
-                        "Ki as low as 3.2 nM",
+                        "best affinity in this sample of 100",
+                        f"{min(affinities):.2g} nM",
+                        "single-digit nM; the exact minimum is page-dependent",
                     )
+                    report("nanomolar ligands confirmed", min(affinities) < 10, "yes")
 
     # ------------------------------------------------------------------
     step(6, "Reason about pharmacology and CNS druggability")


### PR DESCRIPTION
The README read like a test report — its first substantive sentence was about matching published values, it carried three Published-vs-Observed tables, and its longest section was forensics on a ChEMBL outage. Someone arriving at the folder wants to run the case, not audit a regression run.

## What changes

Every case now has the same three headings, so the mechanics are explicit rather than implied:

- **Input** — the identifier or data files handed in, and the question asked
- **Process** — a table of steps, the tools each step calls, and what it establishes; the pivotal step is marked
- **Output** — the verdict, with the actual printed result above it

The header carries a diagram of that shape plus a summary table, so the pattern is visible before reading any single case.

Each case's pivotal moment appears as real output: the DepMap dependency that reframes *BLM*, the mechanism check that disqualifies nolasiban after it passes every property filter, and the adjusted odds ratio with the direction trap that would otherwise invert it.

The verification material stays, as a short "Reading the output" section: how the `published:` annotations work, which values drift and which must not, and the ChEMBL outage in three lines instead of thirty.

Documentation only — no code changes.

## Accuracy

Step and tool counts in the tables are extracted from the scripts with AST rather than written by hand (7 steps/15 tools, 6 steps/15 tools, 3 steps/1 tool in three modes), and every tool named is one the script actually calls. Every number quoted is copied from a recorded run.