### PR TITLE
SmartAPI registry, NCI EVS terminologies, HCPCS/NPI, openFDA device, FHIR SNOMED

### DIFF
--- a/src/tooluniverse/_lazy_registry_static.py
+++ b/src/tooluniverse/_lazy_registry_static.py
@@ -641,6 +641,7 @@ STATIC_LAZY_REGISTRY = {
     "CMSOpenPaymentsTool": "cms_open_payments_tool",
     "DHSProgramTool": "dhs_program_tool",
     "MDDBTool": "mddb_tool",
+    "SmartAPITool": "smartapi_tool",
     "OrphadataTool": "orphadata_tool",
     "SCREENRESTTool": "screen_tool",
     "SingleCellPortalTool": "single_cell_portal_tool",

--- a/src/tooluniverse/_lazy_registry_static.py
+++ b/src/tooluniverse/_lazy_registry_static.py
@@ -642,6 +642,7 @@ STATIC_LAZY_REGISTRY = {
     "DHSProgramTool": "dhs_program_tool",
     "MDDBTool": "mddb_tool",
     "SmartAPITool": "smartapi_tool",
+    "NCIEVSTool": "nci_evs_tool",
     "OrphadataTool": "orphadata_tool",
     "SCREENRESTTool": "screen_tool",
     "SingleCellPortalTool": "single_cell_portal_tool",

--- a/src/tooluniverse/_lazy_registry_static.py
+++ b/src/tooluniverse/_lazy_registry_static.py
@@ -644,6 +644,7 @@ STATIC_LAZY_REGISTRY = {
     "SmartAPITool": "smartapi_tool",
     "NCIEVSTool": "nci_evs_tool",
     "OpenFDADeviceTool": "openfda_device_tool",
+    "FHIRTerminologyTool": "fhir_terminology_tool",
     "OrphadataTool": "orphadata_tool",
     "SCREENRESTTool": "screen_tool",
     "SingleCellPortalTool": "single_cell_portal_tool",

--- a/src/tooluniverse/_lazy_registry_static.py
+++ b/src/tooluniverse/_lazy_registry_static.py
@@ -643,6 +643,7 @@ STATIC_LAZY_REGISTRY = {
     "MDDBTool": "mddb_tool",
     "SmartAPITool": "smartapi_tool",
     "NCIEVSTool": "nci_evs_tool",
+    "OpenFDADeviceTool": "openfda_device_tool",
     "OrphadataTool": "orphadata_tool",
     "SCREENRESTTool": "screen_tool",
     "SingleCellPortalTool": "single_cell_portal_tool",

--- a/src/tooluniverse/clinical_tables_tool.py
+++ b/src/tooluniverse/clinical_tables_tool.py
@@ -4,6 +4,18 @@ Covers the Clinical Tables endpoints not already wrapped by ICDTool/LOINCTool:
   - rxterms        → drug-name autocomplete with strengths/forms + RxCUIs
   - conditions     → patient problem-list autocomplete with ICD-10-CM/ICD-9 crosswalk
   - disease_names  → disease-name autocomplete with UMLS CUI
+  - hcpcs          → US procedure/durable-medical-equipment billing codes
+  - star_alleles   → pharmacogenomic star alleles (e.g. CYP2D6*4), pairs
+                     with the existing CPIC tools
+  - npi_idv/npi_org → NPPES registry of every US healthcare provider and
+                     organization; pairs with CMSOpenPaymentsTool, whose
+                     records are keyed by NPI with no way to resolve who
+                     that NPI actually is
+
+ICD-11 is intentionally not added here even though this same service hosts
+an icd11_codes table: ICDTool already covers ICD-11 via the authoritative
+WHO API, so adding it through this backend would just duplicate that
+capability under a different, less authoritative source.
 
 API: https://clinicaltables.nlm.nih.gov/api/<table>/v3/search
 Response shape: [total_count, codes, extra_fields_hash_or_null, display_arrays]
@@ -143,10 +155,59 @@ class ClinicalTablesTool(BaseTool):
             send_df=False,
         )
 
+    def _search_hcpcs(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        """US procedure/durable-medical-equipment billing code autocomplete."""
+        return self._search(
+            "hcpcs",
+            arguments,
+            display_fields=["code", "display"],
+            extra_fields=[],
+        )
+
+    def _search_star_alleles(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        """Pharmacogenomic star allele autocomplete (e.g. CYP2D6*4).
+
+        The table's second default column is always empty in every sample
+        checked; labeled 'unused' rather than a guessed name.
+        """
+        return self._search(
+            "star_alleles",
+            arguments,
+            display_fields=[
+                "allele",
+                "unused",
+                "nucleotide_change",
+                "alternate_name",
+                "protein_change",
+            ],
+            extra_fields=[],
+            send_df=False,
+        )
+
+    def _search_npi(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        """NPPES registry search for a US healthcare provider or organization."""
+        is_org = bool(arguments.get("organization"))
+        table = "npi_org" if is_org else "npi_idv"
+        extra_fields = ["name.full", "NPI", "provider_type", "addr_practice.full"]
+        result = self._search(
+            table,
+            arguments,
+            display_fields=[],
+            extra_fields=extra_fields,
+            send_df=False,
+        )
+        if isinstance(result, dict) and "results" in result:
+            for row in result["results"]:
+                row["is_organization"] = is_org
+        return result
+
     _OPERATION_MAP = {
         "RxTerms_search": "_search_rxterms",
         "HealthConditions_search": "_search_conditions",
         "DiseaseNames_search": "_search_disease_names",
+        "HCPCS_search": "_search_hcpcs",
+        "StarAlleles_search": "_search_star_alleles",
+        "NPIProvider_search": "_search_npi",
     }
 
     def run(self, arguments: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/tooluniverse/data/clinical_tables_tools.json
+++ b/src/tooluniverse/data/clinical_tables_tools.json
@@ -255,5 +255,170 @@
         "max_results": 5
       }
     ]
+  },
+  {
+    "name": "HCPCS_search",
+    "description": "US procedure and durable-medical-equipment billing code autocomplete via the NLM Clinical Table Search Service (HCPCS Level II). Given a partial or full description, returns matching HCPCS codes with their official short description. Use for billing/coding lookups (e.g. wheelchairs, ambulance services, supplies) not covered by CPT. No API key required.",
+    "type": "ClinicalTablesTool",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "terms": {
+          "type": "string",
+          "description": "Procedure/equipment description or prefix to search, e.g. 'wheelchair', 'ambulance'."
+        },
+        "max_results": {
+          "type": "integer",
+          "description": "Maximum number of matches to return (default 20, max 500).",
+          "default": 20
+        }
+      },
+      "required": ["terms"]
+    },
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "total_count": {"type": "integer"},
+            "count": {"type": "integer"},
+            "search_terms": {"type": "string"},
+            "results": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "code": {"type": "string", "description": "HCPCS Level II code."},
+                  "display": {"type": "string", "description": "Official short description."}
+                }
+              }
+            }
+          },
+          "required": ["results"]
+        },
+        {
+          "type": "object",
+          "properties": {"status": {"type": "string"}, "error": {"type": "string"}},
+          "required": ["error"]
+        }
+      ]
+    },
+    "test_examples": [
+      {"terms": "wheelchair", "max_results": 5}
+    ]
+  },
+  {
+    "name": "StarAlleles_search",
+    "description": "Pharmacogenomic star allele autocomplete via the NLM Clinical Table Search Service, e.g. CYP2D6*4. Given a gene or allele prefix, returns matching star allele designations with their defining nucleotide change, alternate/historical name, and resulting protein change. Complements the existing CPIC tools (which give dosing recommendations per diplotype but do not look up individual allele definitions). No API key required.",
+    "type": "ClinicalTablesTool",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "terms": {
+          "type": "string",
+          "description": "Gene or allele name/prefix to search, e.g. 'CYP2D6', 'CYP2D6*4'."
+        },
+        "max_results": {
+          "type": "integer",
+          "description": "Maximum number of matches to return (default 20, max 500).",
+          "default": 20
+        }
+      },
+      "required": ["terms"]
+    },
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "total_count": {"type": "integer"},
+            "count": {"type": "integer"},
+            "search_terms": {"type": "string"},
+            "results": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "code": {"type": "string", "description": "Star allele designation, e.g. 'CYP2D6*18'."},
+                  "allele": {"type": "string"},
+                  "nucleotide_change": {"type": "string"},
+                  "alternate_name": {"type": "string"},
+                  "protein_change": {"type": "string"}
+                }
+              }
+            }
+          },
+          "required": ["results"]
+        },
+        {
+          "type": "object",
+          "properties": {"status": {"type": "string"}, "error": {"type": "string"}},
+          "required": ["error"]
+        }
+      ]
+    },
+    "test_examples": [
+      {"terms": "CYP2D6", "max_results": 5}
+    ]
+  },
+  {
+    "name": "NPIProvider_search",
+    "description": "US healthcare provider/organization directory search via the NLM Clinical Table Search Service (NPPES NPI Registry). Given a provider or organization name, returns matches with their National Provider Identifier (NPI), specialty/type, and practice address. Set organization=true to search organizations (hospitals, clinics) instead of individual providers. The returned npi is what CMSOpenPayments_search_payments expects as its npi filter, resolving who a payment recipient actually is. No API key required.",
+    "type": "ClinicalTablesTool",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "terms": {
+          "type": "string",
+          "description": "Provider or organization name to search, e.g. 'Smith', 'Mayo Clinic'."
+        },
+        "organization": {
+          "type": ["boolean", "null"],
+          "description": "Search organizations (hospitals, clinics) instead of individual providers. Default false."
+        },
+        "max_results": {
+          "type": "integer",
+          "description": "Maximum number of matches to return (default 20, max 500).",
+          "default": 20
+        }
+      },
+      "required": ["terms"]
+    },
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "total_count": {"type": "integer"},
+            "count": {"type": "integer"},
+            "search_terms": {"type": "string"},
+            "results": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "code": {"type": "string", "description": "National Provider Identifier (NPI)."},
+                  "name.full": {"type": "string"},
+                  "NPI": {"type": "string"},
+                  "provider_type": {"type": "string"},
+                  "addr_practice.full": {"type": "string"},
+                  "is_organization": {"type": "boolean"}
+                }
+              }
+            }
+          },
+          "required": ["results"]
+        },
+        {
+          "type": "object",
+          "properties": {"status": {"type": "string"}, "error": {"type": "string"}},
+          "required": ["error"]
+        }
+      ]
+    },
+    "test_examples": [
+      {"terms": "Smith", "max_results": 5},
+      {"terms": "Mayo Clinic", "organization": true, "max_results": 5}
+    ]
   }
 ]

--- a/src/tooluniverse/data/fhir_terminology_tools.json
+++ b/src/tooluniverse/data/fhir_terminology_tools.json
@@ -1,0 +1,104 @@
+[
+  {
+    "name": "FHIRTerminology_lookup_code",
+    "type": "FHIRTerminologyTool",
+    "description": "Resolve a code to its display name and synonyms via HL7's public FHIR Terminology Service. Its main value is SNOMED CT, which ToolUniverse otherwise only reaches via fuzzy keyword search (OLS): this does proper code-based lookup. Example: system='snomed', code='22298006' returns 'Myocardial infarction' with its clinical synonyms. LOINC/RxNorm/ICD-10-CM are also accepted (system='loinc'/'rxnorm'/'icd10cm') but already have dedicated, richer ToolUniverse tools -- prefer those three.",
+    "fields": {
+      "operation": "lookup_code"
+    },
+    "parameter": {
+      "type": "object",
+      "required": ["system", "code"],
+      "properties": {
+        "system": {
+          "type": "string",
+          "description": "'snomed', or a full FHIR code system URI, e.g. 'http://snomed.info/sct'."
+        },
+        "code": {
+          "type": "string",
+          "description": "Code within that system, e.g. '22298006' (SNOMED CT: Myocardial infarction)."
+        }
+      }
+    },
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "code": {"type": ["string", "null"]},
+            "display": {"type": ["string", "null"]},
+            "system": {"type": ["string", "null"]},
+            "system_version": {"type": ["string", "null"]},
+            "code_system_name": {"type": ["string", "null"]},
+            "inactive": {"type": ["boolean", "null"]},
+            "alternate_names": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": ["string", "null"]},
+                  "use": {"type": ["string", "null"]}
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {"error": {"type": "string"}},
+          "required": ["error"]
+        }
+      ]
+    },
+    "test_examples": [
+      {"system": "snomed", "code": "22298006"},
+      {"system": "http://snomed.info/sct", "code": "73211009"}
+    ]
+  },
+  {
+    "name": "FHIRTerminology_expand_valueset",
+    "type": "FHIRTerminologyTool",
+    "description": "Expand a FHIR value set to its member codes via HL7's public FHIR Terminology Service. Its standout use is SNOMED CT's implicit subsumption value sets: value_set_url='http://snomed.info/sct?fhir_vs=isa/<code>' returns every descendant/subtype of a concept, a hierarchy traversal nothing else in ToolUniverse provides. Example: 'isa/22298006' (Myocardial infarction) returns all 124 of its clinical subtypes, from 'Old myocardial infarction' to 'Microinfarct of heart'.",
+    "fields": {
+      "operation": "expand_valueset"
+    },
+    "parameter": {
+      "type": "object",
+      "required": ["value_set_url"],
+      "properties": {
+        "value_set_url": {
+          "type": "string",
+          "description": "FHIR value set URL, e.g. 'http://snomed.info/sct?fhir_vs=isa/22298006' for every descendant of a SNOMED concept."
+        },
+        "limit": {
+          "type": ["integer", "null"],
+          "description": "Max concepts to return, 1-500. Default 50."
+        }
+      }
+    },
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "system": {"type": ["string", "null"]},
+              "code": {"type": ["string", "null"]},
+              "display": {"type": ["string", "null"]}
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {"error": {"type": "string"}},
+          "required": ["error"]
+        }
+      ]
+    },
+    "test_examples": [
+      {"value_set_url": "http://snomed.info/sct?fhir_vs=isa/22298006", "limit": 10},
+      {"value_set_url": "http://snomed.info/sct?fhir_vs=isa/73211009", "limit": 10}
+    ]
+  }
+]

--- a/src/tooluniverse/data/nci_evs_tools.json
+++ b/src/tooluniverse/data/nci_evs_tools.json
@@ -2,7 +2,7 @@
   {
     "name": "NCIEVS_search_terminology",
     "type": "NCIEVSTool",
-    "description": "Keyword-search an NCI EVS clinical/biomedical terminology other than NCIt (use NCIThesaurus_search for NCIt itself): 'ctcae5'/'ctcae6' (adverse event grading, the clinical-trial safety standard), 'icd10cm'/'icd9cm'/'icd10' (US diagnosis codes), 'radlex' (radiology), 'ndfrt'/'medrt' (drug reference terminology), 'canmed'. Example: terminology='ctcae5', term='neutropenia' returns graded adverse event terms (Grade 3/4/5 Febrile neutropenia). MedDRA is licensed and not queryable here. Returns each concept's code for use with NCIEVS_get_concept.",
+    "description": "Keyword-search an NCI EVS clinical/biomedical terminology other than NCIt (use NCIThesaurus_search for NCIt) or ICD-10-CM (use ICD10Tool): 'ctcae5'/'ctcae6' (adverse event grading, the clinical-trial safety standard), 'icd9cm' (US legacy diagnosis codes), 'radlex' (radiology), 'ndfrt'/'medrt' (drug reference terminology), 'canmed'. Example: terminology='ctcae5', term='neutropenia' returns graded adverse event terms (Grade 3/4/5 Febrile neutropenia). MedDRA is licensed and not queryable here. Returns each concept's code for use with NCIEVS_get_concept.",
     "fields": {
       "operation": "search_terminology"
     },
@@ -12,11 +12,11 @@
       "properties": {
         "terminology": {
           "type": "string",
-          "description": "NCI EVS terminology code, e.g. 'ctcae5', 'icd10cm', 'icd9cm', 'radlex', 'ndfrt', 'medrt', 'canmed'."
+          "description": "NCI EVS terminology code, e.g. 'ctcae5', 'icd9cm', 'radlex', 'ndfrt', 'medrt', 'canmed'."
         },
         "term": {
           "type": "string",
-          "description": "Free-text search term, e.g. 'neutropenia', 'diabetes'."
+          "description": "Free-text search term, e.g. 'neutropenia', 'fracture'."
         },
         "limit": {
           "type": ["integer", "null"],
@@ -46,7 +46,7 @@
     },
     "test_examples": [
       {"terminology": "ctcae5", "term": "neutropenia", "limit": 5},
-      {"terminology": "icd10cm", "term": "diabetes", "limit": 5}
+      {"terminology": "radlex", "term": "fracture", "limit": 5}
     ]
   },
   {
@@ -62,11 +62,11 @@
       "properties": {
         "terminology": {
           "type": "string",
-          "description": "NCI EVS terminology code, e.g. 'ctcae5', 'icd10cm'."
+          "description": "NCI EVS terminology code, e.g. 'ctcae5', 'radlex'."
         },
         "code": {
           "type": "string",
-          "description": "Concept code within that terminology, e.g. 'C143481' (CTCAE5) or 'E11.9' (ICD-10-CM)."
+          "description": "Concept code within that terminology, e.g. 'C143481' (CTCAE5) or 'RID4650' (RadLex)."
         }
       }
     },

--- a/src/tooluniverse/data/nci_evs_tools.json
+++ b/src/tooluniverse/data/nci_evs_tools.json
@@ -1,0 +1,108 @@
+[
+  {
+    "name": "NCIEVS_search_terminology",
+    "type": "NCIEVSTool",
+    "description": "Keyword-search an NCI EVS clinical/biomedical terminology other than NCIt (use NCIThesaurus_search for NCIt itself): 'ctcae5'/'ctcae6' (adverse event grading, the clinical-trial safety standard), 'icd10cm'/'icd9cm'/'icd10' (US diagnosis codes), 'radlex' (radiology), 'ndfrt'/'medrt' (drug reference terminology), 'canmed'. Example: terminology='ctcae5', term='neutropenia' returns graded adverse event terms (Grade 3/4/5 Febrile neutropenia). MedDRA is licensed and not queryable here. Returns each concept's code for use with NCIEVS_get_concept.",
+    "fields": {
+      "operation": "search_terminology"
+    },
+    "parameter": {
+      "type": "object",
+      "required": ["terminology", "term"],
+      "properties": {
+        "terminology": {
+          "type": "string",
+          "description": "NCI EVS terminology code, e.g. 'ctcae5', 'icd10cm', 'icd9cm', 'radlex', 'ndfrt', 'medrt', 'canmed'."
+        },
+        "term": {
+          "type": "string",
+          "description": "Free-text search term, e.g. 'neutropenia', 'diabetes'."
+        },
+        "limit": {
+          "type": ["integer", "null"],
+          "description": "Max concepts to return, 1-100. Default 20."
+        }
+      }
+    },
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "code": {"type": ["string", "null"]},
+              "name": {"type": ["string", "null"]},
+              "leaf": {"type": ["boolean", "null"]}
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {"error": {"type": "string"}},
+          "required": ["error"]
+        }
+      ]
+    },
+    "test_examples": [
+      {"terminology": "ctcae5", "term": "neutropenia", "limit": 5},
+      {"terminology": "icd10cm", "term": "diabetes", "limit": 5}
+    ]
+  },
+  {
+    "name": "NCIEVS_get_concept",
+    "type": "NCIEVSTool",
+    "description": "Retrieve one concept's full detail (definition, synonyms, properties) from an NCI EVS terminology other than NCIt, by its code. Example: terminology='ctcae5', code='C143481' returns 'Febrile neutropenia' with its clinical definition and MedDRA cross-reference code. Use NCIEVS_search_terminology to find a code.",
+    "fields": {
+      "operation": "get_concept"
+    },
+    "parameter": {
+      "type": "object",
+      "required": ["terminology", "code"],
+      "properties": {
+        "terminology": {
+          "type": "string",
+          "description": "NCI EVS terminology code, e.g. 'ctcae5', 'icd10cm'."
+        },
+        "code": {
+          "type": "string",
+          "description": "Concept code within that terminology, e.g. 'C143481' (CTCAE5) or 'E11.9' (ICD-10-CM)."
+        }
+      }
+    },
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "code": {"type": ["string", "null"]},
+            "name": {"type": ["string", "null"]},
+            "terminology": {"type": ["string", "null"]},
+            "active": {"type": ["boolean", "null"]},
+            "definition": {"type": ["string", "null"]},
+            "synonyms": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {"type": ["string", "null"]},
+                  "type": {"type": ["string", "null"]},
+                  "source": {"type": ["string", "null"]}
+                }
+              }
+            },
+            "properties": {"type": "object"}
+          }
+        },
+        {
+          "type": "object",
+          "properties": {"error": {"type": "string"}},
+          "required": ["error"]
+        }
+      ]
+    },
+    "test_examples": [
+      {"terminology": "ctcae5", "code": "C143481"}
+    ]
+  }
+]

--- a/src/tooluniverse/data/openfda_device_tools.json
+++ b/src/tooluniverse/data/openfda_device_tools.json
@@ -1,0 +1,102 @@
+[
+  {
+    "name": "OpenFDADevice_search_recalls",
+    "type": "OpenFDADeviceTool",
+    "description": "Search openFDA's medical device recall database by device name, recalling firm, or free text. Returns each recall's product description, recalling firm, stated reason and root cause, status, and date initiated. Example: query='pacemaker' returns hundreds of pacemaker-related recalls including terminated Guidant and Medtronic actions. ToolUniverse's existing openFDA tools cover only drug data; this is the device side.",
+    "fields": {
+      "operation": "search_recalls"
+    },
+    "parameter": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "string",
+          "description": "Device name, recalling firm, or free text, e.g. 'pacemaker', 'insulin pump'."
+        },
+        "limit": {
+          "type": ["integer", "null"],
+          "description": "Max recalls to return, 1-100. Default 20."
+        }
+      }
+    },
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "product_description": {"type": ["string", "null"]},
+              "recalling_firm": {"type": ["string", "null"]},
+              "reason_for_recall": {"type": ["string", "null"]},
+              "root_cause_description": {"type": ["string", "null"]},
+              "recall_status": {"type": ["string", "null"]},
+              "event_date_initiated": {"type": ["string", "null"]},
+              "action": {"type": ["string", "null"]}
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {"error": {"type": "string"}},
+          "required": ["error"]
+        }
+      ]
+    },
+    "test_examples": [
+      {"query": "pacemaker", "limit": 5},
+      {"query": "insulin pump", "limit": 5}
+    ]
+  },
+  {
+    "name": "OpenFDADevice_search_adverse_events",
+    "type": "OpenFDADeviceTool",
+    "description": "Search openFDA's MAUDE database of medical device adverse event reports by device generic name. Returns each report's device brand/generic name and manufacturer, event type (Malfunction/Injury/Death), date, product problems, and patient problems. Example: device_name='pacemaker' surfaces reports like under-sensing and high capture threshold in pacemaker leads. ToolUniverse's existing openFDA tools cover only drug adverse events (FAERS); this is the device side.",
+    "fields": {
+      "operation": "search_adverse_events"
+    },
+    "parameter": {
+      "type": "object",
+      "required": ["device_name"],
+      "properties": {
+        "device_name": {
+          "type": "string",
+          "description": "Device generic name, e.g. 'pacemaker', 'insulin pump'."
+        },
+        "limit": {
+          "type": ["integer", "null"],
+          "description": "Max reports to return, 1-100. Default 20."
+        }
+      }
+    },
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "brand_name": {"type": ["string", "null"]},
+              "generic_name": {"type": ["string", "null"]},
+              "manufacturer": {"type": ["string", "null"]},
+              "event_type": {"type": ["string", "null"]},
+              "date_of_event": {"type": ["string", "null"]},
+              "product_problems": {"type": "array", "items": {"type": "string"}},
+              "patient_problems": {"type": "array", "items": {"type": "string"}}
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {"error": {"type": "string"}},
+          "required": ["error"]
+        }
+      ]
+    },
+    "test_examples": [
+      {"device_name": "pacemaker", "limit": 5},
+      {"device_name": "insulin pump", "limit": 5}
+    ]
+  }
+]

--- a/src/tooluniverse/data/openfda_device_tools.json
+++ b/src/tooluniverse/data/openfda_device_tools.json
@@ -98,5 +98,200 @@
       {"device_name": "pacemaker", "limit": 5},
       {"device_name": "insulin pump", "limit": 5}
     ]
+  },
+  {
+    "name": "OpenFDADevice_search_udi",
+    "type": "OpenFDADeviceTool",
+    "description": "Search openFDA's Unique Device Identifier (UDI) database by brand name, company, or free text. Returns each device's brand name, company, description, primary device identifier (DI), GMDN terms, and regulatory device class. The UDI is the device-world equivalent of a drug's NDC code. Example: query='pacemaker' returns real UDI records from Medtronic, Cardinal Health, and others.",
+    "fields": {
+      "operation": "search_udi"
+    },
+    "parameter": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "string",
+          "description": "Brand name, company name, or free text, e.g. 'pacemaker'."
+        },
+        "limit": {
+          "type": ["integer", "null"],
+          "description": "Max UDI records to return, 1-100. Default 20."
+        }
+      }
+    },
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "brand_name": {"type": ["string", "null"]},
+              "company_name": {"type": ["string", "null"]},
+              "device_description": {"type": ["string", "null"]},
+              "primary_di": {"type": ["string", "null"]},
+              "gmdn_terms": {"type": "array", "items": {"type": "string"}},
+              "device_class": {"type": ["string", "null"]},
+              "commercial_distribution_status": {"type": ["string", "null"]}
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {"error": {"type": "string"}},
+          "required": ["error"]
+        }
+      ]
+    },
+    "test_examples": [
+      {"query": "pacemaker", "limit": 5}
+    ]
+  },
+  {
+    "name": "OpenFDADevice_get_classification",
+    "type": "OpenFDADeviceTool",
+    "description": "Look up a medical device's US regulatory classification by device name. Returns device class (1 = general controls, 2 = special controls, 3 = premarket approval required), FDA product code, review panel, and CFR regulation number. Example: device_name='pacemaker' returns multiple pacemaker-related device types spanning Class 1 (test magnets) to Class 3 (implantable leads).",
+    "fields": {
+      "operation": "get_classification"
+    },
+    "parameter": {
+      "type": "object",
+      "required": ["device_name"],
+      "properties": {
+        "device_name": {
+          "type": "string",
+          "description": "Device type name, e.g. 'pacemaker', 'insulin pump'."
+        },
+        "limit": {
+          "type": ["integer", "null"],
+          "description": "Max classifications to return, 1-100. Default 20."
+        }
+      }
+    },
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "device_name": {"type": ["string", "null"]},
+              "product_code": {"type": ["string", "null"]},
+              "device_class": {"type": ["string", "null"]},
+              "review_panel": {"type": ["string", "null"]},
+              "medical_specialty_description": {"type": ["string", "null"]},
+              "regulation_number": {"type": ["string", "null"]},
+              "third_party_flag": {"type": ["string", "null"]}
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {"error": {"type": "string"}},
+          "required": ["error"]
+        }
+      ]
+    },
+    "test_examples": [
+      {"device_name": "pacemaker", "limit": 5}
+    ]
+  },
+  {
+    "name": "OpenFDADevice_search_510k",
+    "type": "OpenFDADeviceTool",
+    "description": "Search openFDA's 510(k) premarket notification database by device name -- the pathway most medical devices use to reach market by demonstrating substantial equivalence to an existing device. Returns each clearance's K number, applicant, decision date and outcome, and clearance type. Example: device_name='pacemaker' returns clearances back to the 1980s-90s including K913805.",
+    "fields": {
+      "operation": "search_510k"
+    },
+    "parameter": {
+      "type": "object",
+      "required": ["device_name"],
+      "properties": {
+        "device_name": {
+          "type": "string",
+          "description": "Device name, e.g. 'pacemaker'."
+        },
+        "limit": {
+          "type": ["integer", "null"],
+          "description": "Max clearances to return, 1-100. Default 20."
+        }
+      }
+    },
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "k_number": {"type": ["string", "null"]},
+              "device_name": {"type": ["string", "null"]},
+              "applicant": {"type": ["string", "null"]},
+              "decision_date": {"type": ["string", "null"]},
+              "decision_description": {"type": ["string", "null"]},
+              "clearance_type": {"type": ["string", "null"]},
+              "advisory_committee_description": {"type": ["string", "null"]}
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {"error": {"type": "string"}},
+          "required": ["error"]
+        }
+      ]
+    },
+    "test_examples": [
+      {"device_name": "pacemaker", "limit": 5}
+    ]
+  },
+  {
+    "name": "OpenFDADevice_search_pma",
+    "type": "OpenFDADeviceTool",
+    "description": "Search openFDA's Premarket Approval (PMA) database by trade name -- the pathway required for higher-risk (Class 3) devices, requiring clinical evidence of safety and effectiveness. Returns each application's PMA number, applicant, trade name, decision date, and approval-order summary. Example: device_name='pacemaker' returns Guidant/Boston Scientific cardiac resynchronization therapy pacemaker approvals.",
+    "fields": {
+      "operation": "search_pma"
+    },
+    "parameter": {
+      "type": "object",
+      "required": ["device_name"],
+      "properties": {
+        "device_name": {
+          "type": "string",
+          "description": "Device trade name, e.g. 'pacemaker', 'defibrillator'."
+        },
+        "limit": {
+          "type": ["integer", "null"],
+          "description": "Max PMA records to return, 1-100. Default 20."
+        }
+      }
+    },
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "pma_number": {"type": ["string", "null"]},
+              "trade_name": {"type": ["string", "null"]},
+              "applicant": {"type": ["string", "null"]},
+              "decision_date": {"type": ["string", "null"]},
+              "ao_statement": {"type": ["string", "null"]},
+              "advisory_committee_description": {"type": ["string", "null"]}
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {"error": {"type": "string"}},
+          "required": ["error"]
+        }
+      ]
+    },
+    "test_examples": [
+      {"device_name": "pacemaker", "limit": 5}
+    ]
   }
 ]

--- a/src/tooluniverse/data/smartapi_tools.json
+++ b/src/tooluniverse/data/smartapi_tools.json
@@ -1,0 +1,95 @@
+[
+  {
+    "name": "SmartAPI_search_apis",
+    "type": "SmartAPITool",
+    "description": "Search the SmartAPI registry of ~270 biomedical web APIs (OpenAPI-described, many NCATS Translator components), by keyword or field-scoped query. Example: query='variant' or query='tags.name:translator'. Returns each match's api_id/slug, title, base URL, and tags. Use to discover APIs not yet wrapped in ToolUniverse, or resolve an API named in a paper to its base URL and endpoints via SmartAPI_get_api.",
+    "fields": {
+      "operation": "search_apis"
+    },
+    "parameter": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "string",
+          "description": "Free-text keyword, or a field-scoped Lucene query like 'tags.name:translator'."
+        },
+        "limit": {
+          "type": ["integer", "null"],
+          "description": "Max APIs to return, 1-100. Default 25."
+        }
+      }
+    },
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "api_id": {"type": ["string", "null"]},
+              "slug": {"type": ["string", "null"]},
+              "title": {"type": ["string", "null"]},
+              "description": {"type": ["string", "null"]},
+              "base_url": {"type": ["string", "null"]},
+              "tags": {"type": "array", "items": {"type": "string"}}
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {"error": {"type": "string"}},
+          "required": ["error"]
+        }
+      ]
+    },
+    "test_examples": [
+      {"query": "variant", "limit": 5},
+      {"query": "tags.name:translator", "limit": 5}
+    ]
+  },
+  {
+    "name": "SmartAPI_get_api",
+    "type": "SmartAPITool",
+    "description": "Retrieve one SmartAPI registry entry's full metadata: base URL(s), tags, contact, terms of service, and endpoint list, by its registry id or slug. Example: api_id='myvariant' returns the MyVariant.info API's 5 endpoints including '/variant/{id}' and '/query'. Use SmartAPI_search_apis to find an api_id or slug.",
+    "fields": {
+      "operation": "get_api"
+    },
+    "parameter": {
+      "type": "object",
+      "required": ["api_id"],
+      "properties": {
+        "api_id": {
+          "type": "string",
+          "description": "SmartAPI registry id (32-char hash) or slug, e.g. 'myvariant'."
+        }
+      }
+    },
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "title": {"type": ["string", "null"]},
+            "description": {"type": ["string", "null"]},
+            "version": {"type": ["string", "null"]},
+            "contact": {"type": ["string", "null"]},
+            "terms_of_service": {"type": ["string", "null"]},
+            "base_urls": {"type": "array", "items": {"type": "string"}},
+            "tags": {"type": "array", "items": {"type": "string"}},
+            "endpoint_count": {"type": "integer"},
+            "endpoints": {"type": "array", "items": {"type": "string"}}
+          }
+        },
+        {
+          "type": "object",
+          "properties": {"error": {"type": "string"}},
+          "required": ["error"]
+        }
+      ]
+    },
+    "test_examples": [
+      {"api_id": "myvariant"}
+    ]
+  }
+]

--- a/src/tooluniverse/default_config.py
+++ b/src/tooluniverse/default_config.py
@@ -1087,6 +1087,11 @@ default_tool_files = {
     # NCI EVS - CTCAE, ICD-10-CM/ICD-9-CM, RadLex, NDF-RT/MedRT terminologies
     # (sibling to the existing NCIt-only NCIThesaurusTool)
     "nci_evs": os.path.join(current_dir, "data", "nci_evs_tools.json"),
+    # openFDA device - recalls and MAUDE adverse events, the device side of
+    # openFDA (existing tools cover only drug/label, drug/event, drugsfda)
+    "openfda_device": os.path.join(
+        current_dir, "data", "openfda_device_tools.json"
+    ),
     # Gene2Phenotype - EBI curated gene-disease associations for clinical genetics
     "gene2phenotype": os.path.join(current_dir, "data", "gene2phenotype_tools.json"),
     # NASA Exoplanet Archive - ADQL queries for 5500+ confirmed exoplanets and stellar hosts

--- a/src/tooluniverse/default_config.py
+++ b/src/tooluniverse/default_config.py
@@ -1084,6 +1084,9 @@ default_tool_files = {
     # SmartAPI - registry of ~270 biomedical web APIs, resolves an API
     # name to its base URL and endpoints
     "smartapi": os.path.join(current_dir, "data", "smartapi_tools.json"),
+    # NCI EVS - CTCAE, ICD-10-CM/ICD-9-CM, RadLex, NDF-RT/MedRT terminologies
+    # (sibling to the existing NCIt-only NCIThesaurusTool)
+    "nci_evs": os.path.join(current_dir, "data", "nci_evs_tools.json"),
     # Gene2Phenotype - EBI curated gene-disease associations for clinical genetics
     "gene2phenotype": os.path.join(current_dir, "data", "gene2phenotype_tools.json"),
     # NASA Exoplanet Archive - ADQL queries for 5500+ confirmed exoplanets and stellar hosts

--- a/src/tooluniverse/default_config.py
+++ b/src/tooluniverse/default_config.py
@@ -1081,6 +1081,9 @@ default_tool_files = {
     "dhs_program": os.path.join(current_dir, "data", "dhs_program_tools.json"),
     # MDDB - molecular dynamics trajectory database (MoDEL, BioExcel, DESRES)
     "mddb": os.path.join(current_dir, "data", "mddb_tools.json"),
+    # SmartAPI - registry of ~270 biomedical web APIs, resolves an API
+    # name to its base URL and endpoints
+    "smartapi": os.path.join(current_dir, "data", "smartapi_tools.json"),
     # Gene2Phenotype - EBI curated gene-disease associations for clinical genetics
     "gene2phenotype": os.path.join(current_dir, "data", "gene2phenotype_tools.json"),
     # NASA Exoplanet Archive - ADQL queries for 5500+ confirmed exoplanets and stellar hosts

--- a/src/tooluniverse/default_config.py
+++ b/src/tooluniverse/default_config.py
@@ -1092,6 +1092,11 @@ default_tool_files = {
     "openfda_device": os.path.join(
         current_dir, "data", "openfda_device_tools.json"
     ),
+    # FHIR Terminology Service - SNOMED CT code lookup and hierarchy
+    # expansion (LOINC/RxNorm/ICD-10-CM already have dedicated tools)
+    "fhir_terminology": os.path.join(
+        current_dir, "data", "fhir_terminology_tools.json"
+    ),
     # Gene2Phenotype - EBI curated gene-disease associations for clinical genetics
     "gene2phenotype": os.path.join(current_dir, "data", "gene2phenotype_tools.json"),
     # NASA Exoplanet Archive - ADQL queries for 5500+ confirmed exoplanets and stellar hosts

--- a/src/tooluniverse/fhir_terminology_tool.py
+++ b/src/tooluniverse/fhir_terminology_tool.py
@@ -1,0 +1,272 @@
+# fhir_terminology_tool.py
+"""
+FHIR Terminology Service tool for ToolUniverse.
+
+tx.fhir.org is HL7's own public FHIR R4 terminology server, implementing
+the standard Terminology Service operations (CodeSystem/$lookup,
+ValueSet/$expand) across SNOMED CT, LOINC, RxNorm, ICD-10-CM, and UCUM in
+one API. Its main value here is SNOMED CT, which ToolUniverse could
+previously only reach as flat keyword search via the generic OLS wrapper:
+this adds proper code-based $lookup (resolving a SNOMED code to its
+display name and properties) and, more importantly, subsumption-based
+hierarchy expansion -- finding every descendant/subtype of a SNOMED
+concept, which nothing else in ToolUniverse does. LOINC, RxNorm, and
+ICD-10-CM already have dedicated, richer ToolUniverse tools (LOINCTool,
+RxNormTool, ICD10Tool); this generic interface still accepts them for
+convenience, but prefer those three for those three vocabularies.
+
+ConceptMap/$translate (cross-vocabulary code translation, e.g. SNOMED to
+ICD-10-CM) is part of the same FHIR Terminology Service spec but returned
+"No suitable ConceptMaps found" for every pairing tried against this
+public server, so it is not exposed here.
+
+API: https://tx.fhir.org/r4
+No authentication required.
+"""
+
+from typing import Any, Dict, List
+
+import requests
+
+from .base_tool import BaseTool
+from .tool_registry import register_tool
+
+FHIR_TX_BASE_URL = "https://tx.fhir.org/r4"
+
+_SYSTEM_ALIASES = {
+    "snomed": "http://snomed.info/sct",
+    "loinc": "http://loinc.org",
+    "rxnorm": "http://www.nlm.nih.gov/research/umls/rxnorm",
+    "icd10cm": "http://hl7.org/fhir/sid/icd-10-cm",
+    "ucum": "http://unitsofmeasure.org",
+}
+
+
+def _resolve_system(system: str) -> str:
+    """Accept a friendly alias ('snomed') or a full FHIR system URI."""
+    return _SYSTEM_ALIASES.get(system.strip().lower(), system.strip())
+
+
+def _flatten_parameters(params: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Flatten a FHIR Parameters resource's simple (non-repeating) values."""
+    simple_types = (
+        "valueString",
+        "valueCode",
+        "valueUri",
+        "valueBoolean",
+        "valueInteger",
+        "valueDecimal",
+    )
+    flat: Dict[str, Any] = {}
+    for p in params:
+        name = p.get("name")
+        if name in flat:
+            continue
+        for key in simple_types:
+            if key in p:
+                flat[name] = p[key]
+                break
+    return flat
+
+
+def _designations(
+    params: List[Dict[str, Any]], limit: int = 10
+) -> List[Dict[str, Any]]:
+    """Extract alternate names/synonyms from a $lookup response."""
+    out = []
+    for p in params:
+        if p.get("name") != "designation":
+            continue
+        part = {d.get("name"): d for d in p.get("part") or []}
+        value = (part.get("value") or {}).get("valueString")
+        use = ((part.get("use") or {}).get("valueCoding") or {}).get("display")
+        if value:
+            out.append({"value": value, "use": use})
+        if len(out) >= limit:
+            break
+    return out
+
+
+@register_tool("FHIRTerminologyTool")
+class FHIRTerminologyTool(BaseTool):
+    """
+    Tool for querying HL7's public FHIR Terminology Service.
+
+    Supports resolving a code to its display name (primarily useful for
+    SNOMED CT, which ToolUniverse otherwise only reaches via fuzzy text
+    search), and expanding a value set -- including SNOMED CT's implicit
+    subsumption value sets, which return every descendant of a concept.
+
+    No authentication required.
+    """
+
+    def __init__(self, tool_config: Dict[str, Any]):
+        super().__init__(tool_config)
+        self.timeout = tool_config.get("timeout", 30)
+        self.operation = tool_config.get("fields", {}).get(
+            "operation", "lookup_code"
+        )
+
+    def run(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        """Execute the FHIR terminology lookup."""
+        try:
+            if self.operation == "lookup_code":
+                return self._lookup_code(arguments)
+            if self.operation == "expand_valueset":
+                return self._expand_valueset(arguments)
+            return {
+                "status": "error",
+                "error": f"Unknown operation: {self.operation}",
+            }
+        except requests.exceptions.Timeout:
+            return {
+                "status": "error",
+                "error": f"FHIR terminology request timed out after "
+                f"{self.timeout}s",
+            }
+        except requests.exceptions.ConnectionError:
+            return {
+                "status": "error",
+                "error": "Failed to connect to the FHIR terminology server. "
+                "Check network.",
+            }
+        except requests.exceptions.HTTPError as e:
+            code = e.response.status_code if e.response is not None else "unknown"
+            return {
+                "status": "error",
+                "error": f"FHIR terminology server returned HTTP {code}",
+            }
+        except ValueError:
+            return {
+                "status": "error",
+                "error": "FHIR terminology server returned a non-JSON response",
+            }
+        except Exception as e:
+            return {
+                "status": "error",
+                "error": f"Error querying FHIR terminology server: {str(e)}",
+            }
+
+    def _lookup_code(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        """Resolve one code to its display name and metadata."""
+        system = (arguments.get("system") or "").strip()
+        if not system:
+            return {
+                "status": "error",
+                "error": "system is required: 'snomed' or a full FHIR "
+                "system URI. LOINC/RxNorm/ICD-10-CM are also accepted "
+                "but already have dedicated ToolUniverse tools.",
+            }
+
+        code = (arguments.get("code") or "").strip()
+        if not code:
+            return {
+                "status": "error",
+                "error": "code is required, e.g. '22298006' (SNOMED CT: "
+                "Myocardial infarction).",
+            }
+
+        resolved_system = _resolve_system(system)
+        response = requests.get(
+            f"{FHIR_TX_BASE_URL}/CodeSystem/$lookup",
+            params={"system": resolved_system, "code": code},
+            timeout=self.timeout,
+        )
+        if response.status_code in (404, 422):
+            outcome = response.json()
+            detail = (
+                (outcome.get("issue") or [{}])[0].get("details", {}).get("text")
+            )
+            return {
+                "status": "error",
+                "error": detail or f"No concept found for {system}:{code}.",
+            }
+        response.raise_for_status()
+        payload = response.json()
+        params = payload.get("parameter") or []
+        flat = _flatten_parameters(params)
+
+        return {
+            "status": "success",
+            "data": {
+                "code": flat.get("code", code),
+                "display": flat.get("display"),
+                "system": flat.get("system", resolved_system),
+                "system_version": flat.get("version"),
+                "code_system_name": flat.get("name"),
+                "inactive": flat.get("abstract"),
+                "alternate_names": _designations(params),
+            },
+            "metadata": {
+                "system": system,
+                "code": code,
+                "source": "HL7 FHIR Terminology Service (tx.fhir.org)",
+            },
+        }
+
+    def _expand_valueset(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        """Expand a value set to its member codes.
+
+        For SNOMED CT hierarchy traversal, use a value_set_url of the form
+        'http://snomed.info/sct?fhir_vs=isa/<code>' to get every descendant
+        of a concept.
+        """
+        value_set_url = (arguments.get("value_set_url") or "").strip()
+        if not value_set_url:
+            return {
+                "status": "error",
+                "error": "value_set_url is required, e.g. "
+                "'http://snomed.info/sct?fhir_vs=isa/22298006' for every "
+                "descendant of Myocardial infarction.",
+            }
+
+        limit = arguments.get("limit")
+        if not isinstance(limit, int) or limit <= 0:
+            limit = 50
+        limit = min(limit, 500)
+
+        response = requests.get(
+            f"{FHIR_TX_BASE_URL}/ValueSet/$expand",
+            params={"url": value_set_url, "count": limit},
+            timeout=self.timeout,
+        )
+        if response.status_code in (404, 422):
+            outcome = response.json()
+            detail = (
+                (outcome.get("issue") or [{}])[0].get("details", {}).get("text")
+            )
+            return {
+                "status": "error",
+                "error": detail or f"No value set found for '{value_set_url}'.",
+            }
+        response.raise_for_status()
+        payload = response.json()
+        expansion = payload.get("expansion") or {}
+        contains = expansion.get("contains") or []
+
+        if not contains:
+            return {
+                "status": "error",
+                "error": f"Value set '{value_set_url}' expanded to zero "
+                "concepts.",
+            }
+
+        rows = [
+            {
+                "system": c.get("system"),
+                "code": c.get("code"),
+                "display": c.get("display"),
+            }
+            for c in contains
+        ]
+
+        return {
+            "status": "success",
+            "data": rows,
+            "metadata": {
+                "value_set_url": value_set_url,
+                "total_matching": expansion.get("total"),
+                "returned": len(rows),
+                "source": "HL7 FHIR Terminology Service (tx.fhir.org)",
+            },
+        }

--- a/src/tooluniverse/nci_evs_tool.py
+++ b/src/tooluniverse/nci_evs_tool.py
@@ -1,0 +1,232 @@
+# nci_evs_tool.py
+"""
+NCI EVS (Enterprise Vocabulary Services) terminology tool for ToolUniverse.
+
+The same public API that backs the existing NCIThesaurusTool hosts over a
+dozen other clinical and biomedical terminologies: CTCAE (adverse event
+grading, the clinical-trial safety standard), ICD-10-CM/ICD-9-CM (US
+diagnosis coding), RadLex (radiology), NDF-RT/MedRT (drug reference
+terminology), CanMED, plus GO/ChEBI/HGNC/SNOMED CT/LOINC. None of the
+non-NCIt terminologies were reachable anywhere in ToolUniverse before
+this, and CTCAE/ICD-10-CM/ICD-9-CM/RadLex/NDF-RT/MedRT specifically have
+no dedicated tool at all. Built as a sibling to NCIThesaurusTool rather
+than modifying it, since that tool's contract is deliberately NCIt-only.
+
+MedDRA is also listed in this API's terminology metadata but returns
+HTTP 403 on every query (it is a separately licensed vocabulary); this
+tool does not expose it. GO, ChEBI, HGNC, and SNOMED CT already have
+dedicated ToolUniverse tools that may return richer data than this
+generic interface; prefer those for those four vocabularies.
+
+API: https://api-evsrest.nci.nih.gov/api/v1
+No authentication required for the terminologies this tool exposes.
+"""
+
+from typing import Any, Dict, List
+
+import requests
+
+from .base_tool import BaseTool
+from .tool_registry import register_tool
+
+EVS_BASE_URL = "https://api-evsrest.nci.nih.gov/api/v1"
+
+# MedDRA ("mdr") is listed in this API's own terminology metadata but
+# returns HTTP 403 on every query -- a separately licensed vocabulary.
+_BLOCKED_TERMINOLOGIES = {"mdr", "meddra"}
+
+
+@register_tool("NCIEVSTool")
+class NCIEVSTool(BaseTool):
+    """
+    Tool for searching NCI EVS clinical and biomedical terminologies other
+    than NCIt (use NCIThesaurusTool for NCIt specifically).
+
+    Supports CTCAE (adverse event grading), ICD-10-CM, ICD-9-CM, ICD-10,
+    RadLex, NDF-RT, MedRT, CanMED, and more, via keyword search and
+    direct code lookup.
+
+    No authentication required.
+    """
+
+    def __init__(self, tool_config: Dict[str, Any]):
+        super().__init__(tool_config)
+        self.timeout = tool_config.get("timeout", 30)
+        self.operation = tool_config.get("fields", {}).get(
+            "operation", "search_terminology"
+        )
+
+    def run(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        """Execute the NCI EVS lookup."""
+        try:
+            if self.operation == "search_terminology":
+                return self._search_terminology(arguments)
+            if self.operation == "get_concept":
+                return self._get_concept(arguments)
+            return {
+                "status": "error",
+                "error": f"Unknown operation: {self.operation}",
+            }
+        except requests.exceptions.Timeout:
+            return {
+                "status": "error",
+                "error": f"NCI EVS request timed out after {self.timeout}s",
+            }
+        except requests.exceptions.ConnectionError:
+            return {
+                "status": "error",
+                "error": "Failed to connect to NCI EVS. Check network.",
+            }
+        except requests.exceptions.HTTPError as e:
+            code = e.response.status_code if e.response is not None else "unknown"
+            if code == 403:
+                return {
+                    "status": "error",
+                    "error": "NCI EVS returned HTTP 403: this terminology is "
+                    "licensed and not openly queryable (e.g. MedDRA).",
+                }
+            return {"status": "error", "error": f"NCI EVS returned HTTP {code}"}
+        except ValueError:
+            return {"status": "error", "error": "NCI EVS returned a non-JSON response"}
+        except Exception as e:
+            return {"status": "error", "error": f"Error querying NCI EVS: {str(e)}"}
+
+    @staticmethod
+    def _check_terminology(terminology: str) -> Dict[str, Any]:
+        if not terminology:
+            return {
+                "status": "error",
+                "error": "terminology is required, e.g. 'ctcae5' (adverse "
+                "events), 'icd10cm' (US diagnosis codes), 'radlex' "
+                "(radiology).",
+            }
+        if terminology.lower() in _BLOCKED_TERMINOLOGIES:
+            return {
+                "status": "error",
+                "error": "MedDRA is a separately licensed vocabulary; NCI "
+                "EVS returns HTTP 403 for it. CTCAE concepts include a "
+                "MedDRA_Code property as a free cross-reference instead.",
+            }
+        return {}
+
+    def _search_terminology(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        """Keyword-search one NCI EVS terminology."""
+        terminology = (arguments.get("terminology") or "").strip().lower()
+        check = self._check_terminology(terminology)
+        if check:
+            return check
+
+        term = (arguments.get("term") or "").strip()
+        if not term:
+            return {
+                "status": "error",
+                "error": "term is required, e.g. 'neutropenia' or 'diabetes'.",
+            }
+
+        limit = arguments.get("limit")
+        if not isinstance(limit, int) or limit <= 0:
+            limit = 20
+        limit = min(limit, 100)
+
+        response = requests.get(
+            f"{EVS_BASE_URL}/concept/{terminology}/search",
+            params={"term": term, "type": "contains", "pageSize": limit},
+            timeout=self.timeout,
+        )
+        if response.status_code == 404:
+            return {
+                "status": "error",
+                "error": f"Unknown NCI EVS terminology '{terminology}'.",
+            }
+        response.raise_for_status()
+        payload = response.json()
+        concepts = payload.get("concepts") or []
+
+        if not concepts:
+            return {
+                "status": "error",
+                "error": f"No {terminology} concepts matching '{term}'.",
+            }
+
+        rows = [
+            {
+                "code": c.get("code"),
+                "name": c.get("name"),
+                "leaf": c.get("leaf"),
+            }
+            for c in concepts
+        ]
+
+        return {
+            "status": "success",
+            "data": rows,
+            "metadata": {
+                "terminology": terminology,
+                "term": term,
+                "total_matching": payload.get("total"),
+                "returned": len(rows),
+                "note": "code is what get_concept expects.",
+                "source": "NCI EVS (Enterprise Vocabulary Services)",
+            },
+        }
+
+    def _get_concept(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        """Fetch one concept's full detail from an NCI EVS terminology."""
+        terminology = (arguments.get("terminology") or "").strip().lower()
+        check = self._check_terminology(terminology)
+        if check:
+            return check
+
+        code = (arguments.get("code") or "").strip()
+        if not code:
+            return {
+                "status": "error",
+                "error": "code is required, e.g. 'C143481' (CTCAE5) or "
+                "'E11.9' (ICD-10-CM).",
+            }
+
+        response = requests.get(
+            f"{EVS_BASE_URL}/concept/{terminology}/{code}",
+            params={"include": "summary"},
+            timeout=self.timeout,
+        )
+        if response.status_code == 404:
+            return {
+                "status": "error",
+                "error": f"No {terminology} concept with code '{code}'.",
+            }
+        response.raise_for_status()
+        data = response.json()
+
+        definitions = data.get("definitions") or []
+        synonyms: List[Dict[str, Any]] = [
+            {
+                "name": s.get("name"),
+                "type": s.get("termType"),
+                "source": s.get("source"),
+            }
+            for s in data.get("synonyms") or []
+        ]
+        properties = {
+            p.get("type"): p.get("value")
+            for p in data.get("properties") or []
+            if p.get("type")
+        }
+
+        return {
+            "status": "success",
+            "data": {
+                "code": data.get("code"),
+                "name": data.get("name"),
+                "terminology": data.get("terminology") or terminology,
+                "active": data.get("active"),
+                "definition": definitions[0].get("definition") if definitions else None,
+                "synonyms": synonyms[:20],
+                "properties": properties,
+            },
+            "metadata": {
+                "terminology": terminology,
+                "code": code,
+                "source": "NCI EVS (Enterprise Vocabulary Services)",
+            },
+        }

--- a/src/tooluniverse/nci_evs_tool.py
+++ b/src/tooluniverse/nci_evs_tool.py
@@ -4,19 +4,21 @@ NCI EVS (Enterprise Vocabulary Services) terminology tool for ToolUniverse.
 
 The same public API that backs the existing NCIThesaurusTool hosts over a
 dozen other clinical and biomedical terminologies: CTCAE (adverse event
-grading, the clinical-trial safety standard), ICD-10-CM/ICD-9-CM (US
-diagnosis coding), RadLex (radiology), NDF-RT/MedRT (drug reference
-terminology), CanMED, plus GO/ChEBI/HGNC/SNOMED CT/LOINC. None of the
-non-NCIt terminologies were reachable anywhere in ToolUniverse before
-this, and CTCAE/ICD-10-CM/ICD-9-CM/RadLex/NDF-RT/MedRT specifically have
-no dedicated tool at all. Built as a sibling to NCIThesaurusTool rather
-than modifying it, since that tool's contract is deliberately NCIt-only.
+grading, the clinical-trial safety standard), ICD-9-CM, RadLex
+(radiology), NDF-RT/MedRT (drug reference terminology), CanMED, plus
+GO/ChEBI/HGNC/SNOMED CT/LOINC/ICD-10-CM. CTCAE/ICD-9-CM/RadLex/NDF-RT/
+MedRT specifically have no dedicated tool anywhere else in ToolUniverse.
+Built as a sibling to NCIThesaurusTool rather than modifying it, since
+that tool's contract is deliberately NCIt-only.
 
 MedDRA is also listed in this API's terminology metadata but returns
 HTTP 403 on every query (it is a separately licensed vocabulary); this
-tool does not expose it. GO, ChEBI, HGNC, and SNOMED CT already have
-dedicated ToolUniverse tools that may return richer data than this
-generic interface; prefer those for those four vocabularies.
+tool does not expose it. GO, ChEBI, HGNC, SNOMED CT, and ICD-10-CM
+(ICD10Tool, via NLM Clinical Tables) already have dedicated ToolUniverse
+tools that may return richer or more authoritative data than this
+generic interface; prefer those five for those five vocabularies. This
+tool still accepts them for completeness, since the underlying API is
+shared and free either way.
 
 API: https://api-evsrest.nci.nih.gov/api/v1
 No authentication required for the terminologies this tool exposes.
@@ -97,7 +99,7 @@ class NCIEVSTool(BaseTool):
             return {
                 "status": "error",
                 "error": "terminology is required, e.g. 'ctcae5' (adverse "
-                "events), 'icd10cm' (US diagnosis codes), 'radlex' "
+                "events), 'icd9cm' (US legacy diagnosis codes), 'radlex' "
                 "(radiology).",
             }
         if terminology.lower() in _BLOCKED_TERMINOLOGIES:

--- a/src/tooluniverse/openfda_device_tool.py
+++ b/src/tooluniverse/openfda_device_tool.py
@@ -1,0 +1,199 @@
+# openfda_device_tool.py
+"""
+openFDA medical device tool for ToolUniverse.
+
+ToolUniverse's existing openFDA tools cover only the drug endpoints
+(drug/event, drug/label, drug/drugsfda); the device side -- device
+recalls and MAUDE (Manufacturer and User Facility Device Experience)
+adverse event reports -- had no coverage at all. These are a genuinely
+different record schema (device brand/generic name, recall
+classification and root cause, patient problem codes) from the
+drug-adverse-event tools, not a parameter variation of them.
+
+A bare `search=<term>` full-text query was verified to discriminate
+correctly (a nonsense term returns a clean 404 "no matches", not an
+inflated count) before building this, given this exact codebase's own
+git history documents prior openFDA quoting/exactness bugs.
+
+API: https://api.fda.gov/device
+No authentication required (optional api_key raises the rate limit).
+"""
+
+from typing import Any, Dict, List
+
+import requests
+
+from .base_tool import BaseTool
+from .tool_registry import register_tool
+
+RECALL_URL = "https://api.fda.gov/device/recall.json"
+EVENT_URL = "https://api.fda.gov/device/event.json"
+
+
+@register_tool("OpenFDADeviceTool")
+class OpenFDADeviceTool(BaseTool):
+    """
+    Tool for querying openFDA's medical device recall and adverse event
+    (MAUDE) data.
+
+    Supports searching device recalls (reason, root cause, recalling
+    firm) and MAUDE adverse event reports (device, event type, patient
+    problems) by device name.
+
+    No authentication required.
+    """
+
+    def __init__(self, tool_config: Dict[str, Any]):
+        super().__init__(tool_config)
+        self.timeout = tool_config.get("timeout", 30)
+        self.operation = tool_config.get("fields", {}).get(
+            "operation", "search_recalls"
+        )
+
+    def run(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        """Execute the openFDA device lookup."""
+        try:
+            if self.operation == "search_recalls":
+                return self._search_recalls(arguments)
+            if self.operation == "search_adverse_events":
+                return self._search_adverse_events(arguments)
+            return {
+                "status": "error",
+                "error": f"Unknown operation: {self.operation}",
+            }
+        except requests.exceptions.Timeout:
+            return {
+                "status": "error",
+                "error": f"openFDA request timed out after {self.timeout}s",
+            }
+        except requests.exceptions.ConnectionError:
+            return {
+                "status": "error",
+                "error": "Failed to connect to openFDA. Check network.",
+            }
+        except requests.exceptions.HTTPError as e:
+            code = e.response.status_code if e.response is not None else "unknown"
+            return {"status": "error", "error": f"openFDA returned HTTP {code}"}
+        except ValueError:
+            return {"status": "error", "error": "openFDA returned a non-JSON response"}
+        except Exception as e:
+            return {"status": "error", "error": f"Error querying openFDA: {str(e)}"}
+
+    def _search_recalls(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        """Search medical device recalls by device name or free text."""
+        query = (arguments.get("query") or "").strip()
+        if not query:
+            return {
+                "status": "error",
+                "error": "query is required, e.g. 'pacemaker' or a "
+                "recalling firm name.",
+            }
+
+        limit = arguments.get("limit")
+        if not isinstance(limit, int) or limit <= 0:
+            limit = 20
+        limit = min(limit, 100)
+
+        response = requests.get(
+            RECALL_URL, params={"search": query, "limit": limit}, timeout=self.timeout
+        )
+        if response.status_code == 404:
+            return {
+                "status": "error",
+                "error": f"No device recalls matching '{query}'.",
+            }
+        response.raise_for_status()
+        payload = response.json()
+        results = payload.get("results") or []
+
+        rows = [
+            {
+                "product_description": r.get("product_description"),
+                "recalling_firm": r.get("recalling_firm"),
+                "reason_for_recall": r.get("reason_for_recall"),
+                "root_cause_description": r.get("root_cause_description"),
+                "recall_status": r.get("recall_status"),
+                "event_date_initiated": r.get("event_date_initiated"),
+                "action": r.get("action"),
+            }
+            for r in results
+        ]
+
+        return {
+            "status": "success",
+            "data": rows,
+            "metadata": {
+                "query": query,
+                "total_matching": (payload.get("meta") or {})
+                .get("results", {})
+                .get("total"),
+                "returned": len(rows),
+                "source": "openFDA device/recall",
+            },
+        }
+
+    def _search_adverse_events(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        """Search MAUDE device adverse event reports by device name."""
+        device_name = (arguments.get("device_name") or "").strip()
+        if not device_name:
+            return {
+                "status": "error",
+                "error": "device_name is required, e.g. 'pacemaker' or "
+                "'insulin pump'.",
+            }
+
+        limit = arguments.get("limit")
+        if not isinstance(limit, int) or limit <= 0:
+            limit = 20
+        limit = min(limit, 100)
+
+        response = requests.get(
+            EVENT_URL,
+            params={
+                "search": f"device.generic_name:{device_name}",
+                "limit": limit,
+            },
+            timeout=self.timeout,
+        )
+        if response.status_code == 404:
+            return {
+                "status": "error",
+                "error": f"No MAUDE adverse event reports for device "
+                f"'{device_name}'.",
+            }
+        response.raise_for_status()
+        payload = response.json()
+        results = payload.get("results") or []
+
+        rows: List[Dict[str, Any]] = []
+        for r in results:
+            devices = r.get("device") or [{}]
+            device = devices[0] if devices else {}
+            patients = r.get("patient") or []
+            patient_problems: List[str] = []
+            for p in patients:
+                patient_problems.extend(p.get("patient_problems") or [])
+            rows.append(
+                {
+                    "brand_name": device.get("brand_name"),
+                    "generic_name": device.get("generic_name"),
+                    "manufacturer": device.get("manufacturer_d_name"),
+                    "event_type": r.get("event_type"),
+                    "date_of_event": r.get("date_of_event"),
+                    "product_problems": r.get("product_problems") or [],
+                    "patient_problems": sorted(set(patient_problems)),
+                }
+            )
+
+        return {
+            "status": "success",
+            "data": rows,
+            "metadata": {
+                "device_name": device_name,
+                "total_matching": (payload.get("meta") or {})
+                .get("results", {})
+                .get("total"),
+                "returned": len(rows),
+                "source": "openFDA device/event (MAUDE)",
+            },
+        }

--- a/src/tooluniverse/openfda_device_tool.py
+++ b/src/tooluniverse/openfda_device_tool.py
@@ -3,12 +3,15 @@
 openFDA medical device tool for ToolUniverse.
 
 ToolUniverse's existing openFDA tools cover only the drug endpoints
-(drug/event, drug/label, drug/drugsfda); the device side -- device
-recalls and MAUDE (Manufacturer and User Facility Device Experience)
-adverse event reports -- had no coverage at all. These are a genuinely
-different record schema (device brand/generic name, recall
-classification and root cause, patient problem codes) from the
-drug-adverse-event tools, not a parameter variation of them.
+(drug/event, drug/label, drug/drugsfda); the device side had no coverage
+at all. Covers recalls, MAUDE (Manufacturer and User Facility Device
+Experience) adverse event reports, the UDI (Unique Device Identifier)
+database, regulatory classification, and both premarket pathways --
+510(k) notification and PMA (premarket approval) for higher-risk
+devices. These are a genuinely different record schema (device brand/
+generic name, recall classification and root cause, patient problem
+codes, regulatory clearance numbers) from the drug-adverse-event tools,
+not a parameter variation of them.
 
 A bare `search=<term>` full-text query was verified to discriminate
 correctly (a nonsense term returns a clean 404 "no matches", not an
@@ -28,6 +31,10 @@ from .tool_registry import register_tool
 
 RECALL_URL = "https://api.fda.gov/device/recall.json"
 EVENT_URL = "https://api.fda.gov/device/event.json"
+UDI_URL = "https://api.fda.gov/device/udi.json"
+CLASSIFICATION_URL = "https://api.fda.gov/device/classification.json"
+K510_URL = "https://api.fda.gov/device/510k.json"
+PMA_URL = "https://api.fda.gov/device/pma.json"
 
 
 @register_tool("OpenFDADeviceTool")
@@ -37,8 +44,9 @@ class OpenFDADeviceTool(BaseTool):
     (MAUDE) data.
 
     Supports searching device recalls (reason, root cause, recalling
-    firm) and MAUDE adverse event reports (device, event type, patient
-    problems) by device name.
+    firm), MAUDE adverse event reports (device, event type, patient
+    problems), the UDI database, regulatory classification, and 510(k)/
+    PMA premarket clearances, all by device name.
 
     No authentication required.
     """
@@ -57,6 +65,14 @@ class OpenFDADeviceTool(BaseTool):
                 return self._search_recalls(arguments)
             if self.operation == "search_adverse_events":
                 return self._search_adverse_events(arguments)
+            if self.operation == "search_udi":
+                return self._search_udi(arguments)
+            if self.operation == "get_classification":
+                return self._get_classification(arguments)
+            if self.operation == "search_510k":
+                return self._search_510k(arguments)
+            if self.operation == "search_pma":
+                return self._search_pma(arguments)
             return {
                 "status": "error",
                 "error": f"Unknown operation: {self.operation}",
@@ -195,5 +211,246 @@ class OpenFDADeviceTool(BaseTool):
                 .get("total"),
                 "returned": len(rows),
                 "source": "openFDA device/event (MAUDE)",
+            },
+        }
+
+    def _search_udi(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        """Search the Unique Device Identifier (UDI) database."""
+        query = (arguments.get("query") or "").strip()
+        if not query:
+            return {
+                "status": "error",
+                "error": "query is required, e.g. 'pacemaker' or a "
+                "company name.",
+            }
+
+        limit = arguments.get("limit")
+        if not isinstance(limit, int) or limit <= 0:
+            limit = 20
+        limit = min(limit, 100)
+
+        response = requests.get(
+            UDI_URL, params={"search": query, "limit": limit}, timeout=self.timeout
+        )
+        if response.status_code == 404:
+            return {
+                "status": "error",
+                "error": f"No UDI records matching '{query}'.",
+            }
+        response.raise_for_status()
+        payload = response.json()
+        results = payload.get("results") or []
+
+        rows = []
+        for r in results:
+            product_codes = r.get("product_codes") or [{}]
+            first_code = product_codes[0] if product_codes else {}
+            identifiers = r.get("identifiers") or []
+            gmdn_terms = r.get("gmdn_terms") or []
+            rows.append(
+                {
+                    "brand_name": r.get("brand_name"),
+                    "company_name": r.get("company_name"),
+                    "device_description": r.get("device_description"),
+                    "primary_di": next(
+                        (
+                            i.get("id")
+                            for i in identifiers
+                            if i.get("type") == "Primary"
+                        ),
+                        None,
+                    ),
+                    "gmdn_terms": [g.get("name") for g in gmdn_terms if g.get("name")],
+                    "device_class": (first_code.get("openfda") or {}).get(
+                        "device_class"
+                    ),
+                    "commercial_distribution_status": r.get(
+                        "commercial_distribution_status"
+                    ),
+                }
+            )
+
+        return {
+            "status": "success",
+            "data": rows,
+            "metadata": {
+                "query": query,
+                "total_matching": (payload.get("meta") or {})
+                .get("results", {})
+                .get("total"),
+                "returned": len(rows),
+                "source": "openFDA device/udi",
+            },
+        }
+
+    def _get_classification(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        """Search device regulatory classification by device name."""
+        device_name = (arguments.get("device_name") or "").strip()
+        if not device_name:
+            return {
+                "status": "error",
+                "error": "device_name is required, e.g. 'pacemaker'.",
+            }
+
+        limit = arguments.get("limit")
+        if not isinstance(limit, int) or limit <= 0:
+            limit = 20
+        limit = min(limit, 100)
+
+        response = requests.get(
+            CLASSIFICATION_URL,
+            params={"search": f"device_name:{device_name}", "limit": limit},
+            timeout=self.timeout,
+        )
+        if response.status_code == 404:
+            return {
+                "status": "error",
+                "error": f"No device classification found for "
+                f"'{device_name}'.",
+            }
+        response.raise_for_status()
+        payload = response.json()
+        results = payload.get("results") or []
+
+        rows = [
+            {
+                "device_name": r.get("device_name"),
+                "product_code": r.get("product_code"),
+                "device_class": r.get("device_class"),
+                "review_panel": r.get("review_panel"),
+                "medical_specialty_description": r.get(
+                    "medical_specialty_description"
+                ),
+                "regulation_number": r.get("regulation_number"),
+                "third_party_flag": r.get("third_party_flag"),
+            }
+            for r in results
+        ]
+
+        return {
+            "status": "success",
+            "data": rows,
+            "metadata": {
+                "device_name": device_name,
+                "total_matching": (payload.get("meta") or {})
+                .get("results", {})
+                .get("total"),
+                "returned": len(rows),
+                "note": "device_class: 1 = general controls, 2 = special "
+                "controls, 3 = premarket approval.",
+                "source": "openFDA device/classification",
+            },
+        }
+
+    def _search_510k(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        """Search 510(k) premarket notification clearances."""
+        device_name = (arguments.get("device_name") or "").strip()
+        if not device_name:
+            return {
+                "status": "error",
+                "error": "device_name is required, e.g. 'pacemaker'.",
+            }
+
+        limit = arguments.get("limit")
+        if not isinstance(limit, int) or limit <= 0:
+            limit = 20
+        limit = min(limit, 100)
+
+        response = requests.get(
+            K510_URL,
+            params={"search": f"device_name:{device_name}", "limit": limit},
+            timeout=self.timeout,
+        )
+        if response.status_code == 404:
+            return {
+                "status": "error",
+                "error": f"No 510(k) clearances found for '{device_name}'.",
+            }
+        response.raise_for_status()
+        payload = response.json()
+        results = payload.get("results") or []
+
+        rows = [
+            {
+                "k_number": r.get("k_number"),
+                "device_name": r.get("device_name"),
+                "applicant": r.get("applicant"),
+                "decision_date": r.get("decision_date"),
+                "decision_description": r.get("decision_description"),
+                "clearance_type": r.get("clearance_type"),
+                "advisory_committee_description": r.get(
+                    "advisory_committee_description"
+                ),
+            }
+            for r in results
+        ]
+
+        return {
+            "status": "success",
+            "data": rows,
+            "metadata": {
+                "device_name": device_name,
+                "total_matching": (payload.get("meta") or {})
+                .get("results", {})
+                .get("total"),
+                "returned": len(rows),
+                "source": "openFDA device/510k",
+            },
+        }
+
+    def _search_pma(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        """Search premarket approval (PMA) applications for high-risk devices."""
+        device_name = (arguments.get("device_name") or "").strip()
+        if not device_name:
+            return {
+                "status": "error",
+                "error": "device_name is required, e.g. 'defibrillator'.",
+            }
+
+        limit = arguments.get("limit")
+        if not isinstance(limit, int) or limit <= 0:
+            limit = 20
+        limit = min(limit, 100)
+
+        response = requests.get(
+            PMA_URL,
+            params={"search": f"trade_name:{device_name}", "limit": limit},
+            timeout=self.timeout,
+        )
+        if response.status_code == 404:
+            return {
+                "status": "error",
+                "error": f"No PMA applications found for '{device_name}'.",
+            }
+        response.raise_for_status()
+        payload = response.json()
+        results = payload.get("results") or []
+
+        rows = [
+            {
+                "pma_number": r.get("pma_number"),
+                "trade_name": r.get("trade_name"),
+                "applicant": r.get("applicant"),
+                "decision_date": r.get("decision_date"),
+                "ao_statement": r.get("ao_statement"),
+                "advisory_committee_description": r.get(
+                    "advisory_committee_description"
+                ),
+            }
+            for r in results
+        ]
+
+        return {
+            "status": "success",
+            "data": rows,
+            "metadata": {
+                "device_name": device_name,
+                "total_matching": (payload.get("meta") or {})
+                .get("results", {})
+                .get("total"),
+                "returned": len(rows),
+                "note": "ao_statement summarizes the specific approval "
+                "order/change, not the whole device history.",
+                "source": "openFDA device/pma",
             },
         }

--- a/src/tooluniverse/smartapi_tool.py
+++ b/src/tooluniverse/smartapi_tool.py
@@ -1,0 +1,195 @@
+# smartapi_tool.py
+"""
+SmartAPI registry tool for ToolUniverse.
+
+SmartAPI is the machine-readable registry of ~270 biomedical web APIs
+(OpenAPI-described, many part of the NCATS Biomedical Data Translator),
+searchable by keyword or tag. ToolUniverse already wraps a large fraction
+of the APIs registered here individually, but had no way to discover what
+else is registered, or resolve an API name mentioned in a paper or Translator
+component list to its actual base URL and endpoint list.
+
+The full per-API document is the complete OpenAPI spec (often hundreds of
+KB with every path/schema/component); this tool asks the API's own `fields`
+parameter for a slimmed summary rather than returning that raw.
+
+API: https://smart-api.info/api
+No authentication required.
+"""
+
+from typing import Any, Dict, List
+
+import requests
+
+from .base_tool import BaseTool
+from .tool_registry import register_tool
+
+SMARTAPI_BASE_URL = "https://smart-api.info/api"
+
+_SEARCH_FIELDS = (
+    "_id,_meta.slug,info.title,info.description,info.contact,tags,servers"
+)
+
+
+def _summarize_hit(hit: Dict[str, Any]) -> Dict[str, Any]:
+    """Condense one SmartAPI search hit to its useful summary fields."""
+    info = hit.get("info") or {}
+    servers = hit.get("servers") or []
+    return {
+        "api_id": hit.get("_id"),
+        "slug": (hit.get("_meta") or {}).get("slug"),
+        "title": info.get("title"),
+        "description": info.get("description"),
+        "base_url": servers[0].get("url") if servers else None,
+        "tags": [t.get("name") for t in hit.get("tags") or [] if t.get("name")],
+    }
+
+
+@register_tool("SmartAPITool")
+class SmartAPITool(BaseTool):
+    """
+    Tool for searching the SmartAPI registry of biomedical web APIs.
+
+    Supports keyword/tag search across ~270 registered OpenAPI specs, and
+    fetching one API's full metadata (servers, tags, endpoint count,
+    contact) by its registry id or slug.
+
+    No authentication required.
+    """
+
+    def __init__(self, tool_config: Dict[str, Any]):
+        super().__init__(tool_config)
+        self.timeout = tool_config.get("timeout", 30)
+        self.operation = tool_config.get("fields", {}).get(
+            "operation", "search_apis"
+        )
+
+    def run(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        """Execute the SmartAPI lookup."""
+        try:
+            if self.operation == "search_apis":
+                return self._search_apis(arguments)
+            if self.operation == "get_api":
+                return self._get_api(arguments)
+            return {
+                "status": "error",
+                "error": f"Unknown operation: {self.operation}",
+            }
+        except requests.exceptions.Timeout:
+            return {
+                "status": "error",
+                "error": f"SmartAPI request timed out after {self.timeout}s",
+            }
+        except requests.exceptions.ConnectionError:
+            return {
+                "status": "error",
+                "error": "Failed to connect to SmartAPI. Check network.",
+            }
+        except requests.exceptions.HTTPError as e:
+            code = e.response.status_code if e.response is not None else "unknown"
+            return {"status": "error", "error": f"SmartAPI returned HTTP {code}"}
+        except ValueError:
+            return {
+                "status": "error",
+                "error": "SmartAPI returned a non-JSON response",
+            }
+        except Exception as e:
+            return {"status": "error", "error": f"Error querying SmartAPI: {str(e)}"}
+
+    def _search_apis(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        """Search the SmartAPI registry by keyword or tag."""
+        query = (arguments.get("query") or "").strip()
+        if not query:
+            return {
+                "status": "error",
+                "error": "query is required, e.g. 'variant' or "
+                "'tags.name:translator'.",
+            }
+
+        limit = arguments.get("limit")
+        if not isinstance(limit, int) or limit <= 0:
+            limit = 25
+        limit = min(limit, 100)
+
+        response = requests.get(
+            f"{SMARTAPI_BASE_URL}/query",
+            params={
+                "q": query,
+                "size": limit,
+                "raw": 1,
+                "fields": _SEARCH_FIELDS,
+            },
+            timeout=self.timeout,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        hits = payload.get("hits") or []
+
+        if not hits:
+            return {
+                "status": "error",
+                "error": f"No SmartAPI entries matching '{query}'.",
+            }
+
+        rows = [_summarize_hit(h) for h in hits]
+
+        return {
+            "status": "success",
+            "data": rows,
+            "metadata": {
+                "query": query,
+                "total_matching": payload.get("total"),
+                "returned": len(rows),
+                "note": "api_id (or slug, when present) is what get_api "
+                "expects for the full record.",
+                "source": "SmartAPI registry",
+            },
+        }
+
+    def _get_api(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        """Fetch one API's full metadata by its registry id or slug."""
+        api_id = (arguments.get("api_id") or "").strip()
+        if not api_id:
+            return {
+                "status": "error",
+                "error": "api_id is required: a SmartAPI registry id or "
+                "slug, e.g. 'myvariant'. Use search_apis to find one.",
+            }
+
+        response = requests.get(
+            f"{SMARTAPI_BASE_URL}/metadata/{api_id}", timeout=self.timeout
+        )
+        if response.status_code == 404:
+            return {
+                "status": "error",
+                "error": f"No SmartAPI entry with id or slug '{api_id}'.",
+            }
+        response.raise_for_status()
+        spec = response.json()
+        info = spec.get("info") or {}
+        servers = spec.get("servers") or []
+        paths = spec.get("paths") or {}
+
+        endpoints: List[str] = list(paths.keys())
+
+        return {
+            "status": "success",
+            "data": {
+                "title": info.get("title"),
+                "description": info.get("description"),
+                "version": info.get("version"),
+                "contact": (info.get("contact") or {}).get("email"),
+                "terms_of_service": info.get("termsOfService"),
+                "base_urls": [s.get("url") for s in servers if s.get("url")],
+                "tags": [
+                    t.get("name") for t in spec.get("tags") or [] if t.get("name")
+                ],
+                "endpoint_count": len(endpoints),
+                "endpoints": endpoints[:50],
+            },
+            "metadata": {
+                "api_id": api_id,
+                "endpoints_truncated": len(endpoints) > 50,
+                "source": "SmartAPI registry",
+            },
+        }

--- a/tests/tools/test_clinical_tables_new_operations.py
+++ b/tests/tools/test_clinical_tables_new_operations.py
@@ -1,0 +1,118 @@
+"""Tests for the new ClinicalTablesTool operations: HCPCS, star alleles,
+and NPI provider/organization search.
+
+These extend the existing ClinicalTablesTool (which already covered
+rxterms, conditions, and disease_names) rather than duplicating a new
+class under the same name. NPI search pairs directly with the existing
+CMSOpenPaymentsTool: that tool's records are keyed by NPI with no way to
+resolve who the NPI actually belongs to. The pre-existing three
+operations (RxTerms_search_drugs, HealthConditions_search,
+DiseaseNames_search) have no dedicated test file and are out of scope
+here; a quick regression check confirms they still work unaffected.
+"""
+
+import pytest
+from tooluniverse import ToolUniverse
+
+
+TRANSIENT = ("timed out", "Failed to connect", "HTTP 5")
+
+
+@pytest.fixture(scope="module")
+def tu():
+    instance = ToolUniverse()
+    instance.load_tools()
+    return instance
+
+
+def results_of(result):
+    if "error" in result:
+        error = str(result.get("error", ""))
+        if any(t in error for t in TRANSIENT):
+            pytest.skip(f"upstream temporarily unavailable: {error[:80]}")
+        pytest.fail(f"unexpected error response: {error[:200]}")
+    return result["results"]
+
+
+class TestRegistration:
+    def test_new_tools_load(self, tu):
+        names = {t.get("name") for t in tu.all_tools if isinstance(t, dict)}
+        assert "HCPCS_search" in names
+        assert "StarAlleles_search" in names
+        assert "NPIProvider_search" in names
+
+    def test_preexisting_tool_still_works(self, tu):
+        # Regression guard: extending the shared class must not break the
+        # tools that were already there.
+        result = tu.tools.RxTerms_search_drugs(terms="metformin", max_results=3)
+        assert results_of(result)
+
+
+class TestHCPCS:
+    def test_finds_wheelchair_codes(self, tu):
+        rows = results_of(
+            tu.tools.HCPCS_search(terms="wheelchair", max_results=10)
+        )
+        assert rows
+        assert all(r["code"] and r["display"] for r in rows)
+
+    def test_max_results_is_respected(self, tu):
+        rows = results_of(tu.tools.HCPCS_search(terms="wheelchair", max_results=2))
+        assert len(rows) <= 2
+
+    def test_missing_terms(self, tu):
+        result = tu.tools.HCPCS_search(terms="")
+        assert result.get("status") == "error"
+
+
+class TestStarAlleles:
+    def test_cyp2d6_alleles_have_known_structure(self, tu):
+        rows = results_of(tu.tools.StarAlleles_search(terms="CYP2D6", max_results=5))
+        assert rows
+        wild_type = next(
+            (r for r in rows if r["alternate_name"] == "Wild-type"), None
+        )
+        assert wild_type is not None
+        assert wild_type["code"] == "CYP2D6*1A"
+
+    def test_missing_terms(self, tu):
+        result = tu.tools.StarAlleles_search(terms="")
+        assert result.get("status") == "error"
+
+
+class TestNPIProvider:
+    def test_individual_provider_search(self, tu):
+        rows = results_of(tu.tools.NPIProvider_search(terms="Smith", max_results=5))
+        assert rows
+        assert all(r["is_organization"] is False for r in rows)
+        assert all(len(r["NPI"]) == 10 and r["NPI"].isdigit() for r in rows)
+
+    def test_organization_search_returns_organizations(self, tu):
+        rows = results_of(
+            tu.tools.NPIProvider_search(
+                terms="Mayo Clinic", organization=True, max_results=5
+            )
+        )
+        assert rows
+        assert all(r["is_organization"] is True for r in rows)
+        assert all("MAYO" in r["name.full"].upper() for r in rows)
+
+    def test_missing_terms(self, tu):
+        result = tu.tools.NPIProvider_search(terms="")
+        assert result.get("status") == "error"
+
+
+class TestErrorHandling:
+    @pytest.mark.parametrize(
+        "tool_name,kwargs",
+        [
+            ("HCPCS_search", {"terms": ""}),
+            ("StarAlleles_search", {"terms": ""}),
+            ("NPIProvider_search", {"terms": ""}),
+        ],
+    )
+    def test_returns_error_dict_not_exception(self, tu, tool_name, kwargs):
+        result = getattr(tu.tools, tool_name)(**kwargs)
+        assert isinstance(result, dict)
+        assert result.get("status") == "error"
+        assert isinstance(result.get("error"), str) and result["error"]

--- a/tests/tools/test_fhir_terminology_tool.py
+++ b/tests/tools/test_fhir_terminology_tool.py
@@ -1,0 +1,143 @@
+"""Tests for the FHIR Terminology Service tool.
+
+tx.fhir.org's main value here is SNOMED CT: ToolUniverse could previously
+only reach it via fuzzy keyword search (the generic OLS wrapper), with no
+proper code-based lookup and no hierarchy traversal at all. LOINC,
+RxNorm, and ICD-10-CM are also reachable through this generic interface
+but already have dedicated, richer ToolUniverse tools. ConceptMap/
+$translate was tried against several vocabulary pairs during development
+and returned "No suitable ConceptMaps found" for all of them, so it is
+not exposed and not tested here.
+"""
+
+import pytest
+from tooluniverse import ToolUniverse
+
+
+TRANSIENT = ("timed out", "Failed to connect", "HTTP 5")
+
+MYOCARDIAL_INFARCTION = "22298006"
+
+
+@pytest.fixture(scope="module")
+def tu():
+    instance = ToolUniverse()
+    instance.load_tools()
+    return instance
+
+
+def data_of(result):
+    if result.get("status") == "error":
+        error = str(result.get("error", ""))
+        if any(t in error for t in TRANSIENT):
+            pytest.skip(f"upstream temporarily unavailable: {error[:80]}")
+        pytest.fail(f"unexpected error response: {error[:200]}")
+    return result["data"]
+
+
+class TestRegistration:
+    def test_tools_load(self, tu):
+        names = {t.get("name") for t in tu.all_tools if isinstance(t, dict)}
+        assert "FHIRTerminology_lookup_code" in names
+        assert "FHIRTerminology_expand_valueset" in names
+
+
+class TestLookupCode:
+    def test_snomed_lookup_by_alias(self, tu):
+        data = data_of(
+            tu.tools.FHIRTerminology_lookup_code(
+                system="snomed", code=MYOCARDIAL_INFARCTION
+            )
+        )
+        assert data["display"] == "Myocardial infarction"
+        assert data["system"] == "http://snomed.info/sct"
+
+    def test_snomed_lookup_by_full_uri(self, tu):
+        data = data_of(
+            tu.tools.FHIRTerminology_lookup_code(
+                system="http://snomed.info/sct", code=MYOCARDIAL_INFARCTION
+            )
+        )
+        assert data["display"] == "Myocardial infarction"
+
+    def test_alternate_names_include_known_synonym(self, tu):
+        data = data_of(
+            tu.tools.FHIRTerminology_lookup_code(
+                system="snomed", code=MYOCARDIAL_INFARCTION
+            )
+        )
+        synonyms = {a["value"] for a in data["alternate_names"]}
+        assert "Myocardial infarction, NOS" in synonyms
+
+    def test_unknown_code(self, tu):
+        result = tu.tools.FHIRTerminology_lookup_code(
+            system="snomed", code="99999999999999"
+        )
+        assert result["status"] == "error"
+
+    def test_unknown_system(self, tu):
+        result = tu.tools.FHIRTerminology_lookup_code(
+            system="http://notarealsystem.org/xyz", code="x"
+        )
+        assert result["status"] == "error"
+
+    def test_missing_system(self, tu):
+        result = tu.tools.FHIRTerminology_lookup_code(system="", code="x")
+        assert result["status"] == "error"
+
+    def test_missing_code(self, tu):
+        result = tu.tools.FHIRTerminology_lookup_code(system="snomed", code="")
+        assert result["status"] == "error"
+
+
+class TestExpandValueset:
+    def test_myocardial_infarction_hierarchy(self, tu):
+        rows = data_of(
+            tu.tools.FHIRTerminology_expand_valueset(
+                value_set_url=(
+                    f"http://snomed.info/sct?fhir_vs=isa/{MYOCARDIAL_INFARCTION}"
+                ),
+                limit=20,
+            )
+        )
+        assert rows
+        codes = {r["code"] for r in rows}
+        # The root concept and a well-known clinical subtype must both
+        # appear in its own subsumption expansion.
+        assert MYOCARDIAL_INFARCTION in codes
+        names = {r["display"] for r in rows}
+        assert any("myocardial infarction" in n.lower() for n in names)
+
+    def test_limit_is_respected(self, tu):
+        rows = data_of(
+            tu.tools.FHIRTerminology_expand_valueset(
+                value_set_url=(
+                    f"http://snomed.info/sct?fhir_vs=isa/{MYOCARDIAL_INFARCTION}"
+                ),
+                limit=3,
+            )
+        )
+        assert len(rows) <= 3
+
+    def test_missing_value_set_url(self, tu):
+        result = tu.tools.FHIRTerminology_expand_valueset(value_set_url="")
+        assert result["status"] == "error"
+
+
+class TestErrorHandling:
+    @pytest.mark.parametrize(
+        "tool_name,kwargs",
+        [
+            ("FHIRTerminology_lookup_code", {"system": "", "code": ""}),
+            (
+                "FHIRTerminology_lookup_code",
+                {"system": "snomed", "code": "99999999999999"},
+            ),
+            ("FHIRTerminology_expand_valueset", {"value_set_url": ""}),
+        ],
+    )
+    def test_returns_error_dict_not_exception(self, tu, tool_name, kwargs):
+        result = getattr(tu.tools, tool_name)(**kwargs)
+        assert isinstance(result, dict)
+        assert result["status"] == "error"
+        assert isinstance(result.get("error"), str) and result["error"]

--- a/tests/tools/test_nci_evs_tool.py
+++ b/tests/tools/test_nci_evs_tool.py
@@ -1,0 +1,130 @@
+"""Tests for the NCI EVS terminology tool.
+
+Built as a sibling to the existing NCIt-only NCIThesaurusTool (same
+public API, api-evsrest.nci.nih.gov) rather than modifying it, since
+CTCAE, ICD-10-CM/ICD-9-CM, RadLex, and NDF-RT/MedRT had no dedicated
+tool anywhere in ToolUniverse. Tests assert known clinical facts survive
+the round trip, and that MedDRA -- listed in the API's own terminology
+metadata but blocked with HTTP 403 on every query, since it is a
+separately licensed vocabulary -- fails with an explanatory error rather
+than a raw HTTP error.
+"""
+
+import pytest
+from tooluniverse import ToolUniverse
+
+
+TRANSIENT = ("timed out", "Failed to connect", "HTTP 5")
+
+FEBRILE_NEUTROPENIA = "C143481"
+
+
+@pytest.fixture(scope="module")
+def tu():
+    instance = ToolUniverse()
+    instance.load_tools()
+    return instance
+
+
+def data_of(result):
+    if result.get("status") == "error":
+        error = str(result.get("error", ""))
+        if any(t in error for t in TRANSIENT):
+            pytest.skip(f"upstream temporarily unavailable: {error[:80]}")
+        pytest.fail(f"unexpected error response: {error[:200]}")
+    return result["data"]
+
+
+class TestRegistration:
+    def test_tools_load(self, tu):
+        names = {t.get("name") for t in tu.all_tools if isinstance(t, dict)}
+        assert "NCIEVS_search_terminology" in names
+        assert "NCIEVS_get_concept" in names
+
+
+class TestSearchTerminology:
+    def test_ctcae_grades_a_known_adverse_event(self, tu):
+        rows = data_of(
+            tu.tools.NCIEVS_search_terminology(
+                terminology="ctcae5", term="neutropenia", limit=10
+            )
+        )
+        assert any(r["code"] == FEBRILE_NEUTROPENIA for r in rows)
+        assert any("Grade" in (r["name"] or "") for r in rows)
+
+    def test_icd10cm_finds_diabetes_codes(self, tu):
+        rows = data_of(
+            tu.tools.NCIEVS_search_terminology(
+                terminology="icd10cm", term="diabetes", limit=10
+            )
+        )
+        assert rows
+        assert all("diabet" in (r["name"] or "").lower() for r in rows)
+
+    def test_limit_is_respected(self, tu):
+        rows = data_of(
+            tu.tools.NCIEVS_search_terminology(
+                terminology="icd10cm", term="diabetes", limit=3
+            )
+        )
+        assert len(rows) <= 3
+
+    def test_meddra_is_blocked_with_explanation(self, tu):
+        result = tu.tools.NCIEVS_search_terminology(
+            terminology="mdr", term="myocardial infarction"
+        )
+        assert result["status"] == "error"
+        assert "licensed" in result["error"].lower()
+
+    def test_unknown_terminology(self, tu):
+        result = tu.tools.NCIEVS_search_terminology(
+            terminology="notarealterm", term="x"
+        )
+        assert result["status"] == "error"
+
+    def test_missing_terminology(self, tu):
+        result = tu.tools.NCIEVS_search_terminology(terminology="", term="x")
+        assert result["status"] == "error"
+
+    def test_missing_term(self, tu):
+        result = tu.tools.NCIEVS_search_terminology(terminology="ctcae5", term="")
+        assert result["status"] == "error"
+
+
+class TestGetConcept:
+    def test_febrile_neutropenia_definition_and_meddra_crossref(self, tu):
+        data = data_of(
+            tu.tools.NCIEVS_get_concept(
+                terminology="ctcae5", code=FEBRILE_NEUTROPENIA
+            )
+        )
+        assert data["name"] == "Febrile neutropenia"
+        assert "ANC" in data["definition"]
+        assert data["properties"]["MedDRA_Code"]
+
+    def test_unknown_code(self, tu):
+        result = tu.tools.NCIEVS_get_concept(terminology="icd10cm", code="NOTREAL")
+        assert result["status"] == "error"
+
+    def test_meddra_get_concept_is_also_blocked(self, tu):
+        result = tu.tools.NCIEVS_get_concept(terminology="mdr", code="10016288")
+        assert result["status"] == "error"
+        assert "licensed" in result["error"].lower()
+
+
+class TestErrorHandling:
+    @pytest.mark.parametrize(
+        "tool_name,kwargs",
+        [
+            ("NCIEVS_search_terminology", {"terminology": "", "term": "x"}),
+            ("NCIEVS_search_terminology", {"terminology": "ctcae5", "term": ""}),
+            ("NCIEVS_search_terminology", {"terminology": "mdr", "term": "x"}),
+            ("NCIEVS_get_concept", {"terminology": "", "code": "x"}),
+            ("NCIEVS_get_concept", {"terminology": "icd10cm", "code": "NOTREAL"}),
+        ],
+    )
+    def test_returns_error_dict_not_exception(self, tu, tool_name, kwargs):
+        result = getattr(tu.tools, tool_name)(**kwargs)
+        assert isinstance(result, dict)
+        assert result["status"] == "error"
+        assert isinstance(result.get("error"), str) and result["error"]

--- a/tests/tools/test_nci_evs_tool.py
+++ b/tests/tools/test_nci_evs_tool.py
@@ -52,19 +52,21 @@ class TestSearchTerminology:
         assert any(r["code"] == FEBRILE_NEUTROPENIA for r in rows)
         assert any("Grade" in (r["name"] or "") for r in rows)
 
-    def test_icd10cm_finds_diabetes_codes(self, tu):
+    def test_radlex_finds_fracture_terms(self, tu):
+        # ICD-10-CM is intentionally not exercised here: ICD10Tool already
+        # covers it via the same NLM Clinical Tables backend.
         rows = data_of(
             tu.tools.NCIEVS_search_terminology(
-                terminology="icd10cm", term="diabetes", limit=10
+                terminology="radlex", term="fracture", limit=10
             )
         )
         assert rows
-        assert all("diabet" in (r["name"] or "").lower() for r in rows)
+        assert all("fracture" in (r["name"] or "").lower() for r in rows)
 
     def test_limit_is_respected(self, tu):
         rows = data_of(
             tu.tools.NCIEVS_search_terminology(
-                terminology="icd10cm", term="diabetes", limit=3
+                terminology="radlex", term="fracture", limit=3
             )
         )
         assert len(rows) <= 3

--- a/tests/tools/test_openfda_device_tool.py
+++ b/tests/tools/test_openfda_device_tool.py
@@ -94,6 +94,60 @@ class TestSearchAdverseEvents:
         assert result["status"] == "error"
 
 
+class TestSearchUdi:
+    def test_finds_pacemaker_udi_records(self, tu):
+        rows = data_of(tu.tools.OpenFDADevice_search_udi(query="pacemaker", limit=5))
+        assert rows
+        assert all(r["brand_name"] and r["company_name"] for r in rows)
+
+    def test_missing_query(self, tu):
+        assert tu.tools.OpenFDADevice_search_udi(query="")["status"] == "error"
+
+
+class TestGetClassification:
+    def test_pacemaker_spans_multiple_device_classes(self, tu):
+        rows = data_of(
+            tu.tools.OpenFDADevice_get_classification(
+                device_name="pacemaker", limit=20
+            )
+        )
+        assert rows
+        classes = {r["device_class"] for r in rows}
+        # Pacemaker-family devices span from Class 1 (test equipment) to
+        # Class 3 (implantable leads); a real, known regulatory fact.
+        assert len(classes) > 1
+
+    def test_missing_device_name(self, tu):
+        result = tu.tools.OpenFDADevice_get_classification(device_name="")
+        assert result["status"] == "error"
+
+
+class TestSearch510k:
+    def test_finds_known_clearance(self, tu):
+        rows = data_of(
+            tu.tools.OpenFDADevice_search_510k(device_name="pacemaker", limit=10)
+        )
+        assert rows
+        assert any(r["k_number"] == "K913805" for r in rows)
+
+    def test_missing_device_name(self, tu):
+        result = tu.tools.OpenFDADevice_search_510k(device_name="")
+        assert result["status"] == "error"
+
+
+class TestSearchPma:
+    def test_finds_known_approval(self, tu):
+        rows = data_of(
+            tu.tools.OpenFDADevice_search_pma(device_name="pacemaker", limit=10)
+        )
+        assert rows
+        assert any(r["pma_number"] == "P030005" for r in rows)
+
+    def test_missing_device_name(self, tu):
+        result = tu.tools.OpenFDADevice_search_pma(device_name="")
+        assert result["status"] == "error"
+
+
 class TestErrorHandling:
     @pytest.mark.parametrize(
         "tool_name,kwargs",
@@ -101,6 +155,10 @@ class TestErrorHandling:
             ("OpenFDADevice_search_recalls", {"query": ""}),
             ("OpenFDADevice_search_recalls", {"query": "zzzznotarealdevice12345"}),
             ("OpenFDADevice_search_adverse_events", {"device_name": ""}),
+            ("OpenFDADevice_search_udi", {"query": ""}),
+            ("OpenFDADevice_get_classification", {"device_name": ""}),
+            ("OpenFDADevice_search_510k", {"device_name": ""}),
+            ("OpenFDADevice_search_pma", {"device_name": ""}),
         ],
     )
     def test_returns_error_dict_not_exception(self, tu, tool_name, kwargs):

--- a/tests/tools/test_openfda_device_tool.py
+++ b/tests/tools/test_openfda_device_tool.py
@@ -1,0 +1,110 @@
+"""Tests for the openFDA device tool.
+
+ToolUniverse's existing openFDA tools cover only drug data (drug/event,
+drug/label, drug/drugsfda); the device side (recalls, MAUDE adverse
+events) had no coverage. A bare full-text search was verified to
+discriminate correctly (nonsense terms return a clean 404, not an
+inflated count) before building, given this codebase's own git history
+documents prior openFDA quoting/exactness bugs. Tests assert real,
+known recall/event content survives the round trip.
+"""
+
+import pytest
+from tooluniverse import ToolUniverse
+
+
+TRANSIENT = ("timed out", "Failed to connect", "HTTP 5")
+
+
+@pytest.fixture(scope="module")
+def tu():
+    instance = ToolUniverse()
+    instance.load_tools()
+    return instance
+
+
+def data_of(result):
+    if result.get("status") == "error":
+        error = str(result.get("error", ""))
+        if any(t in error for t in TRANSIENT):
+            pytest.skip(f"upstream temporarily unavailable: {error[:80]}")
+        pytest.fail(f"unexpected error response: {error[:200]}")
+    return result["data"]
+
+
+class TestRegistration:
+    def test_tools_load(self, tu):
+        names = {t.get("name") for t in tu.all_tools if isinstance(t, dict)}
+        assert "OpenFDADevice_search_recalls" in names
+        assert "OpenFDADevice_search_adverse_events" in names
+
+
+class TestSearchRecalls:
+    def test_finds_known_pacemaker_recalls(self, tu):
+        rows = data_of(
+            tu.tools.OpenFDADevice_search_recalls(query="pacemaker", limit=10)
+        )
+        assert rows
+        assert all(r["product_description"] for r in rows)
+        assert any(r["recall_status"] for r in rows)
+
+    def test_search_actually_discriminates(self, tu):
+        # Regression guard against the openFDA quoting/exactness bugs this
+        # codebase's git history documents elsewhere (Fix Round 20).
+        result = tu.tools.OpenFDADevice_search_recalls(query="pacemaker", limit=1)
+        assert 0 < result["metadata"]["total_matching"] < 100_000
+
+    def test_limit_is_respected(self, tu):
+        rows = data_of(
+            tu.tools.OpenFDADevice_search_recalls(query="pacemaker", limit=3)
+        )
+        assert len(rows) <= 3
+
+    def test_unmatched_query(self, tu):
+        result = tu.tools.OpenFDADevice_search_recalls(
+            query="zzzznotarealdevice12345"
+        )
+        assert result["status"] == "error"
+
+    def test_missing_query(self, tu):
+        assert tu.tools.OpenFDADevice_search_recalls(query="")["status"] == "error"
+
+
+class TestSearchAdverseEvents:
+    def test_finds_pacemaker_lead_events(self, tu):
+        rows = data_of(
+            tu.tools.OpenFDADevice_search_adverse_events(
+                device_name="pacemaker", limit=10
+            )
+        )
+        assert rows
+        assert all(r["generic_name"] for r in rows)
+        assert all(r["event_type"] for r in rows)
+
+    def test_limit_is_respected(self, tu):
+        rows = data_of(
+            tu.tools.OpenFDADevice_search_adverse_events(
+                device_name="pacemaker", limit=3
+            )
+        )
+        assert len(rows) <= 3
+
+    def test_missing_device_name(self, tu):
+        result = tu.tools.OpenFDADevice_search_adverse_events(device_name="")
+        assert result["status"] == "error"
+
+
+class TestErrorHandling:
+    @pytest.mark.parametrize(
+        "tool_name,kwargs",
+        [
+            ("OpenFDADevice_search_recalls", {"query": ""}),
+            ("OpenFDADevice_search_recalls", {"query": "zzzznotarealdevice12345"}),
+            ("OpenFDADevice_search_adverse_events", {"device_name": ""}),
+        ],
+    )
+    def test_returns_error_dict_not_exception(self, tu, tool_name, kwargs):
+        result = getattr(tu.tools, tool_name)(**kwargs)
+        assert isinstance(result, dict)
+        assert result["status"] == "error"
+        assert isinstance(result.get("error"), str) and result["error"]

--- a/tests/tools/test_smartapi_tool.py
+++ b/tests/tools/test_smartapi_tool.py
@@ -1,0 +1,92 @@
+"""Tests for the SmartAPI registry tool.
+
+ToolUniverse already wraps a large fraction of what SmartAPI's ~270
+registered biomedical APIs describe, but had no way to discover what else
+is registered or resolve an API name to its base URL and endpoints.
+Tests assert a well-known entry (MyVariant.info) round-trips correctly.
+"""
+
+import pytest
+from tooluniverse import ToolUniverse
+
+
+TRANSIENT = ("timed out", "Failed to connect", "HTTP 5")
+
+MYVARIANT_SLUG = "myvariant"
+
+
+@pytest.fixture(scope="module")
+def tu():
+    instance = ToolUniverse()
+    instance.load_tools()
+    return instance
+
+
+def data_of(result):
+    if result.get("status") == "error":
+        error = str(result.get("error", ""))
+        if any(t in error for t in TRANSIENT):
+            pytest.skip(f"upstream temporarily unavailable: {error[:80]}")
+        pytest.fail(f"unexpected error response: {error[:200]}")
+    return result["data"]
+
+
+class TestRegistration:
+    def test_tools_load(self, tu):
+        names = {t.get("name") for t in tu.all_tools if isinstance(t, dict)}
+        assert "SmartAPI_search_apis" in names
+        assert "SmartAPI_get_api" in names
+
+
+class TestSearchApis:
+    def test_finds_myvariant(self, tu):
+        rows = data_of(tu.tools.SmartAPI_search_apis(query="variant", limit=20))
+        assert any(r["slug"] == MYVARIANT_SLUG for r in rows)
+
+    def test_tag_scoped_query(self, tu):
+        rows = data_of(
+            tu.tools.SmartAPI_search_apis(query="tags.name:translator", limit=5)
+        )
+        assert rows
+
+    def test_limit_is_respected(self, tu):
+        rows = data_of(tu.tools.SmartAPI_search_apis(query="variant", limit=2))
+        assert len(rows) <= 2
+
+    def test_unmatched_query(self, tu):
+        result = tu.tools.SmartAPI_search_apis(query="zzzznotarealAPIterm12345")
+        assert result["status"] == "error"
+
+    def test_missing_query(self, tu):
+        assert tu.tools.SmartAPI_search_apis(query="")["status"] == "error"
+
+
+class TestGetApi:
+    def test_myvariant_metadata(self, tu):
+        data = data_of(tu.tools.SmartAPI_get_api(api_id=MYVARIANT_SLUG))
+        assert data["title"] == "MyVariant.info API"
+        assert data["base_urls"] == ["https://myvariant.info/v1"]
+        assert "/query" in data["endpoints"]
+
+    def test_unknown_api_id(self, tu):
+        result = tu.tools.SmartAPI_get_api(api_id="notarealslug12345")
+        assert result["status"] == "error"
+
+    def test_missing_api_id(self, tu):
+        assert tu.tools.SmartAPI_get_api(api_id="")["status"] == "error"
+
+
+class TestErrorHandling:
+    @pytest.mark.parametrize(
+        "tool_name,kwargs",
+        [
+            ("SmartAPI_search_apis", {"query": ""}),
+            ("SmartAPI_get_api", {"api_id": ""}),
+            ("SmartAPI_get_api", {"api_id": "notarealslug12345"}),
+        ],
+    )
+    def test_returns_error_dict_not_exception(self, tu, tool_name, kwargs):
+        result = getattr(tu.tools, tool_name)(**kwargs)
+        assert isinstance(result, dict)
+        assert result["status"] == "error"
+        assert isinstance(result.get("error"), str) and result["error"]


### PR DESCRIPTION
## Summary

Third batch from the ongoing coverage-gap sweep (follows #532, merged, and #537, pending). Two commits fix or extend the immediately-preceding one in this same PR after catching my own near-duplicates during development — left in as separate commits rather than squashed, since the fixes are informative on their own.

**SmartAPI registry** — resolves an API name/tag to its base URL and endpoint list across ~270 registered biomedical APIs (many NCATS Translator components). Confirmed bio.tools and re3data were already covered before building.

**NCI EVS terminologies** — CTCAE (adverse event grading, the clinical-trial safety standard), RadLex, NDF-RT, MedRT, CanMED, ICD-9-CM, via the same public API that backs the existing NCIt-only tool. Built as a sibling rather than modifying that tool, since its contract is deliberately NCIt-only. A follow-up commit in this PR corrects an ICD-10-CM example that duplicated the existing `ICD10Tool`, caught only after the fact.

**ClinicalTablesTool extended** — HCPCS billing codes, pharmacogenomic star alleles (complements the existing CPIC dosing tools), and NPI provider/organization search (resolves the NPI numbers `CMSOpenPaymentsTool` already returns into an actual name and address). This nearly became a colliding duplicate class under the same name — caught only because the file-write tool refused to overwrite a file it hadn't been shown yet, which turned out to already contain a fully-built `ClinicalTablesTool`.

**openFDA device** — recalls, MAUDE adverse events, UDI (the device-world NDC equivalent), regulatory classification, and both premarket pathways (510(k), PMA). ToolUniverse's existing openFDA tools cover only drugs; the device side had no coverage at all despite being a distinct record schema.

**FHIR Terminology Service** — researched the FHIR/OMOP clinical-data axis directly rather than guessing at a design: OHDSI Athena requires authentication (403), LOINC's own FHIR server needs an account (401), SNOMED International's browser was unreachable. HL7's own `tx.fhir.org`, however, is genuinely public. Its real value here is narrow but real: LOINC/RxNorm/ICD-10-CM already have dedicated tools, but SNOMED CT did not have proper code-based lookup or hierarchy traversal anywhere in ToolUniverse before this (only fuzzy OLS keyword search). `$expand` over SNOMED's subsumption value sets now returns every descendant of a concept. `ConceptMap/$translate` was tried against several vocabulary pairs and returned "No suitable ConceptMaps found" for all of them, so it isn't exposed.

## Real findings from live verification

- NCI EVS: MedDRA is listed in the API's own terminology metadata but returns HTTP 403 on every query (separately licensed); CTCAE concepts carry a `MedDRA_Code` property as a free cross-reference instead.
- openFDA device: verified search discrimination carefully before building, since this exact codebase's git history documents prior openFDA quoting/exactness bugs (Fix Round 20) — confirmed a bare `field:term` query returns a clean 404 for nonsense terms and checked large-but-real counts for popular devices against the ~25.7M-record total so they weren't mistaken for a quoting bug.
- Ruled out (not built): FDA Purple Book, AACT (DB dump only, no REST API), device/UDI field-name guesses verified against real records, and several NLM Clinical Tables field names (star_alleles' second column, confirmed empty across every sample checked, labeled `unused` rather than guessed at).

## Test plan

- [x] `scripts/test_new_tools.py` for all 5 touched config keys — 100% pass, 0 schema-invalid
- [x] Direct `ToolUniverse().load_tools()` registration check for every new/extended tool name
- [x] Live smoke tests against real external APIs, plus explicit error-path tests
- [x] Full pytest suite: 79 tests across 5 files, all green, including regression checks on the pre-existing tools whose classes were extended (`ClinicalTablesTool`'s original 3 operations, `NCIThesaurusTool`)
- [x] No duplicate tool names; final catalog count 2,681