### PR TITLE
feat: add OrcaRouter as a named LLM provider

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -168,6 +168,11 @@ OPENAI_API_KEY=
 # Without: Only needed if you select OpenRouter as the agentic LLM provider.
 OPENROUTER_API_KEY=
 
+# ORCAROUTER_API_KEY (optional) — Use OrcaRouter-hosted models for LLM-backed (agentic) tools. (https://www.orcarouter.ai)
+# ORCAROUTER_BASE_URL (optional) — Defaults to https://api.orcarouter.ai/v1
+# Without: Only needed if you select OrcaRouter as the agentic LLM provider.
+ORCAROUTER_API_KEY=
+
 # TXAGENT_MCP_SERVER_HOST (required) — URL of a self-hosted TxAgent MCP server. (https://github.com/mims-harvard/TxAgent)
 # Without: Leave blank unless you run your own TxAgent.
 TXAGENT_MCP_SERVER_HOST=

--- a/docs/guide/agentic_tools_tutorial.rst
+++ b/docs/guide/agentic_tools_tutorial.rst
@@ -73,6 +73,12 @@ ToolUniverse supports these AI providers:
  - Configuration: Set ``OPENROUTER_API_KEY``
  - See :doc:`../guide/openrouter_support` for details
 
+**OrcaRouter**
+ - Access to multiple providers through one API
+ - Models: ``orcarouter/auto``, ``orcarouter/fusion``, and more
+ - Configuration: Set ``ORCAROUTER_API_KEY``
+ - See :doc:`../guide/orcarouter_support` for details
+
 **vLLM (Self-Hosted)**
  - Run models on your own infrastructure
  - Models: Any model supported by vLLM (Llama, Mistral, Qwen, etc.)
@@ -190,7 +196,7 @@ Set up AI model settings:
 
 **Configuration Options**:
 
-- ``api_type``: "CHATGPT", "OPENAI", "GEMINI", "OPENROUTER", or "VLLM"
+- ``api_type``: "CHATGPT", "OPENAI", "GEMINI", "OPENROUTER", "ORCAROUTER", or "VLLM"
 - ``model_id``: Choose your model (see Step 2)
 
   - For vLLM: Must match the model name loaded on your vLLM server

--- a/docs/guide/api_keys.rst
+++ b/docs/guide/api_keys.rst
@@ -398,7 +398,7 @@ Environment Variables
 
 .. code-block:: bash
 
-   # Default LLM provider (CHATGPT, OPENAI, OPENROUTER, GEMINI, VLLM)
+   # Default LLM provider (CHATGPT, OPENAI, OPENROUTER, ORCAROUTER, GEMINI, VLLM)
    TOOLUNIVERSE_LLM_DEFAULT_PROVIDER=OPENAI
 
    # Model configuration per task

--- a/docs/guide/openai_compatible_support.rst
+++ b/docs/guide/openai_compatible_support.rst
@@ -62,5 +62,7 @@ Provider Notes
 --------------
 
 Use ``OPENAI`` for OpenAI-compatible chat completions endpoints. Use
-``OPENROUTER`` when you want OpenRouter-specific headers and model naming, and
-use ``VLLM`` for self-hosted vLLM servers.
+``OPENROUTER`` when you want OpenRouter-specific headers and model naming, use
+``ORCAROUTER`` to route chat completions through the OrcaRouter gateway
+(``https://api.orcarouter.ai/v1``), and use ``VLLM`` for self-hosted vLLM
+servers.

--- a/docs/guide/orcarouter_support.rst
+++ b/docs/guide/orcarouter_support.rst
@@ -1,0 +1,167 @@
+OrcaRouter Support
+==================
+
+ToolUniverse includes full support for OrcaRouter, allowing you to route chat
+completions through OrcaRouter's gateway while keeping a single OpenAI-compatible
+API. OrcaRouter also runs gateway-level, zero-trust security for AI agents on
+the same endpoint.
+
+Overview
+--------
+
+OrcaRouter provides access to models through:
+
+* **Smart routing** — the ``orcarouter/auto`` model routes each request to the
+  best-fit upstream model automatically.
+* **Fusion family** — ``orcarouter/fusion``, ``orcarouter/fusion-flash``, and
+  ``orcarouter/fusion-mini`` for large-context workloads.
+* And many more via a single unified API.
+
+Configuration
+-------------
+
+Environment Variables
+^^^^^^^^^^^^^^^^^^^^^
+
+To use OrcaRouter, set the following environment variables:
+
+.. code-block:: bash
+
+    # Required
+    export ORCAROUTER_API_KEY="your_orcarouter_api_key_here"
+
+    # Optional - override the gateway endpoint (defaults to https://api.orcarouter.ai/v1)
+    export ORCAROUTER_BASE_URL="https://api.orcarouter.ai/v1"
+
+Getting an API Key
+^^^^^^^^^^^^^^^^^^
+
+1. Visit `OrcaRouter <https://www.orcarouter.ai>`_
+2. Sign up for an account
+3. Navigate to the API Keys section
+4. Generate a new API key
+5. Copy and set it as the ``ORCAROUTER_API_KEY`` environment variable
+
+Using OrcaRouter with AgenticTool
+----------------------------------
+
+Basic Configuration
+^^^^^^^^^^^^^^^^^^^
+
+Configure an AgenticTool to use OrcaRouter:
+
+.. code-block:: python
+
+    from tooluniverse import ToolUniverse
+    from tooluniverse.agentic_tool import AgenticTool
+
+    # Example tool configuration using OrcaRouter
+    tool_config = {
+        "name": "OrcaRouter_Summarizer",
+        "description": "Summarize text using OrcaRouter models",
+        "type": "AgenticTool",
+        "prompt": "Summarize the following text:\n{text}",
+        "input_arguments": ["text"],
+        "parameter": {
+            "type": "object",
+            "properties": {
+                "text": {
+                    "type": "string",
+                    "description": "The text to summarize",
+                    "required": True
+                }
+            },
+            "required": ["text"]
+        },
+        "configs": {
+            "api_type": "ORCAROUTER",
+            "model_id": "orcarouter/auto",
+            "temperature": 0.7,
+            "return_json": False
+        }
+    }
+
+    # Initialize ToolUniverse and register the tool
+    tu = ToolUniverse()
+    tu.register_custom_tool(AgenticTool, tool_config=tool_config)
+
+    # Use the tool (requires ORCAROUTER_API_KEY)
+    result = tu.run({"name": "OrcaRouter_Summarizer", "arguments": {
+        "text": "Your long text here..."
+    }})
+
+
+Using OrcaRouter with ToolFinderLLM
+------------------------------------
+
+Configure ToolFinderLLM to use OrcaRouter models:
+
+.. code-block:: python
+
+    from tooluniverse import ToolUniverse
+    from tooluniverse.tool_finder_llm import ToolFinderLLM
+
+    # Create ToolUniverse instance
+    tu = ToolUniverse()
+
+    # Configure ToolFinderLLM with OrcaRouter
+    tool_finder_config = {
+        "type": "ToolFinderLLM",
+        "name": "Tool_Finder_OrcaRouter",
+        "description": "Find tools using OrcaRouter LLMs",
+        "configs": {
+            "api_type": "ORCAROUTER",
+            "model_id": "orcarouter/auto",
+            "temperature": 0.1,
+            "max_new_tokens": 4096,
+            "return_json": True,
+            "exclude_tools": ["Tool_RAG", "Tool_Finder", "Finish"]
+        }
+    }
+
+    # Register and use (requires ORCAROUTER_API_KEY)
+    tu.register_custom_tool(ToolFinderLLM, tool_config=tool_finder_config)
+    result = tu.run({"name": "Tool_Finder_OrcaRouter", "arguments": {
+        "description": "tools for protein analysis",
+        "limit": 5
+    }})
+
+Fallback Configuration
+----------------------
+
+You can include OrcaRouter in a custom fallback chain:
+
+.. code-block:: python
+
+    import os
+    import json
+
+    custom_chain = [
+        {"api_type": "ORCAROUTER", "model_id": "orcarouter/auto"},
+        {"api_type": "OPENROUTER", "model_id": "anthropic/claude-sonnet-4.5"},
+        {"api_type": "GEMINI", "model_id": "gemini-2.5-flash"}
+    ]
+
+    os.environ["AGENTIC_TOOL_FALLBACK_CHAIN"] = json.dumps(custom_chain)
+
+Advanced Configuration
+----------------------
+
+Custom Model Limits
+^^^^^^^^^^^^^^^^^^^
+
+Override default token limits for specific models:
+
+.. code-block:: python
+
+    import os
+    import json
+
+    custom_limits = {
+        "orcarouter/auto": {
+            "max_output": 32000,
+            "context_window": 200000
+        }
+    }
+
+    os.environ["ORCAROUTER_DEFAULT_MODEL_LIMITS"] = json.dumps(custom_limits)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -236,6 +236,7 @@ Community & Support
    guide/logging
    guide/streaming_tools
    guide/openrouter_support
+   guide/orcarouter_support
    guide/vllm_support
    guide/openai_compatible_support
    guide/euhealth_tools_tutorial

--- a/docs/sitemap.rst
+++ b/docs/sitemap.rst
@@ -38,6 +38,7 @@ Tutorials & Workflows
 - :doc:`guide/examples` - Examples
 - :doc:`guide/logging` - Logging
 - :doc:`guide/openrouter_support` - OpenRouter Support
+- :doc:`guide/orcarouter_support` - OrcaRouter Support
 - :doc:`guide/streaming_tools` - Streaming Tools
 - :doc:`guide/tools` - Tools
 - :doc:`guide/vllm_support` - vLLM Support

--- a/examples/orcarouter_example.py
+++ b/examples/orcarouter_example.py
@@ -1,0 +1,85 @@
+"""
+OrcaRouter Integration Example
+================================
+
+This example demonstrates how to use OrcaRouter with ToolUniverse to route
+chat completions through OrcaRouter's gateway. OrcaRouter also runs
+gateway-level, zero-trust security for AI agents on the same endpoint.
+
+Requirements:
+- OrcaRouter API key (get from https://www.orcarouter.ai)
+- Set ORCAROUTER_API_KEY environment variable
+"""
+
+import os
+from tooluniverse import ToolUniverse
+
+
+def setup_orcarouter():
+    """Set up OrcaRouter API key (replace with your actual key)."""
+    if not os.getenv("ORCAROUTER_API_KEY"):
+        print("⚠️  Please set ORCAROUTER_API_KEY environment variable")
+        print("   export ORCAROUTER_API_KEY='your_key_here'")
+        return False
+    return True
+
+
+def example_smart_route():
+    """Example: Basic usage with OrcaRouter smart routing."""
+    print("\n" + "=" * 70)
+    print("Example: Using OrcaRouter smart routing (orcarouter/auto)")
+    print("=" * 70)
+
+    tu = ToolUniverse()
+
+    # Create a simple summarization tool using OrcaRouter
+    tool_config = {
+        "name": "OrcaRouter_Summarizer",
+        "description": "Summarize text using OrcaRouter",
+        "type": "AgenticTool",
+        "prompt": "Provide a concise summary of the following text in 2-3 sentences:\n\n{text}",
+        "input_arguments": ["text"],
+        "parameter": {
+            "type": "object",
+            "properties": {
+                "text": {
+                    "type": "string",
+                    "description": "The text to summarize",
+                    "required": True,
+                }
+            },
+            "required": ["text"],
+        },
+        "configs": {
+            "api_type": "ORCAROUTER",
+            "model_id": "orcarouter/auto",
+            "temperature": 0.3,
+            "return_json": False,
+        },
+    }
+
+    # Register and use the tool
+    tu.register_tool_from_config(tool_config)
+
+    sample_text = """
+    Artificial intelligence has made remarkable progress in recent years, with
+    large language models demonstrating unprecedented capabilities in natural
+    language understanding and generation. These models can perform a wide range
+    of tasks including translation, summarization, question answering, and even
+    creative writing. However, challenges remain in areas such as factual accuracy,
+    reasoning capabilities, and computational efficiency.
+    """
+
+    result = tu.execute_tool("OrcaRouter_Summarizer", {"text": sample_text})
+    print("\n📝 Input Text:")
+    print(sample_text.strip())
+    print("\n✨ Summary:")
+    if isinstance(result, dict) and "result" in result:
+        print(result["result"])
+    else:
+        print(result)
+
+
+if __name__ == "__main__":
+    if setup_orcarouter():
+        example_smart_route()

--- a/plugin/skills/setup-tooluniverse/API_KEYS_REFERENCE.md
+++ b/plugin/skills/setup-tooluniverse/API_KEYS_REFERENCE.md
@@ -200,7 +200,7 @@ Detailed guide for every API key used by ToolUniverse. Use this when walking use
 
 These keys power ToolUniverse's **agentic features** -- tools that use LLMs to synthesize results, plan multi-step analyses, and generate reports. At least one LLM provider key is needed for these features.
 
-The system checks providers in this order: **Azure OpenAI -> OpenRouter -> Gemini**. Configure whichever you prefer.
+The system checks providers in this order: **Azure OpenAI -> OpenRouter -> Gemini**. OrcaRouter is also supported as an alternative LLM provider. Configure whichever you prefer.
 
 ### GEMINI_API_KEY
 
@@ -227,6 +227,18 @@ The system checks providers in this order: **Azure OpenAI -> OpenRouter -> Gemin
   4. Click "Create Key"
   5. Add credits to your account for usage
 - **Env variable**: `OPENROUTER_API_KEY`
+
+### ORCAROUTER_API_KEY
+
+- **Service**: OrcaRouter
+- **Required**: No (alternative LLM provider)
+- **What it does**: Routes chat completions through the OrcaRouter gateway with smart routing (`orcarouter/auto`). It also runs gateway-level, zero-trust security for AI agents on the same endpoint.
+- **How to get it**:
+  1. Go to https://www.orcarouter.ai
+  2. Sign up or log in
+  3. Go to the API Keys section
+  4. Create a new API key
+- **Env variable**: `ORCAROUTER_API_KEY`
 
 ### OPENAI_API_KEY
 
@@ -295,5 +307,5 @@ The system checks providers in this order: **Azure OpenAI -> OpenRouter -> Gemin
 | **Drug safety** | `FDA_API_KEY`, `UMLS_API_KEY` |
 | **Patents** | `USPTO_API_KEY` |
 | **Electronic components/IC design** | `MOUSER_API_KEY`, `DIGIKEY_CLIENT_ID` + `DIGIKEY_CLIENT_SECRET` |
-| **AI-powered analysis** | Any one of: `GEMINI_API_KEY`, `OPENROUTER_API_KEY`, `OPENAI_API_KEY` |
+| **AI-powered analysis** | Any one of: `GEMINI_API_KEY`, `OPENROUTER_API_KEY`, `OPENAI_API_KEY`, `ORCAROUTER_API_KEY` |
 | **Full setup (all features)** | All Tier 1 + relevant Tier 2 + one Tier 3 key |

--- a/plugins/tooluniverse/skills/setup-tooluniverse/API_KEYS_REFERENCE.md
+++ b/plugins/tooluniverse/skills/setup-tooluniverse/API_KEYS_REFERENCE.md
@@ -200,7 +200,7 @@ Detailed guide for every API key used by ToolUniverse. Use this when walking use
 
 These keys power ToolUniverse's **agentic features** -- tools that use LLMs to synthesize results, plan multi-step analyses, and generate reports. At least one LLM provider key is needed for these features.
 
-The system checks providers in this order: **Azure OpenAI -> OpenRouter -> Gemini**. Configure whichever you prefer.
+The system checks providers in this order: **Azure OpenAI -> OpenRouter -> Gemini**. OrcaRouter is also supported as an alternative LLM provider. Configure whichever you prefer.
 
 ### GEMINI_API_KEY
 
@@ -227,6 +227,18 @@ The system checks providers in this order: **Azure OpenAI -> OpenRouter -> Gemin
   4. Click "Create Key"
   5. Add credits to your account for usage
 - **Env variable**: `OPENROUTER_API_KEY`
+
+### ORCAROUTER_API_KEY
+
+- **Service**: OrcaRouter
+- **Required**: No (alternative LLM provider)
+- **What it does**: Routes chat completions through the OrcaRouter gateway with smart routing (`orcarouter/auto`). It also runs gateway-level, zero-trust security for AI agents on the same endpoint.
+- **How to get it**:
+  1. Go to https://www.orcarouter.ai
+  2. Sign up or log in
+  3. Go to the API Keys section
+  4. Create a new API key
+- **Env variable**: `ORCAROUTER_API_KEY`
 
 ### OPENAI_API_KEY
 
@@ -295,5 +307,5 @@ The system checks providers in this order: **Azure OpenAI -> OpenRouter -> Gemin
 | **Drug safety** | `FDA_API_KEY`, `UMLS_API_KEY` |
 | **Patents** | `USPTO_API_KEY` |
 | **Electronic components/IC design** | `MOUSER_API_KEY`, `DIGIKEY_CLIENT_ID` + `DIGIKEY_CLIENT_SECRET` |
-| **AI-powered analysis** | Any one of: `GEMINI_API_KEY`, `OPENROUTER_API_KEY`, `OPENAI_API_KEY` |
+| **AI-powered analysis** | Any one of: `GEMINI_API_KEY`, `OPENROUTER_API_KEY`, `OPENAI_API_KEY`, `ORCAROUTER_API_KEY` |
 | **Full setup (all features)** | All Tier 1 + relevant Tier 2 + one Tier 3 key |

--- a/skills/setup-tooluniverse/API_KEYS_REFERENCE.md
+++ b/skills/setup-tooluniverse/API_KEYS_REFERENCE.md
@@ -200,7 +200,7 @@ Detailed guide for every API key used by ToolUniverse. Use this when walking use
 
 These keys power ToolUniverse's **agentic features** -- tools that use LLMs to synthesize results, plan multi-step analyses, and generate reports. At least one LLM provider key is needed for these features.
 
-The system checks providers in this order: **Azure OpenAI -> OpenRouter -> Gemini**. Configure whichever you prefer.
+The system checks providers in this order: **Azure OpenAI -> OpenRouter -> Gemini**. OrcaRouter is also supported as an alternative LLM provider. Configure whichever you prefer.
 
 ### GEMINI_API_KEY
 
@@ -227,6 +227,18 @@ The system checks providers in this order: **Azure OpenAI -> OpenRouter -> Gemin
   4. Click "Create Key"
   5. Add credits to your account for usage
 - **Env variable**: `OPENROUTER_API_KEY`
+
+### ORCAROUTER_API_KEY
+
+- **Service**: OrcaRouter
+- **Required**: No (alternative LLM provider)
+- **What it does**: Routes chat completions through the OrcaRouter gateway with smart routing (`orcarouter/auto`). It also runs gateway-level, zero-trust security for AI agents on the same endpoint.
+- **How to get it**:
+  1. Go to https://www.orcarouter.ai
+  2. Sign up or log in
+  3. Go to the API Keys section
+  4. Create a new API key
+- **Env variable**: `ORCAROUTER_API_KEY`
 
 ### OPENAI_API_KEY
 
@@ -295,5 +307,5 @@ The system checks providers in this order: **Azure OpenAI -> OpenRouter -> Gemin
 | **Drug safety** | `FDA_API_KEY`, `UMLS_API_KEY` |
 | **Patents** | `USPTO_API_KEY` |
 | **Electronic components/IC design** | `MOUSER_API_KEY`, `DIGIKEY_CLIENT_ID` + `DIGIKEY_CLIENT_SECRET` |
-| **AI-powered analysis** | Any one of: `GEMINI_API_KEY`, `OPENROUTER_API_KEY`, `OPENAI_API_KEY` |
+| **AI-powered analysis** | Any one of: `GEMINI_API_KEY`, `OPENROUTER_API_KEY`, `OPENAI_API_KEY`, `ORCAROUTER_API_KEY` |
 | **Full setup (all features)** | All Tier 1 + relevant Tier 2 + one Tier 3 key |

--- a/src/tooluniverse/agentic_tool.py
+++ b/src/tooluniverse/agentic_tool.py
@@ -14,6 +14,7 @@ from .llm_clients import (
     GeminiClient,
     OpenAICompatibleClient,
     OpenRouterClient,
+    OrcaRouterClient,
     VLLMClient,
 )
 
@@ -30,6 +31,7 @@ API_KEY_ENV_VARS = {
     "CHATGPT": ["AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT"],
     "OPENAI": ["OPENAI_API_KEY"],
     "OPENROUTER": ["OPENROUTER_API_KEY"],
+    "ORCAROUTER": ["ORCAROUTER_API_KEY"],
     "GEMINI": ["GEMINI_API_KEY"],
     "VLLM": ["VLLM_SERVER_URL"],
 }
@@ -316,6 +318,8 @@ class AgenticTool(BaseTool):
                 self._llm_client = OpenAICompatibleClient(model_id, self.logger)
             elif api_type == "OPENROUTER":
                 self._llm_client = OpenRouterClient(model_id, self.logger)
+            elif api_type == "ORCAROUTER":
+                self._llm_client = OrcaRouterClient(model_id, self.logger)
             elif api_type == "GEMINI":
                 self._llm_client = GeminiClient(model_id, self.logger)
             elif api_type == "VLLM":
@@ -357,7 +361,7 @@ class AgenticTool(BaseTool):
 
     # ------------------------------------------------------------------ LLM utilities -----------
     def _validate_model_config(self):
-        supported_api_types = ["CHATGPT", "OPENAI", "OPENROUTER", "GEMINI", "VLLM"]
+        supported_api_types = ["CHATGPT", "OPENAI", "OPENROUTER", "ORCAROUTER", "GEMINI", "VLLM"]
         if self._api_type not in supported_api_types:
             raise ValueError(
                 f"Unsupported API type: {self._api_type}. Supported types: {supported_api_types}"
@@ -664,6 +668,8 @@ class AgenticTool(BaseTool):
                 self._llm_client = OpenAICompatibleClient(self._model_id, self.logger)
             elif self._api_type == "OPENROUTER":
                 self._llm_client = OpenRouterClient(self._model_id, self.logger)
+            elif self._api_type == "ORCAROUTER":
+                self._llm_client = OrcaRouterClient(self._model_id, self.logger)
             elif self._api_type == "GEMINI":
                 self._llm_client = GeminiClient(self._gemini_model_id, self.logger)
             elif self._api_type == "VLLM":

--- a/src/tooluniverse/llm_clients.py
+++ b/src/tooluniverse/llm_clients.py
@@ -1188,6 +1188,205 @@ class OpenRouterClient(BaseLLMClient):
         return None
 
 
+class OrcaRouterClient(BaseLLMClient):
+    """
+    OrcaRouter client using OpenAI SDK with a custom base URL.
+
+    Routes chat completions through the OrcaRouter gateway
+    (https://www.orcarouter.ai), which also runs gateway-level, zero-trust
+    security for AI agents on the same endpoint.
+    """
+
+    # Default model limits based on OrcaRouter's gateway models
+    DEFAULT_MODEL_LIMITS: Dict[str, Dict[str, int]] = {
+        "orcarouter/auto": {"max_output": 32_768, "context_window": 200_000},
+        "orcarouter/fusion": {"max_output": 32_768, "context_window": 1_000_000},
+        "orcarouter/fusion-flash": {"max_output": 32_768, "context_window": 200_000},
+        "orcarouter/fusion-mini": {"max_output": 32_768, "context_window": 1_000_000},
+    }
+
+    def __init__(self, model_id: str, logger):
+        try:
+            from openai import OpenAI as _OpenAI  # type: ignore
+            import openai as _openai  # type: ignore
+        except Exception as e:  # pragma: no cover
+            raise RuntimeError("openai client is not available") from e
+
+        self._OpenAI = _OpenAI
+        self._openai = _openai
+        self.model_name = model_id
+        self.logger = logger
+
+        api_key = os.getenv("ORCAROUTER_API_KEY")
+        if not api_key:
+            raise ValueError("ORCAROUTER_API_KEY not set")
+
+        base_url = os.getenv("ORCAROUTER_BASE_URL") or "https://api.orcarouter.ai/v1"
+
+        self.client = self._OpenAI(
+            base_url=base_url,
+            api_key=api_key,
+            max_retries=0,
+        )
+
+        # Load env overrides for model limits
+        env_limits_raw = os.getenv("ORCAROUTER_DEFAULT_MODEL_LIMITS")
+        self._default_limits: Dict[str, Dict[str, int]] = (
+            self.DEFAULT_MODEL_LIMITS.copy()
+        )
+        if env_limits_raw:
+            try:
+                env_limits = _json.loads(env_limits_raw)
+                for k, v in env_limits.items():
+                    if isinstance(v, dict):
+                        base = self._default_limits.get(k, {}).copy()
+                        base.update(
+                            {
+                                kk: int(vv)
+                                for kk, vv in v.items()
+                                if isinstance(vv, (int, float, str))
+                            }
+                        )
+                        self._default_limits[k] = base
+            except Exception:
+                pass
+
+    def _resolve_default_max_tokens(self, model_id: str) -> Optional[int]:
+        """Resolve default max tokens for a model."""
+        # Highest priority: explicit env per-model tokens mapping
+        mapping_raw = os.getenv("ORCAROUTER_MAX_TOKENS_BY_MODEL")
+        mapping: Dict[str, Any] = {}
+        if mapping_raw:
+            try:
+                mapping = _json.loads(mapping_raw)
+            except Exception:
+                mapping = {}
+
+        if model_id in mapping:
+            try:
+                return int(mapping[model_id])
+            except Exception:
+                pass
+
+        # Check for prefix match
+        for k, v in mapping.items():
+            try:
+                if model_id.startswith(k):
+                    return int(v)
+            except Exception:
+                continue
+
+        # Next: built-in/default-limits map
+        if model_id in self._default_limits:
+            return int(self._default_limits[model_id].get("max_output", 0)) or None
+
+        # Check for prefix match in default limits
+        for k, v in self._default_limits.items():
+            try:
+                if model_id.startswith(k):
+                    return int(v.get("max_output", 0)) or None
+            except Exception:
+                continue
+
+        return None
+
+    def test_api(self) -> None:
+        """Test API connectivity with minimal token usage."""
+        test_messages = [{"role": "user", "content": "ping"}]
+        token_attempts = [1, 4, 16, 32]
+        last_error: Optional[Exception] = None
+
+        for tok in token_attempts:
+            try:
+                self.client.chat.completions.create(
+                    model=self.model_name,
+                    messages=test_messages,
+                    max_tokens=tok,
+                    temperature=0,
+                )
+                return
+            except Exception as e:  # noqa: BLE001
+                last_error = e
+                msg = str(e).lower()
+                if (
+                    "max_tokens" in msg
+                    or "model output limit" in msg
+                    or "finish the message" in msg
+                ) and tok != token_attempts[-1]:
+                    continue
+                break
+
+        if last_error:
+            raise ValueError(f"OrcaRouter API test failed: {last_error}")
+        raise ValueError("OrcaRouter API test failed: unknown error")
+
+    def infer(
+        self,
+        messages: List[Dict[str, str]],
+        temperature: Optional[float],
+        max_tokens: Optional[int],
+        return_json: bool,
+        custom_format: Any = None,
+        max_retries: int = 5,
+        retry_delay: int = 5,
+    ) -> Optional[str]:
+        """Execute inference using OrcaRouter."""
+        retries = 0
+        call_fn = (
+            self.client.chat.completions.parse
+            if custom_format is not None
+            else self.client.chat.completions.create
+        )
+
+        response_format = (
+            custom_format
+            if custom_format is not None
+            else ({"type": "json_object"} if return_json else None)
+        )
+
+        eff_max = (
+            max_tokens
+            if max_tokens is not None
+            else self._resolve_default_max_tokens(self.model_name)
+        )
+
+        while retries < max_retries:
+            try:
+                kwargs: Dict[str, Any] = {
+                    "model": self.model_name,
+                    "messages": messages,
+                }
+
+                if response_format is not None:
+                    kwargs["response_format"] = response_format
+                if temperature is not None:
+                    kwargs["temperature"] = temperature
+                if eff_max is not None:
+                    kwargs["max_tokens"] = eff_max
+
+                resp = call_fn(**kwargs)
+
+                if custom_format is not None:
+                    return resp.choices[0].message.parsed.model_dump()
+                return resp.choices[0].message.content
+
+            except self._openai.RateLimitError:  # type: ignore[attr-defined]
+                self.logger.warning(
+                    f"Rate limit exceeded. Retrying in {retry_delay} seconds..."
+                )
+                retries += 1
+                time.sleep(retry_delay * retries)
+            except Exception as e:  # noqa: BLE001
+                self.logger.error(f"OrcaRouter error: {e}")
+                import traceback
+
+                traceback.print_exc()
+                break
+
+        self.logger.error("Max retries exceeded. Unable to complete the request.")
+        return None
+
+
 class VLLMClient(BaseLLMClient):
     def __init__(self, model_name: str, server_url: str, logger):
         try:

--- a/tests/unit/test_orcarouter_client.py
+++ b/tests/unit/test_orcarouter_client.py
@@ -1,0 +1,159 @@
+"""Tests for the OrcaRouter LLM client integration."""
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+
+from tooluniverse.agentic_tool import AgenticTool
+from tooluniverse.llm_clients import OrcaRouterClient
+
+pytestmark = pytest.mark.unit
+
+
+class FakeRateLimitError(Exception):
+    pass
+
+
+class FakeCompletions:
+    def __init__(self):
+        self.calls = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))]
+        )
+
+
+class FakeOpenAIClient:
+    instances = []
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.completions = FakeCompletions()
+        self.chat = SimpleNamespace(
+            completions=SimpleNamespace(
+                create=self.completions.create,
+                parse=self.completions.create,
+            )
+        )
+        FakeOpenAIClient.instances.append(self)
+
+
+@pytest.fixture(autouse=True)
+def fake_openai(monkeypatch):
+    FakeOpenAIClient.instances = []
+    monkeypatch.setitem(
+        sys.modules,
+        "openai",
+        SimpleNamespace(OpenAI=FakeOpenAIClient, RateLimitError=FakeRateLimitError),
+    )
+    monkeypatch.setenv("ORCAROUTER_API_KEY", "test-key")
+    monkeypatch.delenv("ORCAROUTER_BASE_URL", raising=False)
+    monkeypatch.delenv("ORCAROUTER_DEFAULT_MODEL_LIMITS", raising=False)
+    monkeypatch.delenv("ORCAROUTER_MAX_TOKENS_BY_MODEL", raising=False)
+
+
+def test_client_default_base_url(monkeypatch):
+    client = OrcaRouterClient(
+        "orcarouter/auto",
+        logger=SimpleNamespace(warning=lambda *_: None, error=lambda *_: None),
+    )
+    assert FakeOpenAIClient.instances[0].kwargs["base_url"] == (
+        "https://api.orcarouter.ai/v1"
+    )
+    assert FakeOpenAIClient.instances[0].kwargs["api_key"] == "test-key"
+    assert client.model_name == "orcarouter/auto"
+
+
+def test_client_custom_base_url(monkeypatch):
+    monkeypatch.setenv("ORCAROUTER_BASE_URL", "https://custom.example/v1")
+    OrcaRouterClient(
+        "orcarouter/auto",
+        logger=SimpleNamespace(warning=lambda *_: None, error=lambda *_: None),
+    )
+    assert FakeOpenAIClient.instances[0].kwargs["base_url"] == "https://custom.example/v1"
+
+
+def test_client_missing_api_key(monkeypatch):
+    monkeypatch.delenv("ORCAROUTER_API_KEY")
+    with pytest.raises(ValueError, match="ORCAROUTER_API_KEY not set"):
+        OrcaRouterClient(
+            "orcarouter/auto",
+            logger=SimpleNamespace(warning=lambda *_: None, error=lambda *_: None),
+        )
+
+
+def test_infer_json_object(monkeypatch):
+    client = OrcaRouterClient(
+        "orcarouter/auto",
+        logger=SimpleNamespace(warning=lambda *_: None, error=lambda *_: None),
+    )
+    result = client.infer(
+        messages=[{"role": "user", "content": "ping"}],
+        temperature=0,
+        max_tokens=16,
+        return_json=True,
+        max_retries=1,
+        retry_delay=0,
+    )
+    assert result == "ok"
+    call_kwargs = FakeOpenAIClient.instances[0].completions.calls[0]
+    assert call_kwargs["model"] == "orcarouter/auto"
+    assert call_kwargs["response_format"] == {"type": "json_object"}
+
+
+def test_infer_default_max_tokens(monkeypatch):
+    monkeypatch.setenv("ORCAROUTER_MAX_TOKENS_BY_MODEL", '{"orcarouter/auto": 4096}')
+    client = OrcaRouterClient(
+        "orcarouter/auto",
+        logger=SimpleNamespace(warning=lambda *_: None, error=lambda *_: None),
+    )
+    result = client.infer(
+        messages=[{"role": "user", "content": "ping"}],
+        temperature=None,
+        max_tokens=None,
+        return_json=False,
+        max_retries=1,
+        retry_delay=0,
+    )
+    assert result == "ok"
+    assert FakeOpenAIClient.instances[0].completions.calls[0]["max_tokens"] == 4096
+
+
+def test_agentic_tool_orcarouter_in_supported_types():
+    """ORCAROUTER should be a supported API type and route to OrcaRouterClient."""
+    tool_config = {
+        "name": "Test_Tool",
+        "prompt": "Test: {x}",
+        "input_arguments": ["x"],
+        "parameter": {
+            "type": "object",
+            "properties": {"x": {"type": "string"}},
+            "required": ["x"],
+        },
+        "configs": {
+            "api_type": "ORCAROUTER",
+            "model_id": "orcarouter/auto",
+            "validate_api_key": False,
+        },
+    }
+    with patch("tooluniverse.agentic_tool.OrcaRouterClient") as mock_client_class:
+        mock_client = Mock()
+        mock_client_class.return_value = mock_client
+        mock_client.test_api = Mock()
+        mock_client.infer = Mock(return_value="Test result")
+        tool = AgenticTool(tool_config)
+        assert tool._is_available
+        assert tool._current_api_type == "ORCAROUTER"
+        assert tool._current_model_id == "orcarouter/auto"
+
+
+def test_agentic_tool_requires_key_in_env_vars():
+    """ORCAROUTER_API_KEY should be listed in API_KEY_ENV_VARS."""
+    from tooluniverse.agentic_tool import API_KEY_ENV_VARS
+
+    assert "ORCAROUTER" in API_KEY_ENV_VARS
+    assert API_KEY_ENV_VARS["ORCAROUTER"] == ["ORCAROUTER_API_KEY"]


### PR DESCRIPTION
## Summary

Adds OrcaRouter as a named LLM provider for LLM-backed (agentic) tools, mirroring the existing OpenRouter wiring.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible model gateway. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

What's included:
- **`OrcaRouterClient`** in `src/tooluniverse/llm_clients.py` — OpenAI SDK client with default base URL `https://api.orcarouter.ai/v1`, `ORCAROUTER_API_KEY` / `ORCAROUTER_BASE_URL` env vars, and the smart-routing `orcarouter/auto` model. Mirrors `OpenRouterClient` (retries, JSON-object response, per-model max-token resolution).
- **`ORCAROUTER` `api_type`** wired into `AgenticTool._try_api` / `retry_initialization`, `API_KEY_ENV_VARS`, and the supported-api-types validation list.
- **Docs**: new `guide/orcarouter_support.rst` (registered in `index.rst` + `sitemap.rst`), provider-list updates in `agentic_tools_tutorial.rst`, `api_keys.rst`, `openai_compatible_support.rst`, `.env.template`, and the `setup-tooluniverse` skill's `API_KEYS_REFERENCE.md` (canonical + synced plugin copies).
- **Example** `examples/orcarouter_example.py` and **tests** `tests/unit/test_orcarouter_client.py` (7 unit tests).

## Validation

- [x] `ruff check` passed for touched Python files (E/F; clean main has the same 183 ruff-0.16-only warnings)
- [x] `pytest` passed for relevant unit tests — new OrcaRouter tests 7/7; full unit suite `5423 passed / 52 failed` (same 52 pre-existing env failures as clean main, +7 from the new tests)
- [x] L3 live: `OrcaRouterClient.test_api()` and `infer()` against `https://api.orcarouter.ai/v1` with `orcarouter/auto` return HTTP 200 (`ORCA-LIVE-OK`)

## Checklist

- [x] Linked the relevant issue or described the user-facing problem
- [x] Updated docs, examples, or tool metadata for behavior changes
- [x] Added or updated tests for new tools, providers, or schema behavior
- [x] Avoided committing credentials, cached API responses, or large generated artifacts

---

Disclosure: I'm an engineer on the OrcaRouter team.
