### PR TITLE
Retry and bound every ChEMBL HTTP request

### DIFF
--- a/src/tooluniverse/chem_tool.py
+++ b/src/tooluniverse/chem_tool.py
@@ -388,7 +388,9 @@ class ChEMBLRESTTool(BaseTool):
         base = f"{self.base_url}/molecule/{chembl_id}.json"
         headers = {"Accept": "application/json", "User-Agent": "ToolUniverse/1.0"}
         try:
-            resp = requests.get(base, headers=headers, timeout=20)
+            resp = request_with_retry(
+                self.session, "GET", base, headers=headers, timeout=20
+            )
             resp.raise_for_status()
             parent = self._extract_parent_chembl_id(resp.json())
             return parent if parent and parent != chembl_id else None
@@ -410,8 +412,13 @@ class ChEMBLRESTTool(BaseTool):
             {"pref_name__iexact": drug_name, "format": "json", "limit": 5},
         ):
             try:
-                resp = requests.get(
-                    base, params=lookup_params, headers=headers, timeout=20
+                resp = request_with_retry(
+                    self.session,
+                    "GET",
+                    base,
+                    params=lookup_params,
+                    headers=headers,
+                    timeout=20,
                 )
                 resp.raise_for_status()
                 molecules = resp.json().get("molecules", [])
@@ -761,6 +768,11 @@ class ChEMBLTool(BaseTool):
         super().__init__(tool_config)
         self.base_url = base_url
         self.indigo = Indigo()
+        # Match ChEMBLRESTTool: a pooled session and an explicit timeout, so no
+        # request can hang indefinitely when the upstream service stops
+        # responding rather than returning an error.
+        self.session = requests.Session()
+        self.timeout = 30
 
     def run(self, arguments):
         query = arguments.get("query")
@@ -778,7 +790,13 @@ class ChEMBLTool(BaseTool):
         headers = {"Accept": "application/json"}
         search_url = f"{self.base_url}/molecule/search.json?q={quote(compound_name)}"
         print(search_url)
-        response = requests.get(search_url, headers=headers)
+        response = request_with_retry(
+            self.session,
+            "GET",
+            search_url,
+            headers=headers,
+            timeout=self.timeout,
+        )
         response.raise_for_status()
         results = response.json().get("molecules", [])
         if not results or not isinstance(results, list):
@@ -811,7 +829,13 @@ class ChEMBLTool(BaseTool):
         headers = {"Accept": "application/json"}
         if query.upper().startswith("CHEMBL"):
             molecule_url = f"{self.base_url}/molecule/{quote(query)}.json"
-            response = requests.get(molecule_url, headers=headers)
+            response = request_with_retry(
+                self.session,
+                "GET",
+                molecule_url,
+                headers=headers,
+                timeout=self.timeout,
+            )
             response.raise_for_status()
             molecule = response.json()
             if not molecule or not isinstance(molecule, dict):
@@ -842,7 +866,13 @@ class ChEMBLTool(BaseTool):
         """
         headers = {"Accept": "application/json"}
         search_url = f"{self.base_url}/molecule/search.json?q={quote(compound_name)}"
-        response = requests.get(search_url, headers=headers)
+        response = request_with_retry(
+            self.session,
+            "GET",
+            search_url,
+            headers=headers,
+            timeout=self.timeout,
+        )
         response.raise_for_status()
         results = response.json().get("molecules", [])
         if not results or not isinstance(results, list):
@@ -970,7 +1000,13 @@ class ChEMBLTool(BaseTool):
                 headers = {"Accept": "application/json"}
                 search_url = f"{self.base_url}/molecule/search.json?q={quote(query)}"
                 try:
-                    response = requests.get(search_url, headers=headers)
+                    response = request_with_retry(
+                        self.session,
+                        "GET",
+                        search_url,
+                        headers=headers,
+                        timeout=self.timeout,
+                    )
                     response.raise_for_status()
                     results = response.json().get("molecules", [])
                     if results and len(results) > 0:
@@ -1025,7 +1061,13 @@ class ChEMBLTool(BaseTool):
 
             encoded_smiles = quote(smiles)
             similarity_url = f"{self.base_url}/similarity/{encoded_smiles}/{similarity_threshold}.json?limit={max_results}"
-            sim_response = requests.get(similarity_url, headers=headers)
+            sim_response = request_with_retry(
+                self.session,
+                "GET",
+                similarity_url,
+                headers=headers,
+                timeout=self.timeout,
+            )
             sim_response.raise_for_status()
             sim_results = sim_response.json().get("molecules", [])
             similar_molecules = []

--- a/tests/unit/test_chembl_http_resilience.py
+++ b/tests/unit/test_chembl_http_resilience.py
@@ -1,0 +1,130 @@
+"""ChEMBL tools must not issue unprotected HTTP calls.
+
+Most of chem_tool.py's outbound calls used a bare ``requests.get`` with no
+retry and, in five cases, no timeout at all — so a ChEMBL outage that hangs
+rather than erroring could block the caller indefinitely. ``request_with_retry``
+was already imported in the module but applied to only 3 of the 10 call sites.
+
+These tests pin the invariant (every call retried and bounded) rather than the
+particular call sites, so new code cannot quietly reintroduce a bare request.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+
+requests = pytest.importorskip("requests")
+
+CHEM_TOOL = pathlib.Path(__file__).resolve().parents[2] / "src/tooluniverse/chem_tool.py"
+
+
+def _calls(func_name: str):
+    tree = ast.parse(CHEM_TOOL.read_text())
+    return [
+        n
+        for n in ast.walk(tree)
+        if isinstance(n, ast.Call)
+        and (
+            getattr(n.func, "id", None) == func_name
+            or getattr(n.func, "attr", None) == func_name
+        )
+    ]
+
+
+def test_no_bare_requests_get_remains():
+    """Every outbound call goes through the retry helper."""
+    bare = [n.lineno for n in _calls("get") if getattr(getattr(n.func, "value", None), "id", "") == "requests"]
+    assert bare == [], f"unprotected requests.get at lines {bare}"
+
+
+def test_every_request_has_a_timeout():
+    """An outage that hangs must not block the caller forever."""
+    missing = [
+        n.lineno for n in _calls("request_with_retry")
+        if "timeout" not in {k.arg for k in n.keywords}
+    ]
+    assert missing == [], f"request_with_retry without timeout at lines {missing}"
+
+
+def test_all_call_sites_are_retried():
+    assert len(_calls("request_with_retry")) >= 10
+
+
+def test_chembl_tool_has_session_and_timeout():
+    """ChEMBLTool previously had neither, unlike ChEMBLRESTTool."""
+    from tooluniverse.chem_tool import ChEMBLTool
+
+    tool = ChEMBLTool({"name": "t", "type": "ChEMBLTool"})
+    assert isinstance(tool.session, requests.Session)
+    assert isinstance(tool.timeout, (int, float)) and tool.timeout > 0
+
+
+# --------------------------------------------------------------------------
+# Behaviour of the helper itself on the failure mode we actually hit
+# --------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    def __init__(self, status_code):
+        self.status_code = status_code
+        self.headers = {}
+
+    def json(self):
+        return {"molecules": []}
+
+
+class _FakeSession:
+    """Records attempts and replays a scripted sequence of status codes."""
+
+    def __init__(self, statuses):
+        self.statuses = list(statuses)
+        self.calls = []
+
+    def request(self, method, url, **kwargs):
+        self.calls.append((method, url, kwargs))
+        return _FakeResponse(self.statuses[min(len(self.calls) - 1, len(self.statuses) - 1)])
+
+
+def test_retries_on_500_then_succeeds():
+    """A transient 500 (ChEMBL's failure mode) is retried, not surfaced."""
+    from tooluniverse.http_utils import request_with_retry
+
+    session = _FakeSession([500, 500, 200])
+    resp = request_with_retry(
+        session, "GET", "https://example.invalid/x", timeout=5,
+        max_attempts=3, backoff_seconds=0.0,
+    )
+    assert resp.status_code == 200
+    assert len(session.calls) == 3, "should have retried twice before succeeding"
+
+
+def test_gives_up_after_max_attempts_and_returns_last_response():
+    """A sustained outage returns the 500 rather than retrying forever."""
+    from tooluniverse.http_utils import request_with_retry
+
+    session = _FakeSession([500])
+    resp = request_with_retry(
+        session, "GET", "https://example.invalid/x", timeout=5,
+        max_attempts=3, backoff_seconds=0.0,
+    )
+    assert resp.status_code == 500
+    assert len(session.calls) == 3
+
+
+def test_timeout_is_forwarded_to_the_transport():
+    from tooluniverse.http_utils import request_with_retry
+
+    session = _FakeSession([200])
+    request_with_retry(session, "GET", "https://example.invalid/x", timeout=7)
+    assert session.calls[0][2]["timeout"] == 7
+
+
+def test_success_is_not_retried():
+    from tooluniverse.http_utils import request_with_retry
+
+    session = _FakeSession([200])
+    request_with_retry(session, "GET", "https://example.invalid/x", timeout=5)
+    assert len(session.calls) == 1


### PR DESCRIPTION
`chem_tool.py` imports `request_with_retry` but used it for only 4 of its 11 outbound calls. The other 7 were bare `requests.get`, and 5 of those passed **no timeout at all** — so when ChEMBL's data API stops responding rather than returning an error, those calls can block the caller indefinitely.

That is not hypothetical: the API returned HTTP 500 or simply hung for most of this week ([upstream issue](https://github.com/chembl/chembl_webresource_client/issues/144), open since June).

## Change

Route all 11 calls through `request_with_retry` with an explicit timeout, and give `ChEMBLTool` the pooled session and 30s timeout that `ChEMBLRESTTool` already had — it had neither. The two `ChEMBLRESTTool` call sites keep their existing 20s timeout, so the only change there is the added retry.

| | Before | After |
|---|---|---|
| Call sites retried | 3 of 11 | **11 of 11** |
| Bare `requests.get` | 7 | **0** |
| Calls with no timeout | 5 | **0** |

## Tests

`tests/unit/test_chembl_http_resilience.py`, 8 tests. Four pin the invariant via AST rather than specific line numbers, so a new bare request cannot be reintroduced unnoticed. Four exercise the helper against the failure mode actually observed upstream: retry on 500, give up after max attempts, timeout forwarded to the transport, success not retried.

Verified the guards would have caught the original state:

```
BEFORE fix  bare: 7  retried: 3   -> guard test FAILS
AFTER fix   bare: 0  retried: 11  -> guard test PASSES
```

## Cost

No latency cost when the service is healthy — a live `ChEMBL_search_targets` call returns in 0.8s, unchanged.

During a sustained outage a failing call takes longer to report, since it is attempted three times before giving up: roughly 5s to 43s, measured against the outage earlier this week. That is the trade for surviving transient failures, and it replaces a previously **unbounded** hang with a bounded one. If you would rather fail fast, dropping to `max_attempts=2` or a 15s timeout is a one-line change; I kept 3/30s to match what `ChEMBLRESTTool` already used rather than invent a new policy.