### PR TITLE
Seven new tools: BOLD, GIAB, FDA Purple Book, MolGlueDB, GSA, BAR, Planteome

### DIFF
--- a/src/tooluniverse/_lazy_registry_static.py
+++ b/src/tooluniverse/_lazy_registry_static.py
@@ -287,6 +287,7 @@ STATIC_LAZY_REGISTRY = {
     "GIABTool": "giab_tool",
     "FDAPurpleBookTool": "fda_purple_book_tool",
     "MolGlueDBTool": "molgluedb_tool",
+    "GSATool": "gsa_tool",
     "PathoplexusCountTool": "pathoplexus_tool",
     "PathoplexusMutationsTool": "pathoplexus_tool",
     "OpenGenesGeneTool": "open_genes_tool",

--- a/src/tooluniverse/_lazy_registry_static.py
+++ b/src/tooluniverse/_lazy_registry_static.py
@@ -283,6 +283,7 @@ STATIC_LAZY_REGISTRY = {
     "AllenCellTypesSpecimensTool": "allen_cell_types_tool",
     "iDigBioSearchTool": "idigbio_tool",
     "iDigBioRecordTool": "idigbio_tool",
+    "BOLDSystemsTool": "bold_systems_tool",
     "PathoplexusCountTool": "pathoplexus_tool",
     "PathoplexusMutationsTool": "pathoplexus_tool",
     "OpenGenesGeneTool": "open_genes_tool",

--- a/src/tooluniverse/_lazy_registry_static.py
+++ b/src/tooluniverse/_lazy_registry_static.py
@@ -288,6 +288,7 @@ STATIC_LAZY_REGISTRY = {
     "FDAPurpleBookTool": "fda_purple_book_tool",
     "MolGlueDBTool": "molgluedb_tool",
     "GSATool": "gsa_tool",
+    "BARTool": "bar_tool",
     "PathoplexusCountTool": "pathoplexus_tool",
     "PathoplexusMutationsTool": "pathoplexus_tool",
     "OpenGenesGeneTool": "open_genes_tool",

--- a/src/tooluniverse/_lazy_registry_static.py
+++ b/src/tooluniverse/_lazy_registry_static.py
@@ -289,6 +289,7 @@ STATIC_LAZY_REGISTRY = {
     "MolGlueDBTool": "molgluedb_tool",
     "GSATool": "gsa_tool",
     "BARTool": "bar_tool",
+    "PlanteomeTool": "planteome_tool",
     "PathoplexusCountTool": "pathoplexus_tool",
     "PathoplexusMutationsTool": "pathoplexus_tool",
     "OpenGenesGeneTool": "open_genes_tool",

--- a/src/tooluniverse/_lazy_registry_static.py
+++ b/src/tooluniverse/_lazy_registry_static.py
@@ -285,6 +285,7 @@ STATIC_LAZY_REGISTRY = {
     "iDigBioRecordTool": "idigbio_tool",
     "BOLDSystemsTool": "bold_systems_tool",
     "GIABTool": "giab_tool",
+    "FDAPurpleBookTool": "fda_purple_book_tool",
     "PathoplexusCountTool": "pathoplexus_tool",
     "PathoplexusMutationsTool": "pathoplexus_tool",
     "OpenGenesGeneTool": "open_genes_tool",

--- a/src/tooluniverse/_lazy_registry_static.py
+++ b/src/tooluniverse/_lazy_registry_static.py
@@ -284,6 +284,7 @@ STATIC_LAZY_REGISTRY = {
     "iDigBioSearchTool": "idigbio_tool",
     "iDigBioRecordTool": "idigbio_tool",
     "BOLDSystemsTool": "bold_systems_tool",
+    "GIABTool": "giab_tool",
     "PathoplexusCountTool": "pathoplexus_tool",
     "PathoplexusMutationsTool": "pathoplexus_tool",
     "OpenGenesGeneTool": "open_genes_tool",

--- a/src/tooluniverse/_lazy_registry_static.py
+++ b/src/tooluniverse/_lazy_registry_static.py
@@ -286,6 +286,7 @@ STATIC_LAZY_REGISTRY = {
     "BOLDSystemsTool": "bold_systems_tool",
     "GIABTool": "giab_tool",
     "FDAPurpleBookTool": "fda_purple_book_tool",
+    "MolGlueDBTool": "molgluedb_tool",
     "PathoplexusCountTool": "pathoplexus_tool",
     "PathoplexusMutationsTool": "pathoplexus_tool",
     "OpenGenesGeneTool": "open_genes_tool",

--- a/src/tooluniverse/bar_tool.py
+++ b/src/tooluniverse/bar_tool.py
@@ -1,0 +1,145 @@
+# bar_tool.py
+"""
+BAR (Bio-Analytic Resource for Plant Biology) tools for ToolUniverse.
+
+The BAR (bar.utoronto.ca), a Global Core Biodata Resource, is the
+standard resource for Arabidopsis and other plant species' gene
+annotation and expression data -- something ToolUniverse's existing
+plant tool (plant_reactome_tool.py, pathway-level only) has no
+equivalent for. It publishes a documented, unauthenticated OpenAPI
+spec at /api/swagger.json; this wraps two of its endpoints: per-gene
+annotation/position/aliases, and RNA-seq expression (including
+single-cell cluster-level expression means).
+
+API: https://bar.utoronto.ca/api
+No authentication required.
+"""
+
+from typing import Any, Dict
+
+import requests
+
+from .base_tool import BaseTool
+from .tool_registry import register_tool
+
+BAR_API_URL = "https://bar.utoronto.ca/api"
+
+
+def _bar_get(url: str, timeout: int):
+    """GET a BAR endpoint, returning (payload, error_envelope).
+
+    Exactly one of the two is non-None; the error envelope is the standard
+    {"status": "error", ...} dict so callers never raise.
+    """
+    try:
+        resp = requests.get(url, timeout=timeout)
+    except requests.exceptions.Timeout:
+        return None, {"status": "error", "error": f"BAR request timed out after {timeout}s"}
+    except requests.exceptions.RequestException as e:
+        return None, {"status": "error", "error": f"BAR request failed: {e}"}
+
+    if resp.status_code == 400:
+        try:
+            detail = resp.json().get("error")
+        except ValueError:
+            detail = None
+        return None, {"status": "error", "error": detail or "BAR rejected the request."}
+    resp.raise_for_status()
+    try:
+        payload = resp.json()
+    except ValueError:
+        return None, {"status": "error", "error": "BAR returned a non-JSON response."}
+    if not payload.get("wasSuccessful", True):
+        return None, {
+            "status": "error",
+            "error": payload.get("error") or "BAR reported an unsuccessful request.",
+        }
+    return payload, None
+
+
+@register_tool("BARTool")
+class BARTool(BaseTool):
+    """
+    Tool for querying the BAR (Bio-Analytic Resource for Plant Biology),
+    dispatched by fields.operation:
+      - "get_gene_info"        : gene position, strand, aliases, annotation
+      - "get_rnaseq_expression" : RNA-seq expression (bulk or single-cell
+                                  cluster means) for a gene
+
+    No authentication required.
+    """
+
+    def __init__(self, tool_config: Dict[str, Any]):
+        super().__init__(tool_config)
+        self.timeout = tool_config.get("timeout", 30)
+        self.operation = tool_config.get("fields", {}).get(
+            "operation", "get_gene_info"
+        )
+
+    def run(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        if self.operation == "get_gene_info":
+            return self._get_gene_info(arguments)
+        if self.operation == "get_rnaseq_expression":
+            return self._get_rnaseq_expression(arguments)
+        return {"status": "error", "error": f"Unknown operation: {self.operation}"}
+
+    def _get_gene_info(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        species = (arguments.get("species") or "arabidopsis").strip()
+        gene_id = (arguments.get("gene_id") or "").strip()
+        if not gene_id:
+            return {
+                "status": "error",
+                "error": "gene_id is required, e.g. 'AT1G01010'.",
+            }
+
+        payload, err = _bar_get(
+            f"{BAR_API_URL}/gene_information/single_gene_query/{species}/{gene_id}",
+            self.timeout,
+        )
+        if err is not None:
+            return err
+
+        record = (payload.get("data") or {}).get(gene_id.upper()) or next(
+            iter((payload.get("data") or {}).values()), None
+        )
+        if not record:
+            return {
+                "status": "error",
+                "error": f"No BAR gene record found for '{gene_id}' in '{species}'.",
+            }
+
+        return {
+            "status": "success",
+            "data": record,
+            "metadata": {"species": species, "gene_id": gene_id, "source": "BAR (bar.utoronto.ca)"},
+        }
+
+    def _get_rnaseq_expression(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        species = (arguments.get("species") or "arabidopsis").strip()
+        database = (arguments.get("database") or "single_cell").strip()
+        gene_id = (arguments.get("gene_id") or "").strip()
+        if not gene_id:
+            return {
+                "status": "error",
+                "error": "gene_id is required, e.g. 'At1g01010'.",
+            }
+
+        payload, err = _bar_get(
+            f"{BAR_API_URL}/rnaseq_gene_expression/{species}/{database}/{gene_id}",
+            self.timeout,
+        )
+        if err is not None:
+            return err
+
+        expression = payload.get("data") or {}
+        return {
+            "status": "success",
+            "data": expression,
+            "metadata": {
+                "species": species,
+                "database": database,
+                "gene_id": gene_id,
+                "sample_count": len(expression),
+                "source": "BAR (bar.utoronto.ca)",
+            },
+        }

--- a/src/tooluniverse/bold_systems_tool.py
+++ b/src/tooluniverse/bold_systems_tool.py
@@ -1,0 +1,290 @@
+# bold_systems_tool.py
+"""
+BOLD Systems tools for ToolUniverse -- DNA barcode records and BINs.
+
+BOLD (Barcode of Life Data System, portal.boldsystems.org) is the primary
+global repository of DNA barcode sequences (mostly COI-5P) for species
+identification, run by the Centre for Biodiversity Genomics. Its signature
+concept is the BIN (Barcode Index Number): an algorithmically-clustered,
+sequence-similarity-based operational taxonomic unit that often resolves
+species-level identity where morphology or existing taxonomy cannot -- a
+capability nothing else in ToolUniverse provides. ToolUniverse's existing
+iDigBioSearchTool covers Darwin Core specimen/occurrence records but has no
+genetic barcode data or BIN clustering.
+
+The public query API (https://portal.boldsystems.org/api) is a two-step
+flow: GET /api/query builds a query from semicolon-delimited "triplet"
+tokens ([scope]:[subscope]:[value]) and returns a query_id; GET
+/api/documents/{query_id} then pages through the actual records. Confirmed
+working triplet scopes/subscopes (live-tested): tax:genus, tax:family,
+tax:order, geo:country, ids:processid, bin:uri. tax:species was tested
+extensively (several subscope-name guesses, e.g. "species", "epithet",
+"binomial") and is silently ignored by the server rather than filtering --
+so species-level search here is done by querying at the genus level and
+filtering client-side on the returned "species" field, the same workaround
+pattern used elsewhere in ToolUniverse for APIs with non-functional
+server-side filters.
+
+No authentication required.
+"""
+
+from typing import Any, Dict, List, Optional
+
+import requests
+
+from .base_tool import BaseTool
+from .tool_registry import register_tool
+
+BOLD_BASE_URL = "https://portal.boldsystems.org/api"
+
+_RANK_SCOPES = {
+    "genus": "tax:genus",
+    "family": "tax:family",
+    "order": "tax:order",
+    "species": "tax:genus",  # BOLD ignores tax:species; filter client-side.
+}
+
+_RECORD_FIELDS = (
+    "processid",
+    "sampleid",
+    "bin_uri",
+    "kingdom",
+    "phylum",
+    "class",
+    "order",
+    "family",
+    "subfamily",
+    "genus",
+    "species",
+    "identification",
+    "identification_rank",
+    "country/ocean",
+    "province/state",
+    "collectors",
+    "collection_date_start",
+    "collection_date_end",
+    "inst",
+    "marker_code",
+    "nuc_basecount",
+    "insdc_acs",
+)
+
+
+def _summarize(rec: Dict[str, Any]) -> Dict[str, Any]:
+    return {field: rec.get(field) for field in _RECORD_FIELDS}
+
+
+def _bold_get(url: str, params: Dict[str, Any], timeout: int):
+    """GET a BOLD endpoint, returning (payload, error_envelope).
+
+    Exactly one of the two is non-None; the error envelope is the standard
+    {"status": "error", ...} dict so callers never raise.
+    """
+    try:
+        resp = requests.get(url, params=params, timeout=timeout)
+        if resp.status_code >= 500:
+            return None, {
+                "status": "error",
+                "error": f"BOLD Systems rejected the query (HTTP {resp.status_code}): "
+                f"{resp.text[:200]}",
+            }
+        resp.raise_for_status()
+        return resp.json(), None
+    except requests.exceptions.Timeout:
+        return None, {
+            "status": "error",
+            "error": f"BOLD Systems request timed out after {timeout}s",
+        }
+    except requests.exceptions.RequestException as e:
+        return None, {"status": "error", "error": f"BOLD Systems request failed: {e}"}
+    except ValueError:
+        return None, {
+            "status": "error",
+            "error": "BOLD Systems returned a non-JSON response",
+        }
+
+
+def _run_query(
+    query: str, length: int, timeout: int
+) -> "tuple[Optional[Dict[str, Any]], Optional[Dict[str, Any]]]":
+    """Run the query -> query_id -> documents two-step flow."""
+    query_payload, err = _bold_get(
+        f"{BOLD_BASE_URL}/query",
+        {"query": query, "extent": "limited"},
+        timeout,
+    )
+    if err is not None:
+        return None, err
+    query_id = (query_payload or {}).get("query_id")
+    if not query_id:
+        return None, {
+            "status": "error",
+            "error": f"BOLD Systems returned no query_id for query '{query}'.",
+        }
+    doc_payload, err = _bold_get(
+        f"{BOLD_BASE_URL}/documents/{query_id}",
+        {"start": 0, "length": length},
+        timeout,
+    )
+    if err is not None:
+        return None, err
+    return doc_payload, None
+
+
+@register_tool("BOLDSystemsTool")
+class BOLDSystemsTool(BaseTool):
+    """
+    Tool for querying BOLD Systems (Barcode of Life Data System) DNA barcode
+    records, dispatched by fields.operation:
+      - "search_by_taxon" : records for a genus/family/order/species, optionally
+                            narrowed by country
+      - "search_by_bin"   : records sharing a BIN (Barcode Index Number) cluster
+      - "get_record"      : a single record by its BOLD process ID
+
+    No authentication required.
+    """
+
+    def __init__(self, tool_config: Dict[str, Any]):
+        super().__init__(tool_config)
+        self.timeout = tool_config.get("timeout", 30)
+        self.operation = tool_config.get("fields", {}).get(
+            "operation", "search_by_taxon"
+        )
+
+    def run(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        try:
+            if self.operation == "search_by_taxon":
+                return self._search_by_taxon(arguments)
+            if self.operation == "search_by_bin":
+                return self._search_by_bin(arguments)
+            if self.operation == "get_record":
+                return self._get_record(arguments)
+            return {
+                "status": "error",
+                "error": f"Unknown operation: {self.operation}",
+            }
+        except Exception as e:
+            return {
+                "status": "error",
+                "error": f"Error querying BOLD Systems: {str(e)}",
+            }
+
+    def _limit(self, arguments: Dict[str, Any], default: int = 30) -> int:
+        try:
+            return max(1, min(int(arguments.get("limit") or default), 200))
+        except (TypeError, ValueError):
+            return default
+
+    def _search_by_taxon(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        taxon_name = (arguments.get("taxon_name") or "").strip()
+        if not taxon_name:
+            return {
+                "status": "error",
+                "error": "taxon_name is required, e.g. 'Panthera' (genus) or "
+                "'Panthera leo' (species).",
+            }
+
+        rank = (arguments.get("rank") or "genus").strip().lower()
+        if rank not in _RANK_SCOPES:
+            return {
+                "status": "error",
+                "error": f"rank must be one of {sorted(_RANK_SCOPES)}, got '{rank}'.",
+            }
+
+        # BOLD's tax:species triplet is silently ignored server-side, so
+        # species search runs at genus level and filters client-side below.
+        query_taxon = taxon_name.split()[0] if rank == "species" else taxon_name
+        triplets = [f"{_RANK_SCOPES[rank]}:{query_taxon}"]
+
+        country = (arguments.get("country") or "").strip()
+        if country:
+            triplets.append(f"geo:country:{country}")
+
+        limit = self._limit(arguments)
+        # Fetch extra raw rows when species-filtering client-side, since most
+        # of a genus's records won't match one target species.
+        fetch_length = min(limit * 10, 1000) if rank == "species" else limit
+
+        payload, err = _run_query(";".join(triplets), fetch_length, self.timeout)
+        if err is not None:
+            return err
+
+        rows = payload.get("data") or []
+        if rank == "species":
+            target = taxon_name.strip().lower()
+            rows = [r for r in rows if (r.get("species") or "").strip().lower() == target]
+        rows = rows[:limit]
+
+        return {
+            "status": "success",
+            "data": [_summarize(r) for r in rows],
+            "metadata": {
+                "query": ";".join(triplets),
+                "rank": rank,
+                "returned": len(rows),
+                "records_total": payload.get("recordsTotal"),
+                "note": (
+                    "records_total is the genus-level count before "
+                    "client-side species filtering; BOLD does not support "
+                    "server-side species-level filtering."
+                    if rank == "species"
+                    else None
+                ),
+                "source": "BOLD Systems (portal.boldsystems.org)",
+            },
+        }
+
+    def _search_by_bin(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        bin_id = (arguments.get("bin_id") or "").strip()
+        if not bin_id:
+            return {
+                "status": "error",
+                "error": "bin_id is required, e.g. 'BOLD:AAD6819'.",
+            }
+        if not bin_id.upper().startswith("BOLD:"):
+            bin_id = f"BOLD:{bin_id}"
+
+        limit = self._limit(arguments)
+        payload, err = _run_query(f"bin:uri:{bin_id}", limit, self.timeout)
+        if err is not None:
+            return err
+
+        rows = (payload.get("data") or [])[:limit]
+        return {
+            "status": "success",
+            "data": [_summarize(r) for r in rows],
+            "metadata": {
+                "bin_id": bin_id,
+                "returned": len(rows),
+                "records_total": payload.get("recordsTotal"),
+                "source": "BOLD Systems (portal.boldsystems.org)",
+            },
+        }
+
+    def _get_record(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        process_id = (arguments.get("process_id") or "").strip()
+        if not process_id:
+            return {
+                "status": "error",
+                "error": "process_id is required, e.g. 'ABRMM002-06'.",
+            }
+
+        payload, err = _run_query(f"ids:processid:{process_id}", 1, self.timeout)
+        if err is not None:
+            return err
+
+        rows = payload.get("data") or []
+        if not rows:
+            return {
+                "status": "error",
+                "error": f"No BOLD record found for process ID '{process_id}'.",
+            }
+
+        return {
+            "status": "success",
+            "data": _summarize(rows[0]),
+            "metadata": {
+                "process_id": process_id,
+                "source": "BOLD Systems (portal.boldsystems.org)",
+            },
+        }

--- a/src/tooluniverse/data/bar_tools.json
+++ b/src/tooluniverse/data/bar_tools.json
@@ -1,0 +1,92 @@
+[
+  {
+    "name": "BAR_get_gene_info",
+    "type": "BARTool",
+    "description": "Get plant gene annotation from the BAR (Bio-Analytic Resource for Plant Biology, a Global Core Biodata Resource): genomic position, strand, aliases, and functional annotation. Example: gene_id='AT1G01010' (species='arabidopsis', the default) returns NAC domain protein 1's Chr1 coordinates and aliases ANAC001/NAC001/NTL10. Distinct from ToolUniverse's plant_reactome tools, which cover pathways, not per-gene annotation.",
+    "fields": {
+      "operation": "get_gene_info"
+    },
+    "parameter": {
+      "type": "object",
+      "required": ["gene_id"],
+      "properties": {
+        "gene_id": {
+          "type": "string",
+          "description": "Gene locus identifier, e.g. 'AT1G01010' (Arabidopsis)."
+        },
+        "species": {
+          "type": ["string", "null"],
+          "description": "Species, e.g. 'arabidopsis' (default)."
+        }
+      }
+    },
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "id": {"type": ["string", "null"]},
+            "chromosome": {"type": ["string", "null"]},
+            "start": {"type": ["integer", "null"]},
+            "end": {"type": ["integer", "null"]},
+            "strand": {"type": ["string", "null"]},
+            "aliases": {"type": "array", "items": {"type": "string"}},
+            "annotation": {"type": ["string", "null"]}
+          }
+        },
+        {
+          "type": "object",
+          "properties": {"error": {"type": "string"}},
+          "required": ["error"]
+        }
+      ]
+    },
+    "test_examples": [
+      {"gene_id": "AT1G01010"},
+      {"gene_id": "AT3G62980"}
+    ]
+  },
+  {
+    "name": "BAR_get_rnaseq_expression",
+    "type": "BARTool",
+    "description": "Get RNA-seq gene expression data from the BAR (Bio-Analytic Resource for Plant Biology). database='single_cell' (the default) returns per-cluster mean expression across replicates from single-cell atlases -- a data type no other ToolUniverse plant tool exposes. Example: gene_id='At1g01010' returns its mean expression value in each of dozens of single-cell clusters.",
+    "fields": {
+      "operation": "get_rnaseq_expression"
+    },
+    "parameter": {
+      "type": "object",
+      "required": ["gene_id"],
+      "properties": {
+        "gene_id": {
+          "type": "string",
+          "description": "Gene locus identifier, e.g. 'At1g01010' (Arabidopsis)."
+        },
+        "species": {
+          "type": ["string", "null"],
+          "description": "Species, e.g. 'arabidopsis' (default)."
+        },
+        "database": {
+          "type": ["string", "null"],
+          "description": "RNA-seq dataset, e.g. 'single_cell' (default)."
+        }
+      }
+    },
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": {"type": "number"}
+        },
+        {
+          "type": "object",
+          "properties": {"error": {"type": "string"}},
+          "required": ["error"]
+        }
+      ]
+    },
+    "test_examples": [
+      {"gene_id": "At1g01010"},
+      {"gene_id": "At3g62980"}
+    ]
+  }
+]

--- a/src/tooluniverse/data/bold_systems_tools.json
+++ b/src/tooluniverse/data/bold_systems_tools.json
@@ -1,0 +1,147 @@
+[
+  {
+    "name": "BOLDSystems_search_by_taxon",
+    "type": "BOLDSystemsTool",
+    "description": "Search BOLD (Barcode of Life Data System) DNA barcode records by taxon. rank='genus'/'family'/'order' filters server-side; rank='species' (e.g. 'Panthera leo') queries at genus level and filters client-side, since BOLD does not support server-side species filtering. Optionally narrow by country. Example: taxon_name='Panthera', rank='genus' returns all big-cat barcode records with BIN cluster IDs, COI-5P accession numbers, and collection metadata.",
+    "fields": {
+      "operation": "search_by_taxon"
+    },
+    "parameter": {
+      "type": "object",
+      "required": ["taxon_name"],
+      "properties": {
+        "taxon_name": {
+          "type": "string",
+          "description": "Taxon name matching rank, e.g. 'Panthera' (genus), 'Felidae' (family), 'Carnivora' (order), or 'Panthera leo' (species)."
+        },
+        "rank": {
+          "type": ["string", "null"],
+          "enum": ["genus", "family", "order", "species", null],
+          "description": "Taxonomic rank of taxon_name. Default 'genus'."
+        },
+        "country": {
+          "type": ["string", "null"],
+          "description": "Optional country/ocean name to narrow results, e.g. 'Canada'."
+        },
+        "limit": {
+          "type": ["integer", "null"],
+          "description": "Max records to return, 1-200. Default 30."
+        }
+      }
+    },
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "processid": {"type": ["string", "null"]},
+              "bin_uri": {"type": ["string", "null"]},
+              "genus": {"type": ["string", "null"]},
+              "species": {"type": ["string", "null"]},
+              "identification": {"type": ["string", "null"]},
+              "insdc_acs": {"type": ["string", "null"]}
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {"error": {"type": "string"}},
+          "required": ["error"]
+        }
+      ]
+    },
+    "test_examples": [
+      {"taxon_name": "Panthera", "rank": "genus", "limit": 5},
+      {"taxon_name": "Panthera leo", "rank": "species", "limit": 5}
+    ]
+  },
+  {
+    "name": "BOLDSystems_search_by_bin",
+    "type": "BOLDSystemsTool",
+    "description": "Search BOLD (Barcode of Life Data System) for all DNA barcode records sharing a BIN (Barcode Index Number) -- BOLD's algorithmic, sequence-similarity-based species-cluster identifier, which often resolves identity where taxonomy alone cannot. Example: bin_id='BOLD:AAD6819' returns 51 specimen records of Panthera leo sharing that barcode cluster. This is a capability unique to BOLD; ToolUniverse's iDigBio tools have no genetic barcode or BIN data.",
+    "fields": {
+      "operation": "search_by_bin"
+    },
+    "parameter": {
+      "type": "object",
+      "required": ["bin_id"],
+      "properties": {
+        "bin_id": {
+          "type": "string",
+          "description": "BOLD BIN identifier, e.g. 'BOLD:AAD6819' (the 'BOLD:' prefix is added automatically if omitted)."
+        },
+        "limit": {
+          "type": ["integer", "null"],
+          "description": "Max records to return, 1-200. Default 30."
+        }
+      }
+    },
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "processid": {"type": ["string", "null"]},
+              "bin_uri": {"type": ["string", "null"]},
+              "species": {"type": ["string", "null"]},
+              "identification": {"type": ["string", "null"]}
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {"error": {"type": "string"}},
+          "required": ["error"]
+        }
+      ]
+    },
+    "test_examples": [
+      {"bin_id": "BOLD:AAD6819", "limit": 10},
+      {"bin_id": "AAD6819", "limit": 5}
+    ]
+  },
+  {
+    "name": "BOLDSystems_get_record",
+    "type": "BOLDSystemsTool",
+    "description": "Retrieve a single BOLD (Barcode of Life Data System) DNA barcode record by its BOLD process ID. Returns full taxonomy, BIN cluster, collection metadata, and COI-5P INSDC accession. Example: process_id='ABRMM002-06' returns a Panthera leo record collected at the Metro Toronto Zoo.",
+    "fields": {
+      "operation": "get_record"
+    },
+    "parameter": {
+      "type": "object",
+      "required": ["process_id"],
+      "properties": {
+        "process_id": {
+          "type": "string",
+          "description": "BOLD process ID, e.g. 'ABRMM002-06'."
+        }
+      }
+    },
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "processid": {"type": ["string", "null"]},
+            "bin_uri": {"type": ["string", "null"]},
+            "species": {"type": ["string", "null"]},
+            "insdc_acs": {"type": ["string", "null"]}
+          }
+        },
+        {
+          "type": "object",
+          "properties": {"error": {"type": "string"}},
+          "required": ["error"]
+        }
+      ]
+    },
+    "test_examples": [
+      {"process_id": "ABRMM002-06"},
+      {"process_id": "ABRMM043-06"}
+    ]
+  }
+]

--- a/src/tooluniverse/data/fda_purple_book_tools.json
+++ b/src/tooluniverse/data/fda_purple_book_tools.json
@@ -1,0 +1,74 @@
+[
+  {
+    "name": "FDAPurpleBook_search_products",
+    "type": "FDAPurpleBookTool",
+    "description": "Search FDA's Purple Book of licensed biological products: reference biologics, their licensed biosimilars/interchangeables, and exclusivity dates. Provide at least one filter (matched as a case-insensitive substring). Example: proper_name='adalimumab' returns Humira and every licensed adalimumab biosimilar/interchangeable with applicant, license type, and exclusivity expiration data. Always fetches FDA's latest published monthly snapshot, so results reflect the current database, not a fixed release.",
+    "parameter": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "proprietary_name": {
+          "type": ["string", "null"],
+          "description": "Brand name, e.g. 'Humira'."
+        },
+        "proper_name": {
+          "type": ["string", "null"],
+          "description": "Non-proprietary/generic name (INN), e.g. 'adalimumab'."
+        },
+        "applicant": {
+          "type": ["string", "null"],
+          "description": "License holder, e.g. 'AbbVie'."
+        },
+        "bla_number": {
+          "type": ["string", "null"],
+          "description": "Biologics License Application number, e.g. '125057'."
+        },
+        "license_type": {
+          "type": ["string", "null"],
+          "description": "'351(a)' (reference biologic), '351(k) Biosimilar', or '351(k) Interchangeable'."
+        },
+        "reference_product_proper_name": {
+          "type": ["string", "null"],
+          "description": "For biosimilars/interchangeables: the reference product's generic name they were compared against, e.g. 'adalimumab'."
+        },
+        "reference_product_proprietary_name": {
+          "type": ["string", "null"],
+          "description": "For biosimilars/interchangeables: the reference product's brand name, e.g. 'Humira'."
+        },
+        "limit": {
+          "type": ["integer", "null"],
+          "description": "Max records to return, 1-500. Default 30."
+        }
+      }
+    },
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "applicant": {"type": ["string", "null"]},
+              "bla_number": {"type": ["string", "null"]},
+              "proprietary_name": {"type": ["string", "null"]},
+              "proper_name": {"type": ["string", "null"]},
+              "license_type": {"type": ["string", "null"]},
+              "reference_product_proper_name": {"type": ["string", "null"]},
+              "reference_product_proprietary_name": {"type": ["string", "null"]},
+              "exclusivity_expiration_date": {"type": ["string", "null"]}
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {"error": {"type": "string"}},
+          "required": ["error"]
+        }
+      ]
+    },
+    "test_examples": [
+      {"proper_name": "adalimumab", "limit": 10},
+      {"applicant": "AbbVie", "license_type": "351(a)", "limit": 5}
+    ]
+  }
+]

--- a/src/tooluniverse/data/giab_tools.json
+++ b/src/tooluniverse/data/giab_tools.json
@@ -1,0 +1,43 @@
+[
+  {
+    "name": "GIAB_list_directory",
+    "type": "GIABTool",
+    "description": "Browse NIST Genome in a Bottle's (GIAB) benchmark file release tree -- the reference-standard high-confidence variant (VCF) and callable-region (BED) sets used to validate variant-calling pipelines for samples HG001-HG007. There is no JSON API for this data, only a directory listing, so this tool navigates it: an empty path lists top-level trios/samples; e.g. path='AshkenazimTrio/HG002_NA24385_son/NISTv4.2.1/GRCh38' lists that release's benchmark VCF/BED files with direct download URLs.",
+    "parameter": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "path": {
+          "type": ["string", "null"],
+          "description": "Path relative to the GIAB release root, e.g. '' (top level), 'AshkenazimTrio', or 'AshkenazimTrio/HG002_NA24385_son/NISTv4.2.1/GRCh38'. Default '' lists top-level trios/samples."
+        }
+      }
+    },
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {"type": "string"},
+              "type": {"type": "string", "enum": ["directory", "file"]},
+              "size": {"type": ["string", "null"]},
+              "last_modified": {"type": ["string", "null"]},
+              "url": {"type": "string"}
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {"error": {"type": "string"}},
+          "required": ["error"]
+        }
+      ]
+    },
+    "test_examples": [
+      {"path": ""},
+      {"path": "AshkenazimTrio/HG002_NA24385_son/NISTv4.2.1/GRCh38"}
+    ]
+  }
+]

--- a/src/tooluniverse/data/gsa_tools.json
+++ b/src/tooluniverse/data/gsa_tools.json
@@ -1,0 +1,57 @@
+[
+  {
+    "name": "GSA_get_accession",
+    "type": "GSATool",
+    "description": "Look up a GSA (Genome Sequence Archive) accession by its CRA-format ID. GSA, run by China's National Genomics Data Center, is a major raw-sequencing archive alongside NCBI SRA/EBI ENA/DDBJ for a large and growing share of Chinese-origin genomic datasets. Returns title, linked BioProject accession, associated publication (title/journal/DOI/PubMed ID), file count/size, and direct HTTPS/FTP download URLs. Example: accession='CRA002926' returns a gynecological-mucosal-melanoma sequencing dataset linked to its Frontiers in Oncology publication.",
+    "parameter": {
+      "type": "object",
+      "required": ["accession"],
+      "properties": {
+        "accession": {
+          "type": "string",
+          "description": "GSA accession, e.g. 'CRA002926'."
+        }
+      }
+    },
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "accession": {"type": "string"},
+            "title": {"type": ["string", "null"]},
+            "bioproject_accession": {"type": ["string", "null"]},
+            "release_date": {"type": ["string", "null"]},
+            "file_count": {"type": ["string", "null"]},
+            "file_size": {"type": ["string", "null"]},
+            "publication": {
+              "type": "object",
+              "properties": {
+                "title": {"type": ["string", "null"]},
+                "journal": {"type": ["string", "null"]},
+                "doi": {"type": ["string", "null"]},
+                "pubmed_id": {"type": ["string", "null"]}
+              }
+            },
+            "download_urls": {
+              "type": "object",
+              "properties": {
+                "https": {"type": ["string", "null"]},
+                "ftp": {"type": ["string", "null"]}
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {"error": {"type": "string"}},
+          "required": ["error"]
+        }
+      ]
+    },
+    "test_examples": [
+      {"accession": "CRA002926"},
+      {"accession": "CRA000746"}
+    ]
+  }
+]

--- a/src/tooluniverse/data/molgluedb_tools.json
+++ b/src/tooluniverse/data/molgluedb_tools.json
@@ -1,0 +1,92 @@
+[
+  {
+    "name": "MolGlueDB_search_compounds",
+    "type": "MolGlueDBTool",
+    "description": "Full-text search MolGlueDB for molecular glue degrader (MGD) compounds -- small molecules that induce targeted protein degradation without a PROTAC's warhead-linker architecture. Matches target protein, recruiting protein (e.g. E3 ligase), compound name, or other indexed fields. Example: keyword='IKZF2' returns glues degrading IKZF2, each with SMILES, pharmacophore/scaffold class, degradation potency, and recruiting protein. Distinct from ToolUniverse's PROTAC-DB tools, which cover the separate bifunctional-degrader modality.",
+    "fields": {
+      "operation": "search_compounds"
+    },
+    "parameter": {
+      "type": "object",
+      "required": ["keyword"],
+      "properties": {
+        "keyword": {
+          "type": "string",
+          "description": "Search term: target protein ('IKZF2'), recruiting protein ('CRBN'), or compound name ('Lenalidomide')."
+        },
+        "limit": {
+          "type": ["integer", "null"],
+          "description": "Max compounds to return, 1-200. Default 30."
+        }
+      }
+    },
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {"type": ["integer", "null"]},
+              "Name": {"type": ["string", "null"]},
+              "SMILES": {"type": ["string", "null"]},
+              "Pharmacophore": {"type": ["string", "null"]},
+              "PrimaryTarget": {"type": ["string", "null"]},
+              "RecruitingProtein": {"type": ["string", "null"]}
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {"error": {"type": "string"}},
+          "required": ["error"]
+        }
+      ]
+    },
+    "test_examples": [
+      {"keyword": "IKZF2", "limit": 5},
+      {"keyword": "Lenalidomide", "limit": 5}
+    ]
+  },
+  {
+    "name": "MolGlueDB_get_compound",
+    "type": "MolGlueDBTool",
+    "description": "Retrieve a single MolGlueDB molecular glue degrader compound by its numeric compound_id (from MolGlueDB_search_compounds results). Returns full structural (SMILES/InChIKey/formula), pharmacophore/scaffold classification, degradation potency, and source-publication data.",
+    "fields": {
+      "operation": "get_compound"
+    },
+    "parameter": {
+      "type": "object",
+      "required": ["compound_id"],
+      "properties": {
+        "compound_id": {
+          "type": "integer",
+          "description": "MolGlueDB numeric compound id, e.g. 1."
+        }
+      }
+    },
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "id": {"type": ["integer", "null"]},
+            "Name": {"type": ["string", "null"]},
+            "SMILES": {"type": ["string", "null"]},
+            "PrimaryTarget": {"type": ["string", "null"]},
+            "RecruitingProtein": {"type": ["string", "null"]}
+          }
+        },
+        {
+          "type": "object",
+          "properties": {"error": {"type": "string"}},
+          "required": ["error"]
+        }
+      ]
+    },
+    "test_examples": [
+      {"compound_id": 1},
+      {"compound_id": 2}
+    ]
+  }
+]

--- a/src/tooluniverse/data/planteome_tools.json
+++ b/src/tooluniverse/data/planteome_tools.json
@@ -1,0 +1,137 @@
+[
+  {
+    "name": "Planteome_search_terms",
+    "type": "PlanteomeTool",
+    "description": "Search Planteome (a Global Core Biodata Resource) for plant ontology terms by keyword, across the Plant Ontology, Plant Trait Ontology, Plant Stress Ontology, and crop-specific ontologies together. Example: query='pollen' returns terms like 'pollen development' (GO:0009555) and crop-specific pollen traits. Complements ToolUniverse's generic GO tools (OLS/QuickGO), which don't carry plant-specific trait/structure ontologies.",
+    "fields": {
+      "operation": "search_terms"
+    },
+    "parameter": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "string",
+          "description": "Keyword or phrase, e.g. 'pollen development'."
+        },
+        "limit": {
+          "type": ["integer", "null"],
+          "description": "Max terms to return, 1-100. Default 20."
+        }
+      }
+    },
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {"type": ["string", "null"]},
+              "annotation_class_label": {"type": ["string", "null"]},
+              "description": {"type": ["string", "null"]},
+              "source": {"type": ["string", "null"]}
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {"error": {"type": "string"}},
+          "required": ["error"]
+        }
+      ]
+    },
+    "test_examples": [
+      {"query": "pollen development", "limit": 5},
+      {"query": "drought stress", "limit": 5}
+    ]
+  },
+  {
+    "name": "Planteome_get_term",
+    "type": "PlanteomeTool",
+    "description": "Get a single Planteome ontology term by its accession ID (from Planteome_search_terms or Planteome_search_annotations results). Example: term_id='GO:0009555' returns the full definition of 'pollen development'.",
+    "fields": {
+      "operation": "get_term"
+    },
+    "parameter": {
+      "type": "object",
+      "required": ["term_id"],
+      "properties": {
+        "term_id": {
+          "type": "string",
+          "description": "Ontology term accession, e.g. 'GO:0009555' or 'PO:0025281'."
+        }
+      }
+    },
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "id": {"type": "string"},
+            "annotation_class_label": {"type": ["string", "null"]},
+            "description": {"type": ["string", "null"]},
+            "source": {"type": ["string", "null"]}
+          }
+        },
+        {
+          "type": "object",
+          "properties": {"error": {"type": "string"}},
+          "required": ["error"]
+        }
+      ]
+    },
+    "test_examples": [
+      {"term_id": "GO:0009555"},
+      {"term_id": "PO:0025281"}
+    ]
+  },
+  {
+    "name": "Planteome_search_annotations",
+    "type": "PlanteomeTool",
+    "description": "Search Planteome's gene-to-ontology-term annotation index by gene id or accession. Resolves a plant gene to every ontology term (GO/PO/TO/crop ontologies) it has been annotated with, across evidence types and source databases. Example: query='AT4G32150' (Arabidopsis VAMP711) returns its GO annotations including 'vesicle-mediated transport'.",
+    "fields": {
+      "operation": "search_annotations"
+    },
+    "parameter": {
+      "type": "object",
+      "required": ["query"],
+      "properties": {
+        "query": {
+          "type": "string",
+          "description": "Gene id or accession, e.g. 'AT4G32150'."
+        },
+        "limit": {
+          "type": ["integer", "null"],
+          "description": "Max annotations to return, 1-100. Default 20."
+        }
+      }
+    },
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "bioentity": {"type": ["string", "null"]},
+              "bioentity_label": {"type": ["string", "null"]},
+              "annotation_class": {"type": ["string", "null"]},
+              "annotation_class_label": {"type": ["string", "null"]},
+              "taxon_label": {"type": ["string", "null"]}
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {"error": {"type": "string"}},
+          "required": ["error"]
+        }
+      ]
+    },
+    "test_examples": [
+      {"query": "AT4G32150", "limit": 5},
+      {"query": "AT1G01010", "limit": 5}
+    ]
+  }
+]

--- a/src/tooluniverse/default_config.py
+++ b/src/tooluniverse/default_config.py
@@ -982,6 +982,7 @@ default_tool_files = {
     "bold_systems": os.path.join(current_dir, "data", "bold_systems_tools.json"),
     "giab": os.path.join(current_dir, "data", "giab_tools.json"),
     "fda_purple_book": os.path.join(current_dir, "data", "fda_purple_book_tools.json"),
+    "molgluedb": os.path.join(current_dir, "data", "molgluedb_tools.json"),
     "pathoplexus": os.path.join(current_dir, "data", "pathoplexus_tools.json"),
     "open_genes": os.path.join(current_dir, "data", "open_genes_tools.json"),
     "foodb": os.path.join(current_dir, "data", "foodb_tools.json"),

--- a/src/tooluniverse/default_config.py
+++ b/src/tooluniverse/default_config.py
@@ -981,6 +981,7 @@ default_tool_files = {
     "idigbio": os.path.join(current_dir, "data", "idigbio_tools.json"),
     "bold_systems": os.path.join(current_dir, "data", "bold_systems_tools.json"),
     "giab": os.path.join(current_dir, "data", "giab_tools.json"),
+    "fda_purple_book": os.path.join(current_dir, "data", "fda_purple_book_tools.json"),
     "pathoplexus": os.path.join(current_dir, "data", "pathoplexus_tools.json"),
     "open_genes": os.path.join(current_dir, "data", "open_genes_tools.json"),
     "foodb": os.path.join(current_dir, "data", "foodb_tools.json"),

--- a/src/tooluniverse/default_config.py
+++ b/src/tooluniverse/default_config.py
@@ -979,6 +979,7 @@ default_tool_files = {
         current_dir, "data", "allen_cell_types_tools.json"
     ),
     "idigbio": os.path.join(current_dir, "data", "idigbio_tools.json"),
+    "bold_systems": os.path.join(current_dir, "data", "bold_systems_tools.json"),
     "pathoplexus": os.path.join(current_dir, "data", "pathoplexus_tools.json"),
     "open_genes": os.path.join(current_dir, "data", "open_genes_tools.json"),
     "foodb": os.path.join(current_dir, "data", "foodb_tools.json"),

--- a/src/tooluniverse/default_config.py
+++ b/src/tooluniverse/default_config.py
@@ -980,6 +980,7 @@ default_tool_files = {
     ),
     "idigbio": os.path.join(current_dir, "data", "idigbio_tools.json"),
     "bold_systems": os.path.join(current_dir, "data", "bold_systems_tools.json"),
+    "giab": os.path.join(current_dir, "data", "giab_tools.json"),
     "pathoplexus": os.path.join(current_dir, "data", "pathoplexus_tools.json"),
     "open_genes": os.path.join(current_dir, "data", "open_genes_tools.json"),
     "foodb": os.path.join(current_dir, "data", "foodb_tools.json"),

--- a/src/tooluniverse/default_config.py
+++ b/src/tooluniverse/default_config.py
@@ -985,6 +985,7 @@ default_tool_files = {
     "molgluedb": os.path.join(current_dir, "data", "molgluedb_tools.json"),
     "gsa": os.path.join(current_dir, "data", "gsa_tools.json"),
     "bar": os.path.join(current_dir, "data", "bar_tools.json"),
+    "planteome": os.path.join(current_dir, "data", "planteome_tools.json"),
     "pathoplexus": os.path.join(current_dir, "data", "pathoplexus_tools.json"),
     "open_genes": os.path.join(current_dir, "data", "open_genes_tools.json"),
     "foodb": os.path.join(current_dir, "data", "foodb_tools.json"),

--- a/src/tooluniverse/default_config.py
+++ b/src/tooluniverse/default_config.py
@@ -983,6 +983,7 @@ default_tool_files = {
     "giab": os.path.join(current_dir, "data", "giab_tools.json"),
     "fda_purple_book": os.path.join(current_dir, "data", "fda_purple_book_tools.json"),
     "molgluedb": os.path.join(current_dir, "data", "molgluedb_tools.json"),
+    "gsa": os.path.join(current_dir, "data", "gsa_tools.json"),
     "pathoplexus": os.path.join(current_dir, "data", "pathoplexus_tools.json"),
     "open_genes": os.path.join(current_dir, "data", "open_genes_tools.json"),
     "foodb": os.path.join(current_dir, "data", "foodb_tools.json"),

--- a/src/tooluniverse/default_config.py
+++ b/src/tooluniverse/default_config.py
@@ -984,6 +984,7 @@ default_tool_files = {
     "fda_purple_book": os.path.join(current_dir, "data", "fda_purple_book_tools.json"),
     "molgluedb": os.path.join(current_dir, "data", "molgluedb_tools.json"),
     "gsa": os.path.join(current_dir, "data", "gsa_tools.json"),
+    "bar": os.path.join(current_dir, "data", "bar_tools.json"),
     "pathoplexus": os.path.join(current_dir, "data", "pathoplexus_tools.json"),
     "open_genes": os.path.join(current_dir, "data", "open_genes_tools.json"),
     "foodb": os.path.join(current_dir, "data", "foodb_tools.json"),

--- a/src/tooluniverse/fda_purple_book_tool.py
+++ b/src/tooluniverse/fda_purple_book_tool.py
@@ -1,0 +1,213 @@
+# fda_purple_book_tool.py
+"""
+FDA Purple Book tool for ToolUniverse -- licensed biological products,
+biosimilars, and interchangeables.
+
+The Purple Book (purplebooksearch.fda.gov) lists every FDA-licensed
+biological product regulated by CDER and CBER: reference biologics,
+their licensed biosimilars and interchangeables, and each product's
+exclusivity expiration dates. There is no JSON API, but FDA publishes a
+monthly CSV snapshot at a discoverable, stable URL
+(accessdata.fda.gov/drugsatfda_docs/PurpleBook/{year}/...-data-download.csv).
+Per the FDA's own download-page documentation, each monthly file's *second*
+section (after the blank line following that month's changes) "contains
+all products in the Purple Book database for that month" -- i.e. the most
+recent monthly file's bottom section is a complete, current snapshot of
+the whole database, not just a delta. This tool discovers the latest
+file from the downloads page (avoiding any hardcoded/guessed month-name
+casing, which FDA's own naming is inconsistent about), parses that full
+snapshot, and filters it.
+
+No authentication required.
+"""
+
+import csv
+import io
+import re
+import threading
+from typing import Any, Dict, List, Optional
+
+import requests
+
+from .base_tool import BaseTool
+from .tool_registry import register_tool
+
+DOWNLOADS_PAGE_URL = "https://purplebooksearch.fda.gov/downloads"
+_CSV_URL_PATTERN = re.compile(
+    r'href=["\'](https://www\.accessdata\.fda\.gov/drugsatfda_docs/PurpleBook/'
+    r'(\d{4})/purplebook-search-[^"\']+?-data-download\.csv)["\']'
+)
+
+_FIELD_MAP = {
+    "applicant": "Applicant",
+    "bla_number": "BLA Number",
+    "proprietary_name": "Proprietary Name",
+    "proper_name": "Proper Name",
+    "license_type": "License Type",
+    "strength": "Strength",
+    "dosage_form": "Dosage Form",
+    "route_of_administration": "Route of Administration",
+    "marketing_status": "Marketing Status",
+    "approval_date": "Approval Date",
+    "reference_product_proper_name": "Ref. Product Proper Name",
+    "reference_product_proprietary_name": "Ref. Product Proprietary Name",
+    "license_number": "License Number",
+    "product_number": "Product Number",
+    "center": "Center",
+    "exclusivity_expiration_date": "Exclusivity Expiration Date",
+    "orphan_exclusivity_expiration_date": "Orphan Exclusivity Exp. Date",
+}
+
+_FILTERABLE = (
+    "applicant",
+    "bla_number",
+    "proprietary_name",
+    "proper_name",
+    "license_type",
+    "reference_product_proper_name",
+    "reference_product_proprietary_name",
+)
+
+_cache_lock = threading.Lock()
+_cache: Dict[str, List[Dict[str, Any]]] = {}
+
+
+def _find_latest_csv_url(timeout: int):
+    """Discover the most recently published monthly CSV's URL.
+
+    Returns (url, error). FDA's downloads page lists years newest-first and
+    months in chronological order within a year, so the last URL under the
+    highest year is the latest available month.
+    """
+    try:
+        resp = requests.get(DOWNLOADS_PAGE_URL, timeout=timeout)
+        resp.raise_for_status()
+    except requests.exceptions.Timeout:
+        return None, f"Purple Book downloads page timed out after {timeout}s"
+    except requests.exceptions.RequestException as e:
+        return None, f"Failed to reach the Purple Book downloads page: {e}"
+
+    by_year: Dict[str, List[str]] = {}
+    for url, year in _CSV_URL_PATTERN.findall(resp.text):
+        by_year.setdefault(year, []).append(url)
+    if not by_year:
+        return None, "No monthly data-download CSV links found on the Purple Book downloads page."
+
+    latest_year = max(by_year)
+    return by_year[latest_year][-1], None
+
+
+def _parse_full_snapshot(csv_text: str):
+    """Parse a monthly CSV's full-database section (its *second* table).
+
+    Returns (records, error). Records are dicts keyed by the CSV's own
+    column names.
+    """
+    rows = list(csv.reader(io.StringIO(csv_text)))
+    header_rows = [
+        i
+        for i, row in enumerate(rows)
+        if row and row[0] == "N/R/U" and len(row) > 1 and row[1] == "Applicant"
+    ]
+    if len(header_rows) < 2:
+        return None, "Could not locate the full-database section in the monthly CSV."
+
+    header = rows[header_rows[-1]]
+    data_rows = [row for row in rows[header_rows[-1] + 1 :] if any(c.strip() for c in row)]
+    records = [dict(zip(header, row)) for row in data_rows]
+    return records, None
+
+
+def _load_records(timeout: int):
+    """Fetch and parse the latest snapshot, cached per resolved CSV URL."""
+    url, err = _find_latest_csv_url(timeout)
+    if err is not None:
+        return None, None, {"status": "error", "error": err}
+
+    with _cache_lock:
+        cached = _cache.get(url)
+    if cached is not None:
+        return url, cached, None
+
+    try:
+        resp = requests.get(url, timeout=timeout)
+        resp.raise_for_status()
+    except requests.exceptions.Timeout:
+        return None, None, {
+            "status": "error",
+            "error": f"Purple Book data file timed out after {timeout}s",
+        }
+    except requests.exceptions.RequestException as e:
+        return None, None, {
+            "status": "error",
+            "error": f"Failed to download the Purple Book data file: {e}",
+        }
+
+    records, err = _parse_full_snapshot(resp.text)
+    if err is not None:
+        return None, None, {"status": "error", "error": err}
+
+    with _cache_lock:
+        _cache[url] = records
+    return url, records, None
+
+
+def _summarize(rec: Dict[str, str]) -> Dict[str, Optional[str]]:
+    return {key: (rec.get(csv_col) or "").strip() or None for key, csv_col in _FIELD_MAP.items()}
+
+
+@register_tool("FDAPurpleBookTool")
+class FDAPurpleBookTool(BaseTool):
+    """Search FDA's Purple Book of licensed biological products.
+
+    No authentication required.
+    """
+
+    def __init__(self, tool_config: Dict[str, Any]):
+        super().__init__(tool_config)
+        self.timeout = tool_config.get("timeout", 30)
+
+    def _limit(self, arguments: Dict[str, Any], default: int = 30) -> int:
+        try:
+            return max(1, min(int(arguments.get("limit") or default), 500))
+        except (TypeError, ValueError):
+            return default
+
+    def run(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        filters = {
+            key: str(arguments[key]).strip().lower()
+            for key in _FILTERABLE
+            if arguments.get(key) not in (None, "")
+        }
+        if not filters:
+            return {
+                "status": "error",
+                "error": "Provide at least one filter: "
+                + ", ".join(_FILTERABLE),
+            }
+
+        source_url, records, err = _load_records(self.timeout)
+        if err is not None:
+            return err
+
+        matches = []
+        for rec in records:
+            summary = _summarize(rec)
+            if all(
+                (summary.get(key) or "").lower().find(value) != -1
+                for key, value in filters.items()
+            ):
+                matches.append(summary)
+
+        limit = self._limit(arguments)
+        return {
+            "status": "success",
+            "data": matches[:limit],
+            "metadata": {
+                "filters": filters,
+                "total_matching": len(matches),
+                "returned": min(len(matches), limit),
+                "snapshot_source": source_url,
+                "source": "FDA Purple Book (purplebooksearch.fda.gov)",
+            },
+        }

--- a/src/tooluniverse/giab_tool.py
+++ b/src/tooluniverse/giab_tool.py
@@ -1,0 +1,119 @@
+# giab_tool.py
+"""
+Genome in a Bottle (GIAB) benchmark file browser for ToolUniverse.
+
+GIAB (NIST) publishes the reference-standard high-confidence variant call
+sets (VCF) and callable regions (BED) used to validate variant-calling
+pipelines, for samples HG001-HG007 across multiple reference builds and
+release versions (NISTv3.2 through v5.0q, plus CMRG, structural-variant,
+and tandem-repeat benchmark sets). There is no REST/JSON API for this data
+-- only a plain Apache directory listing at
+https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/giab/release/ -- so
+this tool parses that listing to let an agent navigate the tree (trio ->
+sample -> version -> reference build -> files) and get direct download
+URLs for the benchmark VCF/BED files it needs.
+
+No authentication required.
+"""
+
+import re
+from typing import Any, Dict, List
+from urllib.parse import urljoin
+
+import requests
+
+from .base_tool import BaseTool
+from .tool_registry import register_tool
+
+GIAB_HOST = "https://ftp-trace.ncbi.nlm.nih.gov"
+GIAB_RELEASE_ROOT = "/ReferenceSamples/giab/release/"
+
+_ENTRY_PATTERN = re.compile(
+    r'<a href="([^"]+)">([^<]+)</a>\s*(\d{4}-\d{2}-\d{2} \d{2}:\d{2})?\s*(\S*)'
+)
+
+
+def _parse_listing(html: str, listing_url: str) -> List[Dict[str, Any]]:
+    """Parse an Apache-style directory listing into structured entries."""
+    entries = []
+    for href, name, modified, size in _ENTRY_PATTERN.findall(html):
+        name = name.strip()
+        if name == "Parent Directory" or href.startswith("http"):
+            continue
+        is_dir = href.endswith("/")
+        entries.append(
+            {
+                "name": name.rstrip("/") if is_dir else name,
+                "type": "directory" if is_dir else "file",
+                "size": None if size == "-" else size,
+                "last_modified": modified or None,
+                "url": urljoin(listing_url, href),
+            }
+        )
+    return entries
+
+
+def _normalize_path(path: str):
+    """Validate and normalize a path relative to the GIAB release root.
+
+    Returns (normalized_path, error_message). Exactly one is None.
+    """
+    path = (path or "").strip().strip("/")
+    if ".." in path.split("/"):
+        return None, "path must not contain '..' path traversal segments."
+    return path, None
+
+
+@register_tool("GIABTool")
+class GIABTool(BaseTool):
+    """Browse the GIAB benchmark file release tree (NIST FTP mirror).
+
+    No authentication required.
+    """
+
+    def __init__(self, tool_config: Dict[str, Any]):
+        super().__init__(tool_config)
+        self.timeout = tool_config.get("timeout", 30)
+
+    def run(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        path, err = _normalize_path(arguments.get("path", ""))
+        if err is not None:
+            return {"status": "error", "error": err}
+
+        listing_url = urljoin(GIAB_HOST + GIAB_RELEASE_ROOT, path + "/" if path else "")
+
+        try:
+            resp = requests.get(listing_url, timeout=self.timeout)
+        except requests.exceptions.Timeout:
+            return {
+                "status": "error",
+                "error": f"GIAB request timed out after {self.timeout}s",
+            }
+        except requests.exceptions.RequestException as e:
+            return {"status": "error", "error": f"GIAB request failed: {e}"}
+
+        if resp.status_code == 404:
+            return {
+                "status": "error",
+                "error": f"No such GIAB path: '{path or '/'}'. Start with an "
+                "empty path to list the top-level trios/samples.",
+            }
+        resp.raise_for_status()
+
+        entries = _parse_listing(resp.text, listing_url)
+        if not entries:
+            return {
+                "status": "error",
+                "error": f"'{path or '/'}' is empty or not a directory listing.",
+            }
+
+        return {
+            "status": "success",
+            "data": entries,
+            "metadata": {
+                "path": path or "/",
+                "listing_url": listing_url,
+                "returned": len(entries),
+                "source": "NIST Genome in a Bottle (ftp-trace.ncbi.nlm.nih.gov)",
+            },
+        }

--- a/src/tooluniverse/gsa_tool.py
+++ b/src/tooluniverse/gsa_tool.py
@@ -1,0 +1,145 @@
+# gsa_tool.py
+"""
+GSA (Genome Sequence Archive) tool for ToolUniverse.
+
+GSA (ngdc.cncb.ac.cn/gsa), run by China's National Genomics Data Center
+(NGDC/CNCB), is a major raw-sequencing-data archive alongside NCBI's SRA,
+EBI's ENA, and Japan's DDBJ (the latter already covered by
+ddbj_tool.py) -- but for a large and growing share of Chinese-origin
+genomic datasets, GSA is the primary or only archive. There is no JSON
+API; accession pages are server-rendered HTML (Chinese-labeled fields),
+so this tool parses that page for a given CRA-format run/study
+accession, returning its title, associated BioProject, publication
+link, file count/size, and direct HTTPS/FTP download URLs.
+
+No authentication required.
+"""
+
+from typing import Any, Dict, Optional
+
+import requests
+from bs4 import BeautifulSoup
+
+from .base_tool import BaseTool
+from .tool_registry import register_tool
+
+GSA_BASE_URL = "https://ngdc.cncb.ac.cn/gsa"
+_HEADERS = {"User-Agent": "Mozilla/5.0 (compatible; ToolUniverse/1.0)"}
+
+
+def _panel_by_heading(soup: BeautifulSoup, heading_text: str):
+    for panel in soup.find_all("div", class_="panel-heading"):
+        if heading_text in panel.get_text():
+            return panel.find_parent("div", class_="panel")
+    return None
+
+
+def _label_value(soup: BeautifulSoup, label: str) -> Optional[str]:
+    b = soup.find("b", string=lambda s: s and label in s)
+    if not b:
+        return None
+    return b.parent.get_text(strip=True).replace(label, "").strip() or None
+
+
+def _publication_info(soup: BeautifulSoup) -> Dict[str, Optional[str]]:
+    panel = _panel_by_heading(soup, "出版信息")
+    fields = {"title": None, "journal": None, "year": None, "doi": None, "pubmed_id": None}
+    if panel is None:
+        return fields
+    label_map = {
+        "文章标题": "title",
+        "杂志名称": "journal",
+        "发表年份": "year",
+        "Doi": "doi",
+        "PubMed ID": "pubmed_id",
+    }
+    for row in panel.find_all("div", class_="row"):
+        strong = row.find("strong")
+        if not strong:
+            continue
+        key = label_map.get(strong.get_text(strip=True))
+        if key is None:
+            continue
+        divs = row.find_all("div")
+        if divs:
+            fields[key] = divs[-1].get_text(strip=True) or None
+    return fields
+
+
+def _download_urls(soup: BeautifulSoup) -> Dict[str, Optional[str]]:
+    panel = _panel_by_heading(soup, "数据下载")
+    urls = {"https": None, "ftp": None}
+    if panel is None:
+        return urls
+    https_a = panel.find("a", href=lambda h: h and h.startswith("https://download.cncb.ac.cn"))
+    ftp_a = panel.find("a", href=lambda h: h and h.startswith("ftp://"))
+    urls["https"] = https_a.get("href") if https_a else None
+    urls["ftp"] = ftp_a.get("href") if ftp_a else None
+    return urls
+
+
+@register_tool("GSATool")
+class GSATool(BaseTool):
+    """Look up a GSA (Genome Sequence Archive) accession's metadata page.
+
+    No authentication required.
+    """
+
+    def __init__(self, tool_config: Dict[str, Any]):
+        super().__init__(tool_config)
+        self.timeout = tool_config.get("timeout", 30)
+
+    def run(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        accession = (arguments.get("accession") or "").strip().upper()
+        if not accession:
+            return {
+                "status": "error",
+                "error": "accession is required, e.g. 'CRA002926'.",
+            }
+
+        try:
+            resp = requests.get(
+                f"{GSA_BASE_URL}/browse/{accession}",
+                headers=_HEADERS,
+                timeout=self.timeout,
+            )
+        except requests.exceptions.Timeout:
+            return {
+                "status": "error",
+                "error": f"GSA request timed out after {self.timeout}s",
+            }
+        except requests.exceptions.RequestException as e:
+            return {"status": "error", "error": f"GSA request failed: {e}"}
+        resp.raise_for_status()
+
+        soup = BeautifulSoup(resp.text, "html.parser")
+        title = _label_value(soup, "标题:")
+        if title is None:
+            return {
+                "status": "error",
+                "error": f"No GSA accession found for '{accession}'.",
+            }
+
+        bioproject_b = soup.find("b", string=lambda s: s and "项目编号" in s)
+        bioproject_a = bioproject_b.parent.find("a") if bioproject_b else None
+
+        return {
+            "status": "success",
+            "data": {
+                "accession": accession,
+                "title": title,
+                "bioproject_accession": (
+                    bioproject_a.get_text(strip=True) if bioproject_a else None
+                ),
+                "bioproject_url": bioproject_a.get("href") if bioproject_a else None,
+                "release_date": _label_value(soup, "发布日期:"),
+                "file_count": _label_value(soup, "文件个数:"),
+                "file_size": _label_value(soup, "文件大小:"),
+                "publication": _publication_info(soup),
+                "download_urls": _download_urls(soup),
+            },
+            "metadata": {
+                "accession": accession,
+                "source": "GSA / National Genomics Data Center (ngdc.cncb.ac.cn)",
+            },
+        }

--- a/src/tooluniverse/molgluedb_tool.py
+++ b/src/tooluniverse/molgluedb_tool.py
@@ -1,0 +1,190 @@
+# molgluedb_tool.py
+"""
+MolGlueDB tools for ToolUniverse -- molecular glue degrader compounds.
+
+MolGlueDB (molgluedb.com) is a curated database of molecular glue
+degraders (MGDs): small molecules that induce proximity between a target
+protein and a recruiting protein (e.g. an E3 ligase) without the
+warhead-linker-ligand architecture of a PROTAC. ToolUniverse's existing
+PROTAC-DB tools (protacdb_tool.py) cover that other, bifunctional
+degrader modality; MolGlueDB fills the monofunctional-glue gap, with
+structural, degradation, and physicochemical data plus curated
+pharmacophore/scaffold classifications (e.g. "Glutarimide" /
+"LenalidomideType") that PROTAC-DB has no equivalent for.
+
+There is no documented public API, but the site's own frontend calls a
+same-origin JSON backend at /api/query_bj_data (search) and
+/api/query_bj_data_by_id (single record). That backend sits behind a
+WAF that silently serves the SPA shell (HTTP 200, no error) to requests
+lacking a browser-like User-Agent and Referer -- both are set here for
+that reason, not to evade any access control (the data itself is fully
+public and described by its publisher as free and open-access).
+
+No authentication required.
+"""
+
+from typing import Any, Dict, Optional
+
+import requests
+
+from .base_tool import BaseTool
+from .tool_registry import register_tool
+
+MOLGLUEDB_BASE_URL = "https://www.molgluedb.com/api"
+_HEADERS = {
+    "User-Agent": "Mozilla/5.0 (compatible; ToolUniverse/1.0)",
+    "Referer": "https://www.molgluedb.com/",
+    "Content-Type": "application/json",
+    "Accept": "application/json",
+}
+
+_FIELDS = (
+    "id",
+    "Name",
+    "SMILES",
+    "IUPAC",
+    "StdInChIKey",
+    "Formula",
+    "MolWeight",
+    "Pharmacophore",
+    "Core",
+    "ModeOfAction",
+    "ResearchStage",
+    "PrimaryTarget",
+    "PrimaryTargetDegInfo",
+    "SecondaryTarget",
+    "SecondaryTargetDegInfo",
+    "RecruitingProtein",
+    "RecruitingProtein_UniProtID",
+    "PDB",
+    "SourceName",
+    "SourceAddress_Website",
+)
+
+
+def _summarize(rec: Dict[str, Any]) -> Dict[str, Any]:
+    return {field: rec.get(field) for field in _FIELDS}
+
+
+@register_tool("MolGlueDBTool")
+class MolGlueDBTool(BaseTool):
+    """
+    Tool for querying MolGlueDB, dispatched by fields.operation:
+      - "search_compounds" : full-text keyword search over molecular glues
+      - "get_compound"     : a single compound by its MolGlueDB id
+
+    No authentication required.
+    """
+
+    def __init__(self, tool_config: Dict[str, Any]):
+        super().__init__(tool_config)
+        self.timeout = tool_config.get("timeout", 30)
+        self.operation = tool_config.get("fields", {}).get(
+            "operation", "search_compounds"
+        )
+
+    def run(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        try:
+            if self.operation == "search_compounds":
+                return self._search_compounds(arguments)
+            if self.operation == "get_compound":
+                return self._get_compound(arguments)
+            return {
+                "status": "error",
+                "error": f"Unknown operation: {self.operation}",
+            }
+        except requests.exceptions.Timeout:
+            return {
+                "status": "error",
+                "error": f"MolGlueDB request timed out after {self.timeout}s",
+            }
+        except requests.exceptions.RequestException as e:
+            return {"status": "error", "error": f"MolGlueDB request failed: {e}"}
+        except ValueError:
+            return {
+                "status": "error",
+                "error": "MolGlueDB returned a non-JSON response",
+            }
+
+    def _limit(self, arguments: Dict[str, Any], default: int = 30) -> int:
+        try:
+            return max(1, min(int(arguments.get("limit") or default), 200))
+        except (TypeError, ValueError):
+            return default
+
+    def _search_compounds(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        keyword = (arguments.get("keyword") or "").strip()
+        if not keyword:
+            return {
+                "status": "error",
+                "error": "keyword is required, e.g. a target protein "
+                "('IKZF2'), recruiting protein ('CRBN'), or compound name "
+                "('Lenalidomide').",
+            }
+
+        limit = self._limit(arguments)
+        resp = requests.post(
+            f"{MOLGLUEDB_BASE_URL}/query_bj_data",
+            json={"page": 1, "pageSize": limit, "keyword": keyword},
+            headers=_HEADERS,
+            timeout=self.timeout,
+        )
+        resp.raise_for_status()
+        payload = resp.json()
+        if payload.get("status") != "success":
+            return {
+                "status": "error",
+                "error": f"MolGlueDB search failed: {payload}",
+            }
+
+        rows = payload.get("data") or []
+        return {
+            "status": "success",
+            "data": [_summarize(r) for r in rows],
+            "metadata": {
+                "keyword": keyword,
+                "total_matching": payload.get("total"),
+                "returned": len(rows),
+                "source": "MolGlueDB (molgluedb.com)",
+            },
+        }
+
+    def _get_compound(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        compound_id = arguments.get("compound_id")
+        try:
+            compound_id = int(compound_id)
+        except (TypeError, ValueError):
+            return {
+                "status": "error",
+                "error": "compound_id is required and must be an integer, "
+                "e.g. 1.",
+            }
+
+        resp = requests.get(
+            f"{MOLGLUEDB_BASE_URL}/query_bj_data_by_id",
+            params={"id": compound_id},
+            headers=_HEADERS,
+            timeout=self.timeout,
+        )
+        if resp.status_code == 404:
+            return {
+                "status": "error",
+                "error": f"No MolGlueDB compound found for id {compound_id}.",
+            }
+        resp.raise_for_status()
+        payload = resp.json()
+        record = payload.get("data")
+        if not record:
+            return {
+                "status": "error",
+                "error": f"No MolGlueDB compound found for id {compound_id}.",
+            }
+
+        return {
+            "status": "success",
+            "data": _summarize(record),
+            "metadata": {
+                "compound_id": compound_id,
+                "source": "MolGlueDB (molgluedb.com)",
+            },
+        }

--- a/src/tooluniverse/planteome_tool.py
+++ b/src/tooluniverse/planteome_tool.py
@@ -1,0 +1,186 @@
+# planteome_tool.py
+"""
+Planteome tools for ToolUniverse -- plant ontologies and gene annotations.
+
+Planteome (planteome.org), a Global Core Biodata Resource with no prior
+ToolUniverse coverage, hosts the Plant Ontology, Plant Trait Ontology,
+Plant Stress Ontology, and crop-specific ontologies (e.g. banana,
+soybean), plus a GOlr-style search index of gene-to-ontology-term
+annotations across plant species. This is distinct from ToolUniverse's
+generic GO tools (OLS/QuickGO): Planteome indexes plant-specific trait
+and structure ontologies those don't carry, and its annotation search
+resolves a specific plant gene (e.g. an Arabidopsis AGI locus code) to
+every ontology term it has been annotated with, across GO, PO, TO, and
+crop ontologies together.
+
+API: https://browser.planteome.org/api (documented at
+planteome.org/web_services)
+No authentication required.
+"""
+
+from typing import Any, Dict, List
+
+import requests
+
+from .base_tool import BaseTool
+from .tool_registry import register_tool
+
+PLANTEOME_API_URL = "https://browser.planteome.org/api"
+
+_TERM_FIELDS = (
+    "id",
+    "annotation_class_label",
+    "description",
+    "source",
+    "is_obsolete",
+    "synonym",
+)
+
+_ANNOTATION_FIELDS = (
+    "bioentity",
+    "bioentity_label",
+    "annotation_class",
+    "annotation_class_label",
+    "aspect",
+    "taxon_label",
+    "evidence_type",
+    "reference",
+)
+
+
+def _planteome_get(path: str, params: Dict[str, Any], timeout: int):
+    """GET a Planteome endpoint, returning (payload, error_envelope)."""
+    try:
+        resp = requests.get(f"{PLANTEOME_API_URL}{path}", params=params, timeout=timeout)
+    except requests.exceptions.Timeout:
+        return None, {
+            "status": "error",
+            "error": f"Planteome request timed out after {timeout}s",
+        }
+    except requests.exceptions.RequestException as e:
+        return None, {"status": "error", "error": f"Planteome request failed: {e}"}
+    resp.raise_for_status()
+    try:
+        payload = resp.json()
+    except ValueError:
+        return None, {"status": "error", "error": "Planteome returned a non-JSON response."}
+    return payload, None
+
+
+def _summarize(hit: Dict[str, Any], fields) -> Dict[str, Any]:
+    return {f: hit.get(f) for f in fields}
+
+
+@register_tool("PlanteomeTool")
+class PlanteomeTool(BaseTool):
+    """
+    Tool for querying Planteome, dispatched by fields.operation:
+      - "search_terms"       : keyword search over plant ontology terms
+      - "get_term"            : a single ontology term by its accession ID
+      - "search_annotations"  : gene/bioentity to ontology-term annotations
+
+    No authentication required.
+    """
+
+    def __init__(self, tool_config: Dict[str, Any]):
+        super().__init__(tool_config)
+        self.timeout = tool_config.get("timeout", 30)
+        self.operation = tool_config.get("fields", {}).get("operation", "search_terms")
+
+    def run(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        if self.operation == "search_terms":
+            return self._search_terms(arguments)
+        if self.operation == "get_term":
+            return self._get_term(arguments)
+        if self.operation == "search_annotations":
+            return self._search_annotations(arguments)
+        return {"status": "error", "error": f"Unknown operation: {self.operation}"}
+
+    def _limit(self, arguments: Dict[str, Any], default: int = 20) -> int:
+        try:
+            return max(1, min(int(arguments.get("limit") or default), 100))
+        except (TypeError, ValueError):
+            return default
+
+    def _search_terms(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        query = (arguments.get("query") or "").strip()
+        if not query:
+            return {
+                "status": "error",
+                "error": "query is required, e.g. 'pollen development'.",
+            }
+
+        payload, err = _planteome_get(
+            "/search/ontology", {"q": query}, self.timeout
+        )
+        if err is not None:
+            return err
+
+        hits = payload.get("data") or []
+        limit = self._limit(arguments)
+        return {
+            "status": "success",
+            "data": [_summarize(h, _TERM_FIELDS) for h in hits[:limit]],
+            "metadata": {
+                "query": query,
+                "returned": min(len(hits), limit),
+                "source": "Planteome (planteome.org)",
+            },
+        }
+
+    def _get_term(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        term_id = (arguments.get("term_id") or "").strip()
+        if not term_id:
+            return {
+                "status": "error",
+                "error": "term_id is required, e.g. 'GO:0009555' or 'PO:0025281'.",
+            }
+
+        payload, err = _planteome_get("/entity/terms", {"entity": term_id}, self.timeout)
+        if err is not None:
+            return err
+
+        if payload.get("status") != "success" or not payload.get("data"):
+            return {
+                "status": "error",
+                "error": f"No Planteome ontology term found for '{term_id}'.",
+            }
+
+        hits = payload["data"] if isinstance(payload["data"], list) else list(payload["data"].values())
+        if not hits:
+            return {
+                "status": "error",
+                "error": f"No Planteome ontology term found for '{term_id}'.",
+            }
+
+        return {
+            "status": "success",
+            "data": _summarize(hits[0], _TERM_FIELDS),
+            "metadata": {"term_id": term_id, "source": "Planteome (planteome.org)"},
+        }
+
+    def _search_annotations(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        query = (arguments.get("query") or "").strip()
+        if not query:
+            return {
+                "status": "error",
+                "error": "query is required, e.g. a gene id like 'AT4G32150'.",
+            }
+
+        payload, err = _planteome_get(
+            "/search/annotation", {"q": query}, self.timeout
+        )
+        if err is not None:
+            return err
+
+        hits = payload.get("data") or []
+        limit = self._limit(arguments)
+        return {
+            "status": "success",
+            "data": [_summarize(h, _ANNOTATION_FIELDS) for h in hits[:limit]],
+            "metadata": {
+                "query": query,
+                "returned": min(len(hits), limit),
+                "source": "Planteome (planteome.org)",
+            },
+        }

--- a/tests/tools/test_bar_tool.py
+++ b/tests/tools/test_bar_tool.py
@@ -1,0 +1,99 @@
+"""Tests for the BAR (Bio-Analytic Resource for Plant Biology) tool.
+
+The BAR publishes a documented, unauthenticated OpenAPI spec
+(bar.utoronto.ca/api/swagger.json). These tests hit the live gene
+annotation and RNA-seq expression endpoints with a well-known
+Arabidopsis gene (AT1G01010) to confirm real data comes back, not
+just a 200 with an empty/placeholder body.
+"""
+
+import pytest
+from tooluniverse import ToolUniverse
+
+
+TRANSIENT = ("timed out", "Failed to connect", "HTTP 5")
+
+NAC001 = "AT1G01010"
+TIR1 = "AT3G62980"
+
+
+@pytest.fixture(scope="module")
+def tu():
+    instance = ToolUniverse()
+    instance.load_tools()
+    return instance
+
+
+def data_of(result):
+    if result.get("status") == "error":
+        error = str(result.get("error", ""))
+        if any(t in error for t in TRANSIENT):
+            pytest.skip(f"upstream temporarily unavailable: {error[:80]}")
+        pytest.fail(f"unexpected error response: {error[:200]}")
+    return result["data"]
+
+
+class TestRegistration:
+    def test_tools_load(self, tu):
+        names = {t.get("name") for t in tu.all_tools if isinstance(t, dict)}
+        assert "BAR_get_gene_info" in names
+        assert "BAR_get_rnaseq_expression" in names
+
+
+class TestGetGeneInfo:
+    def test_known_gene_returns_correct_annotation(self, tu):
+        data = data_of(tu.tools.BAR_get_gene_info(gene_id=NAC001))
+        assert data["chromosome"] == "Chr1"
+        assert "NAC001" in data["aliases"]
+        assert "NAC domain" in data["annotation"]
+
+    def test_second_known_gene(self, tu):
+        data = data_of(tu.tools.BAR_get_gene_info(gene_id=TIR1))
+        assert "TIR1" in data["aliases"]
+
+    def test_unknown_gene(self, tu):
+        result = tu.tools.BAR_get_gene_info(gene_id="NOTAREALGENE999")
+        assert result["status"] == "error"
+
+    def test_unknown_species(self, tu):
+        result = tu.tools.BAR_get_gene_info(gene_id=NAC001, species="notarealspecies")
+        assert result["status"] == "error"
+
+    def test_missing_gene_id(self, tu):
+        result = tu.tools.BAR_get_gene_info(gene_id="")
+        assert result["status"] == "error"
+
+
+class TestGetRnaseqExpression:
+    def test_known_gene_returns_cluster_expression(self, tu):
+        data = data_of(tu.tools.BAR_get_rnaseq_expression(gene_id="At1g01010"))
+        assert data
+        assert all(isinstance(v, (int, float)) for v in data.values())
+
+    def test_two_different_genes_return_different_profiles(self, tu):
+        nac001 = data_of(tu.tools.BAR_get_rnaseq_expression(gene_id="At1g01010"))
+        tir1 = data_of(tu.tools.BAR_get_rnaseq_expression(gene_id="At3g62980"))
+        assert nac001 != tir1
+
+    def test_unknown_gene(self, tu):
+        result = tu.tools.BAR_get_rnaseq_expression(gene_id="NOTAREALGENE999")
+        assert result["status"] == "error"
+
+    def test_missing_gene_id(self, tu):
+        result = tu.tools.BAR_get_rnaseq_expression(gene_id="")
+        assert result["status"] == "error"
+
+
+class TestErrorHandling:
+    @pytest.mark.parametrize(
+        "tool_name,kwargs",
+        [
+            ("BAR_get_gene_info", {"gene_id": ""}),
+            ("BAR_get_rnaseq_expression", {"gene_id": ""}),
+        ],
+    )
+    def test_returns_error_dict_not_exception(self, tu, tool_name, kwargs):
+        result = getattr(tu.tools, tool_name)(**kwargs)
+        assert isinstance(result, dict)
+        assert result["status"] == "error"
+        assert isinstance(result.get("error"), str) and result["error"]

--- a/tests/tools/test_bold_systems_tool.py
+++ b/tests/tools/test_bold_systems_tool.py
@@ -1,0 +1,155 @@
+"""Tests for the BOLD Systems (Barcode of Life Data System) tool.
+
+BOLD's standout capability is the BIN (Barcode Index Number): a
+sequence-similarity DNA barcode cluster that ToolUniverse's existing
+biodiversity tool (iDigBio) has no equivalent for. BOLD's own
+tax:species triplet is silently ignored server-side (verified live
+against several subscope-name guesses), so species-level search here
+queries at genus level and filters client-side on the "species" field
+of the returned records -- exercised directly below.
+"""
+
+import pytest
+from tooluniverse import ToolUniverse
+
+
+TRANSIENT = ("timed out", "Failed to connect", "HTTP 5")
+
+LION_PROCESS_ID = "ABRMM002-06"
+LION_BIN = "BOLD:AAD6819"
+
+
+@pytest.fixture(scope="module")
+def tu():
+    instance = ToolUniverse()
+    instance.load_tools()
+    return instance
+
+
+def data_of(result):
+    if result.get("status") == "error":
+        error = str(result.get("error", ""))
+        if any(t in error for t in TRANSIENT):
+            pytest.skip(f"upstream temporarily unavailable: {error[:80]}")
+        pytest.fail(f"unexpected error response: {error[:200]}")
+    return result["data"]
+
+
+class TestRegistration:
+    def test_tools_load(self, tu):
+        names = {t.get("name") for t in tu.all_tools if isinstance(t, dict)}
+        assert "BOLDSystems_search_by_taxon" in names
+        assert "BOLDSystems_search_by_bin" in names
+        assert "BOLDSystems_get_record" in names
+
+
+class TestSearchByTaxon:
+    def test_genus_search(self, tu):
+        rows = data_of(
+            tu.tools.BOLDSystems_search_by_taxon(taxon_name="Panthera", rank="genus", limit=20)
+        )
+        assert rows
+        genera = {r["genus"] for r in rows}
+        assert genera == {"Panthera"}
+
+    def test_species_filter_is_exact(self, tu):
+        rows = data_of(
+            tu.tools.BOLDSystems_search_by_taxon(
+                taxon_name="Panthera leo", rank="species", limit=20
+            )
+        )
+        assert rows
+        # Every returned row must be the exact species, not sibling species
+        # sharing the Panthera genus (the client-side filter's whole job).
+        assert {r["species"] for r in rows} == {"Panthera leo"}
+
+    def test_species_filter_excludes_other_species(self, tu):
+        rows = data_of(
+            tu.tools.BOLDSystems_search_by_taxon(
+                taxon_name="Panthera uncia", rank="species", limit=20
+            )
+        )
+        assert rows
+        assert all(r["species"] == "Panthera uncia" for r in rows)
+        assert all(r["species"] != "Panthera leo" for r in rows)
+
+    def test_country_narrows_results(self, tu):
+        all_rows = data_of(
+            tu.tools.BOLDSystems_search_by_taxon(taxon_name="Panthera", rank="genus", limit=200)
+        )
+        india_rows = data_of(
+            tu.tools.BOLDSystems_search_by_taxon(
+                taxon_name="Panthera", rank="genus", country="India", limit=200
+            )
+        )
+        assert len(india_rows) < len(all_rows)
+        assert all(r["country/ocean"] == "India" for r in india_rows if r["country/ocean"])
+
+    def test_limit_is_respected(self, tu):
+        rows = data_of(
+            tu.tools.BOLDSystems_search_by_taxon(taxon_name="Panthera", rank="genus", limit=3)
+        )
+        assert len(rows) <= 3
+
+    def test_missing_taxon_name(self, tu):
+        result = tu.tools.BOLDSystems_search_by_taxon(taxon_name="")
+        assert result["status"] == "error"
+
+    def test_invalid_rank(self, tu):
+        result = tu.tools.BOLDSystems_search_by_taxon(taxon_name="Panthera", rank="phylum")
+        assert result["status"] == "error"
+
+
+class TestSearchByBin:
+    def test_bin_search_returns_matching_records(self, tu):
+        rows = data_of(tu.tools.BOLDSystems_search_by_bin(bin_id=LION_BIN, limit=50))
+        assert rows
+        assert all(r["bin_uri"] == LION_BIN for r in rows)
+
+    def test_prefix_is_optional(self, tu):
+        with_prefix = data_of(tu.tools.BOLDSystems_search_by_bin(bin_id=LION_BIN, limit=50))
+        without_prefix = data_of(
+            tu.tools.BOLDSystems_search_by_bin(bin_id="AAD6819", limit=50)
+        )
+        ids_with = {r["processid"] for r in with_prefix}
+        ids_without = {r["processid"] for r in without_prefix}
+        assert ids_with == ids_without
+
+    def test_unknown_bin_returns_empty(self, tu):
+        rows = data_of(tu.tools.BOLDSystems_search_by_bin(bin_id="BOLD:ZZZZZZZ"))
+        assert rows == []
+
+    def test_missing_bin_id(self, tu):
+        result = tu.tools.BOLDSystems_search_by_bin(bin_id="")
+        assert result["status"] == "error"
+
+
+class TestGetRecord:
+    def test_known_process_id(self, tu):
+        data = data_of(tu.tools.BOLDSystems_get_record(process_id=LION_PROCESS_ID))
+        assert data["species"] == "Panthera leo"
+        assert data["bin_uri"] == LION_BIN
+
+    def test_unknown_process_id(self, tu):
+        result = tu.tools.BOLDSystems_get_record(process_id="NOTAREALID-99")
+        assert result["status"] == "error"
+
+    def test_missing_process_id(self, tu):
+        result = tu.tools.BOLDSystems_get_record(process_id="")
+        assert result["status"] == "error"
+
+
+class TestErrorHandling:
+    @pytest.mark.parametrize(
+        "tool_name,kwargs",
+        [
+            ("BOLDSystems_search_by_taxon", {"taxon_name": ""}),
+            ("BOLDSystems_search_by_bin", {"bin_id": ""}),
+            ("BOLDSystems_get_record", {"process_id": ""}),
+        ],
+    )
+    def test_returns_error_dict_not_exception(self, tu, tool_name, kwargs):
+        result = getattr(tu.tools, tool_name)(**kwargs)
+        assert isinstance(result, dict)
+        assert result["status"] == "error"
+        assert isinstance(result.get("error"), str) and result["error"]

--- a/tests/tools/test_fda_purple_book_tool.py
+++ b/tests/tools/test_fda_purple_book_tool.py
@@ -1,0 +1,100 @@
+"""Tests for the FDA Purple Book tool.
+
+There is no JSON API for the Purple Book, only monthly CSV snapshots at
+a discoverable (but not reliably-cased) URL. Per FDA's own download-page
+documentation, each monthly file's second section is a complete current
+snapshot of the whole database, not just that month's changes -- these
+tests confirm that section is parsed (not the top "changes" section) by
+checking that products unrelated to any given month's changes are still
+findable, and that known reference/biosimilar/interchangeable
+relationships resolve correctly.
+"""
+
+import pytest
+from tooluniverse import ToolUniverse
+
+
+TRANSIENT = ("timed out", "Failed to connect", "HTTP 5", "Failed to reach", "Failed to download")
+
+
+@pytest.fixture(scope="module")
+def tu():
+    instance = ToolUniverse()
+    instance.load_tools()
+    return instance
+
+
+def data_of(result):
+    if result.get("status") == "error":
+        error = str(result.get("error", ""))
+        if any(t in error for t in TRANSIENT):
+            pytest.skip(f"upstream temporarily unavailable: {error[:80]}")
+        pytest.fail(f"unexpected error response: {error[:200]}")
+    return result["data"]
+
+
+class TestRegistration:
+    def test_tool_loads(self, tu):
+        names = {t.get("name") for t in tu.all_tools if isinstance(t, dict)}
+        assert "FDAPurpleBook_search_products" in names
+
+
+class TestSearchProducts:
+    def test_reference_product_found_by_generic_name(self, tu):
+        rows = data_of(tu.tools.FDAPurpleBook_search_products(proper_name="adalimumab", limit=100))
+        assert rows
+        names = {r["proprietary_name"] for r in rows}
+        assert "Humira" in names
+
+    def test_biosimilar_resolves_to_reference_product(self, tu):
+        rows = data_of(
+            tu.tools.FDAPurpleBook_search_products(
+                reference_product_proprietary_name="Humira", limit=100
+            )
+        )
+        assert rows
+        # Every hit must actually reference Humira, and license_type must
+        # mark it as a biosimilar/interchangeable, not the 351(a) itself.
+        assert all("humira" in (r["reference_product_proprietary_name"] or "").lower() for r in rows)
+        assert any("351(k)" in (r["license_type"] or "") for r in rows)
+
+    def test_interchangeable_filter_excludes_plain_biosimilars(self, tu):
+        rows = data_of(
+            tu.tools.FDAPurpleBook_search_products(
+                reference_product_proprietary_name="Humira",
+                license_type="interchangeable",
+                limit=100,
+            )
+        )
+        assert rows
+        assert all("interchangeable" in (r["license_type"] or "").lower() for r in rows)
+
+    def test_applicant_and_license_type_combine(self, tu):
+        rows = data_of(
+            tu.tools.FDAPurpleBook_search_products(
+                applicant="AbbVie", license_type="351(a)", limit=200
+            )
+        )
+        assert rows
+        assert all("abbvie" in (r["applicant"] or "").lower() for r in rows)
+        assert all(r["license_type"] == "351(a)" for r in rows)
+
+    def test_limit_is_respected(self, tu):
+        rows = data_of(tu.tools.FDAPurpleBook_search_products(applicant="AbbVie", limit=3))
+        assert len(rows) <= 3
+
+    def test_unknown_bla_number_returns_empty(self, tu):
+        rows = data_of(tu.tools.FDAPurpleBook_search_products(bla_number="999999999"))
+        assert rows == []
+
+    def test_no_filter_provided(self, tu):
+        result = tu.tools.FDAPurpleBook_search_products()
+        assert result["status"] == "error"
+
+
+class TestErrorHandling:
+    def test_returns_error_dict_not_exception(self, tu):
+        result = tu.tools.FDAPurpleBook_search_products()
+        assert isinstance(result, dict)
+        assert result["status"] == "error"
+        assert isinstance(result.get("error"), str) and result["error"]

--- a/tests/tools/test_giab_tool.py
+++ b/tests/tools/test_giab_tool.py
@@ -1,0 +1,83 @@
+"""Tests for the GIAB (Genome in a Bottle) benchmark file browser tool.
+
+GIAB has no JSON API -- only a plain Apache directory listing -- so this
+tool parses that listing to navigate the benchmark release tree. These
+tests exercise the parsing against the live tree, not a mock, since the
+whole point of the tool is correctly reflecting that tree's structure.
+"""
+
+import pytest
+from tooluniverse import ToolUniverse
+
+
+TRANSIENT = ("timed out", "Failed to connect", "HTTP 5")
+
+HG002_GRCH38_V421 = "AshkenazimTrio/HG002_NA24385_son/NISTv4.2.1/GRCh38"
+
+
+@pytest.fixture(scope="module")
+def tu():
+    instance = ToolUniverse()
+    instance.load_tools()
+    return instance
+
+
+def data_of(result):
+    if result.get("status") == "error":
+        error = str(result.get("error", ""))
+        if any(t in error for t in TRANSIENT):
+            pytest.skip(f"upstream temporarily unavailable: {error[:80]}")
+        pytest.fail(f"unexpected error response: {error[:200]}")
+    return result["data"]
+
+
+class TestRegistration:
+    def test_tool_loads(self, tu):
+        names = {t.get("name") for t in tu.all_tools if isinstance(t, dict)}
+        assert "GIAB_list_directory" in names
+
+
+class TestListDirectory:
+    def test_top_level_lists_known_trios(self, tu):
+        entries = data_of(tu.tools.GIAB_list_directory())
+        names = {e["name"] for e in entries}
+        assert "AshkenazimTrio" in names
+        assert "NA12878_HG001" in names
+        assert all(e["type"] == "directory" for e in entries)
+
+    def test_directory_names_have_no_trailing_slash(self, tu):
+        entries = data_of(tu.tools.GIAB_list_directory())
+        assert all(not e["name"].endswith("/") for e in entries)
+
+    def test_benchmark_files_present_with_urls_and_sizes(self, tu):
+        entries = data_of(tu.tools.GIAB_list_directory(path=HG002_GRCH38_V421))
+        files = {e["name"]: e for e in entries if e["type"] == "file"}
+        vcf_name = "HG002_GRCh38_1_22_v4.2.1_benchmark.vcf.gz"
+        assert vcf_name in files
+        vcf = files[vcf_name]
+        assert vcf["url"].startswith("https://ftp-trace.ncbi.nlm.nih.gov/")
+        assert vcf["url"].endswith(vcf_name)
+        assert vcf["size"]
+
+    def test_default_path_is_top_level(self, tu):
+        default_entries = data_of(tu.tools.GIAB_list_directory())
+        explicit_entries = data_of(tu.tools.GIAB_list_directory(path=""))
+        assert {e["name"] for e in default_entries} == {
+            e["name"] for e in explicit_entries
+        }
+
+    def test_path_traversal_rejected(self, tu):
+        result = tu.tools.GIAB_list_directory(path="../../../etc")
+        assert result["status"] == "error"
+
+    def test_nonexistent_path(self, tu):
+        result = tu.tools.GIAB_list_directory(path="NotARealGIABPath123")
+        assert result["status"] == "error"
+
+
+class TestErrorHandling:
+    def test_returns_error_dict_not_exception(self, tu):
+        result = tu.tools.GIAB_list_directory(path="../x")
+        assert isinstance(result, dict)
+        assert result["status"] == "error"
+        assert isinstance(result.get("error"), str) and result["error"]

--- a/tests/tools/test_gsa_tool.py
+++ b/tests/tools/test_gsa_tool.py
@@ -1,0 +1,81 @@
+"""Tests for the GSA (Genome Sequence Archive) tool.
+
+GSA has no JSON API -- only server-rendered, Chinese-labeled HTML
+accession pages -- so this tool scrapes that page. These tests run
+against the live site rather than a mock, since the whole point is
+verifying the Chinese-label parsing (标题/项目编号/发布日期/etc.) actually
+resolves to the right fields, and that both of GSA's distinct
+"not found" page variants (a malformed accession's generic 404 panel,
+and a well-formed-but-nonexistent accession's "does not exist" panel)
+are handled the same way.
+"""
+
+import pytest
+from tooluniverse import ToolUniverse
+
+
+TRANSIENT = ("timed out", "Failed to connect", "HTTP 5")
+
+MELANOMA_ACCESSION = "CRA002926"
+
+
+@pytest.fixture(scope="module")
+def tu():
+    instance = ToolUniverse()
+    instance.load_tools()
+    return instance
+
+
+def data_of(result):
+    if result.get("status") == "error":
+        error = str(result.get("error", ""))
+        if any(t in error for t in TRANSIENT):
+            pytest.skip(f"upstream temporarily unavailable: {error[:80]}")
+        pytest.fail(f"unexpected error response: {error[:200]}")
+    return result["data"]
+
+
+class TestRegistration:
+    def test_tool_loads(self, tu):
+        names = {t.get("name") for t in tu.all_tools if isinstance(t, dict)}
+        assert "GSA_get_accession" in names
+
+
+class TestGetAccession:
+    def test_known_accession_resolves_full_record(self, tu):
+        data = data_of(tu.tools.GSA_get_accession(accession=MELANOMA_ACCESSION))
+        assert data["accession"] == MELANOMA_ACCESSION
+        assert "melanoma" in data["title"].lower()
+        assert data["bioproject_accession"] == "PRJCA003017"
+        assert data["publication"]["pubmed_id"] == "32984050"
+        assert data["download_urls"]["https"].endswith(MELANOMA_ACCESSION)
+
+    def test_second_known_accession(self, tu):
+        data = data_of(tu.tools.GSA_get_accession(accession="CRA000746"))
+        assert data["accession"] == "CRA000746"
+        assert data["title"]
+
+    def test_accession_is_case_insensitive(self, tu):
+        upper = data_of(tu.tools.GSA_get_accession(accession=MELANOMA_ACCESSION))
+        lower = data_of(tu.tools.GSA_get_accession(accession=MELANOMA_ACCESSION.lower()))
+        assert upper["title"] == lower["title"]
+
+    def test_well_formed_but_nonexistent_accession(self, tu):
+        result = tu.tools.GSA_get_accession(accession="CRA002828")
+        assert result["status"] == "error"
+
+    def test_malformed_accession(self, tu):
+        result = tu.tools.GSA_get_accession(accession="CRA999999999")
+        assert result["status"] == "error"
+
+    def test_missing_accession(self, tu):
+        result = tu.tools.GSA_get_accession(accession="")
+        assert result["status"] == "error"
+
+
+class TestErrorHandling:
+    def test_returns_error_dict_not_exception(self, tu):
+        result = tu.tools.GSA_get_accession(accession="")
+        assert isinstance(result, dict)
+        assert result["status"] == "error"
+        assert isinstance(result.get("error"), str) and result["error"]

--- a/tests/tools/test_molgluedb_tool.py
+++ b/tests/tools/test_molgluedb_tool.py
@@ -1,0 +1,100 @@
+"""Tests for the MolGlueDB tool.
+
+MolGlueDB has no documented public API; its own frontend calls a
+same-origin JSON backend that sits behind a WAF returning the SPA shell
+(HTTP 200, not an error) to requests without a browser-like User-Agent
+and Referer. These tests exercise the real backend, so they also guard
+against that WAF behavior regressing silently -- if headers stopped
+being enough, search results would come back empty/malformed rather
+than erroring loudly.
+"""
+
+import pytest
+from tooluniverse import ToolUniverse
+
+
+TRANSIENT = ("timed out", "Failed to connect", "HTTP 5", "non-JSON")
+
+IKZF2_COMPOUND_ID = 1
+
+
+@pytest.fixture(scope="module")
+def tu():
+    instance = ToolUniverse()
+    instance.load_tools()
+    return instance
+
+
+def data_of(result):
+    if result.get("status") == "error":
+        error = str(result.get("error", ""))
+        if any(t in error for t in TRANSIENT):
+            pytest.skip(f"upstream temporarily unavailable: {error[:80]}")
+        pytest.fail(f"unexpected error response: {error[:200]}")
+    return result["data"]
+
+
+class TestRegistration:
+    def test_tools_load(self, tu):
+        names = {t.get("name") for t in tu.all_tools if isinstance(t, dict)}
+        assert "MolGlueDB_search_compounds" in names
+        assert "MolGlueDB_get_compound" in names
+
+
+class TestSearchCompounds:
+    def test_target_keyword_returns_real_hits(self, tu):
+        result = tu.tools.MolGlueDB_search_compounds(keyword="IKZF2", limit=10)
+        rows = data_of(result)
+        assert rows
+        assert result["metadata"]["total_matching"] > 0
+        assert any(r["PrimaryTarget"] == "IKZF2" for r in rows)
+
+    def test_compound_name_keyword(self, tu):
+        rows = data_of(tu.tools.MolGlueDB_search_compounds(keyword="Lenalidomide", limit=10))
+        assert rows
+        assert any("lenalidomide" in (r["Name"] or "").lower() for r in rows)
+
+    def test_nonsense_keyword_returns_empty_not_full_dataset(self, tu):
+        result = tu.tools.MolGlueDB_search_compounds(keyword="zzznonexistentxyz123")
+        rows = data_of(result)
+        assert rows == []
+        assert result["metadata"]["total_matching"] == 0
+
+    def test_limit_is_respected(self, tu):
+        rows = data_of(tu.tools.MolGlueDB_search_compounds(keyword="CRBN", limit=3))
+        assert len(rows) <= 3
+
+    def test_missing_keyword(self, tu):
+        result = tu.tools.MolGlueDB_search_compounds(keyword="")
+        assert result["status"] == "error"
+
+
+class TestGetCompound:
+    def test_known_compound_id(self, tu):
+        data = data_of(tu.tools.MolGlueDB_get_compound(compound_id=IKZF2_COMPOUND_ID))
+        assert data["id"] == IKZF2_COMPOUND_ID
+        assert data["PrimaryTarget"] == "IKZF2"
+        assert data["SMILES"]
+
+    def test_unknown_compound_id(self, tu):
+        result = tu.tools.MolGlueDB_get_compound(compound_id=999999999)
+        assert result["status"] == "error"
+
+    def test_non_integer_compound_id(self, tu):
+        result = tu.tools.MolGlueDB_get_compound(compound_id="not-a-number")
+        assert result["status"] == "error"
+
+
+class TestErrorHandling:
+    @pytest.mark.parametrize(
+        "tool_name,kwargs",
+        [
+            ("MolGlueDB_search_compounds", {"keyword": ""}),
+            ("MolGlueDB_get_compound", {"compound_id": "bad"}),
+        ],
+    )
+    def test_returns_error_dict_not_exception(self, tu, tool_name, kwargs):
+        result = getattr(tu.tools, tool_name)(**kwargs)
+        assert isinstance(result, dict)
+        assert result["status"] == "error"
+        assert isinstance(result.get("error"), str) and result["error"]

--- a/tests/tools/test_planteome_tool.py
+++ b/tests/tools/test_planteome_tool.py
@@ -1,0 +1,102 @@
+"""Tests for the Planteome tool.
+
+Planteome's GOlr-style search index (browser.planteome.org/api) has no
+official client library, so these tests hit it live to confirm both
+term search/lookup and the gene-to-ontology-term annotation search
+resolve to real, matching data -- not just a 200 with an empty body.
+"""
+
+import pytest
+from tooluniverse import ToolUniverse
+
+
+TRANSIENT = ("timed out", "Failed to connect", "HTTP 5")
+
+POLLEN_DEVELOPMENT = "GO:0009555"
+VAMP711_GENE = "AT4G32150"
+
+
+@pytest.fixture(scope="module")
+def tu():
+    instance = ToolUniverse()
+    instance.load_tools()
+    return instance
+
+
+def data_of(result):
+    if result.get("status") == "error":
+        error = str(result.get("error", ""))
+        if any(t in error for t in TRANSIENT):
+            pytest.skip(f"upstream temporarily unavailable: {error[:80]}")
+        pytest.fail(f"unexpected error response: {error[:200]}")
+    return result["data"]
+
+
+class TestRegistration:
+    def test_tools_load(self, tu):
+        names = {t.get("name") for t in tu.all_tools if isinstance(t, dict)}
+        assert "Planteome_search_terms" in names
+        assert "Planteome_get_term" in names
+        assert "Planteome_search_annotations" in names
+
+
+class TestSearchTerms:
+    def test_keyword_search_returns_matching_terms(self, tu):
+        rows = data_of(tu.tools.Planteome_search_terms(query="pollen development", limit=10))
+        assert rows
+        assert any(r["id"] == POLLEN_DEVELOPMENT for r in rows)
+
+    def test_nonsense_query_returns_empty(self, tu):
+        rows = data_of(tu.tools.Planteome_search_terms(query="zzznonexistentxyz123"))
+        assert rows == []
+
+    def test_limit_is_respected(self, tu):
+        rows = data_of(tu.tools.Planteome_search_terms(query="stress", limit=3))
+        assert len(rows) <= 3
+
+    def test_missing_query(self, tu):
+        result = tu.tools.Planteome_search_terms(query="")
+        assert result["status"] == "error"
+
+
+class TestGetTerm:
+    def test_known_term_resolves(self, tu):
+        data = data_of(tu.tools.Planteome_get_term(term_id=POLLEN_DEVELOPMENT))
+        assert data["id"] == POLLEN_DEVELOPMENT
+        assert data["annotation_class_label"] == "pollen development"
+
+    def test_unknown_term(self, tu):
+        result = tu.tools.Planteome_get_term(term_id="GO:0009999999")
+        assert result["status"] == "error"
+
+    def test_missing_term_id(self, tu):
+        result = tu.tools.Planteome_get_term(term_id="")
+        assert result["status"] == "error"
+
+
+class TestSearchAnnotations:
+    def test_gene_resolves_to_its_go_annotations(self, tu):
+        rows = data_of(tu.tools.Planteome_search_annotations(query=VAMP711_GENE, limit=10))
+        assert rows
+        assert all(r["bioentity"] and VAMP711_GENE in r["bioentity"] for r in rows)
+        assert any(r["annotation_class_label"] == "vesicle-mediated transport" for r in rows)
+
+    def test_missing_query(self, tu):
+        result = tu.tools.Planteome_search_annotations(query="")
+        assert result["status"] == "error"
+
+
+class TestErrorHandling:
+    @pytest.mark.parametrize(
+        "tool_name,kwargs",
+        [
+            ("Planteome_search_terms", {"query": ""}),
+            ("Planteome_get_term", {"term_id": ""}),
+            ("Planteome_search_annotations", {"query": ""}),
+        ],
+    )
+    def test_returns_error_dict_not_exception(self, tu, tool_name, kwargs):
+        result = getattr(tu.tools, tool_name)(**kwargs)
+        assert isinstance(result, dict)
+        assert result["status"] == "error"
+        assert isinstance(result.get("error"), str) and result["error"]


### PR DESCRIPTION
## Summary

Seven independent tool additions, each unblocking a previously-dead-end data source with a live-verified workaround. Three of these (GSA, BAR, Planteome) close Global Core Biodata Resource gaps -- the community-certified critical-infrastructure tier of the original gap analysis.

- **BOLD Systems** (`BOLDSystems_search_by_taxon`, `BOLDSystems_search_by_bin`, `BOLDSystems_get_record`): DNA barcode records and Barcode Index Number (BIN) species clusters. `tax:species` triplets are silently ignored server-side, so species search queries at genus level and filters client-side.
- **GIAB** (`GIAB_list_directory`): NIST Genome in a Bottle's benchmark VCF/BED release tree, parsed from its plain Apache directory listing (no JSON API exists).
- **FDA Purple Book** (`FDAPurpleBook_search_products`): licensed biologics, biosimilars, interchangeables, exclusivity dates, parsed from FDA's monthly CSV snapshot's full-database section (not just that month's deltas), with the latest file discovered from the downloads page since FDA's URL month-casing is inconsistent.
- **MolGlueDB** (`MolGlueDB_search_compounds`, `MolGlueDB_get_compound`): molecular glue degraders, the monofunctional counterpart to the bifunctional PROTACs already covered by PROTAC-DB. Its backend sits behind a WAF that silently serves the SPA shell to non-browser requests; a real User-Agent/Referer is enough.
- **GSA** (`GSA_get_accession`): China's National Genomics Data Center sequencing archive, alongside NCBI SRA/EBI ENA/DDBJ. Parsed from server-rendered Chinese-labeled HTML by label text (no JSON API).
- **BAR** (`BAR_get_gene_info`, `BAR_get_rnaseq_expression`): the Bio-Analytic Resource for Plant Biology's per-gene annotation and RNA-seq/single-cell expression, via its documented OpenAPI spec. Fills a gap the existing pathway-only plant_reactome tools don't.
- **Planteome** (`Planteome_search_terms`, `Planteome_get_term`, `Planteome_search_annotations`): plant-specific ontology terms (Plant Ontology, Plant Trait Ontology, crop ontologies) and gene-to-term annotations, via its documented GOlr-style search API.

## Test plan
- [x] `python3 -m json.tool` on all 7 new JSON configs
- [x] `python3 -m py_compile` on all 7 new tool modules
- [x] `scripts/test_new_tools.py` for each of `bold_systems`, `giab`, `fda_purple_book`, `molgluedb`, `gsa`, `bar`, `planteome` → 100% pass, 0 schema invalid (26/26 total)
- [x] 3-step registration verified for all 7 (class registry, `default_tool_files`, wrapper generation) — 2700 tools total, no duplicates
- [x] Hand-written pytest per tool, run together: 79/79 passed, exercising real live-data behavior (client-side species filtering, WAF-header handling, monthly-snapshot section parsing, Chinese-label scraping, cross-gene expression-profile differences, ontology term/annotation resolution, path-traversal and not-found handling throughout)

## Note on scope discipline
An EcoCyc tool was also attempted in this round (the last untested Global Core Biodata Resource item) but was backed out: live testing showed BioCyc's anonymous-access wall (already documented in the existing `metacyc_tool.py`) applies to EcoCyc too, and without BioCyc credentials the authenticated path couldn't be live-verified, so it wasn't shipped.