### PR TITLE
Fix: unify legacy auth_env into the http_headers_from_env resolution path

### DIFF
--- a/src/tooluniverse/mcp_client_tool.py
+++ b/src/tooluniverse/mcp_client_tool.py
@@ -111,9 +111,23 @@ class BaseMCPClient:
             raise ValueError("http_headers_from_env must be an object")
 
     def _resolve_http_headers(self) -> Dict[str, str]:
-        """Resolve configured HTTP headers without storing secrets in tool configs."""
+        """Resolve configured HTTP headers without storing secrets in tool configs.
+
+        `auth_env` predates `http_headers_from_env` and is kept as a config-surface
+        alias for it (CLI-saved connections still write `auth_env`), routed through
+        the same validation and re-read fresh on every call instead of once at
+        `__init__`, so a rotated token is picked up without restarting the tool.
+        An explicit `Authorization` entry in `http_headers_from_env` wins if both
+        are set.
+        """
+        mappings = dict(self.http_headers_from_env)
+        if self.auth_env:
+            mappings.setdefault(
+                "Authorization", {"env": self.auth_env, "prefix": "Bearer "}
+            )
+
         headers = {}
-        for header_name, header_config in self.http_headers_from_env.items():
+        for header_name, header_config in mappings.items():
             if (
                 not isinstance(header_name, str)
                 or not header_name

--- a/tests/unit/test_native_remote_tools.py
+++ b/tests/unit/test_native_remote_tools.py
@@ -762,6 +762,44 @@ def test_mcp_auth_env_propagates_without_copying_secret(monkeypatch):
     assert "super-secret" not in json.dumps(proxy)
 
 
+def test_mcp_auth_env_is_reread_on_every_request(monkeypatch):
+    """auth_env is a config-surface alias for http_headers_from_env (unified in
+    _resolve_http_headers), so a rotated token is picked up without restarting
+    the tool -- unlike the `.headers` snapshot taken once at __init__."""
+    monkeypatch.setenv("PRIVATE_MCP_TOKEN", "first-secret")
+    loader = MCPAutoLoaderTool(
+        {
+            "name": "loader",
+            "server_url": "https://gpu.example/mcp",
+            "tool_prefix": "gpu_",
+            "auth_env": "PRIVATE_MCP_TOKEN",
+        }
+    )
+    assert loader._resolve_http_headers() == {"Authorization": "Bearer first-secret"}
+
+    monkeypatch.setenv("PRIVATE_MCP_TOKEN", "rotated-secret")
+    assert loader._resolve_http_headers() == {"Authorization": "Bearer rotated-secret"}
+
+
+def test_explicit_http_headers_from_env_authorization_wins_over_auth_env(
+    monkeypatch,
+):
+    monkeypatch.setenv("PRIVATE_MCP_TOKEN", "legacy-secret")
+    monkeypatch.setenv("REVIEWED_TOKEN", "reviewed-secret")
+    loader = MCPAutoLoaderTool(
+        {
+            "name": "loader",
+            "server_url": "https://gpu.example/mcp",
+            "tool_prefix": "gpu_",
+            "auth_env": "PRIVATE_MCP_TOKEN",
+            "http_headers_from_env": {
+                "Authorization": {"env": "REVIEWED_TOKEN", "prefix": "Bearer "}
+            },
+        }
+    )
+    assert loader._resolve_http_headers() == {"Authorization": "Bearer reviewed-secret"}
+
+
 def test_mcp_proxy_unwraps_standard_text_and_error_results():
     assert _unwrap_mcp_tool_result(
         {


### PR DESCRIPTION
## Why

`BaseMCPClient` ended up with two independent HTTP-header mechanisms from two
branches merged back to back:

- `headers` / `auth_env` -- static, resolved once at `__init__`, wired through
  `tu mcp connect --auth-env` and the saved-connection format
- `http_headers_from_env` -- dynamic, resolved fresh on every request, with
  stricter CRLF/env-name validation (added for the Genomic Intelligence
  contract-hardening work in #409)

Both were kept when #409's merge conflict with `main` was resolved, since
dropping either would have broken already-shipped, already-tested behavior.
This is the promised follow-up: unify the *resolution*, not the config
surface. #409 has since merged, so this is now a plain two-file diff against
`main`.

## What changed

`auth_env` is now a config-surface alias that gets routed into the same
validated, per-request resolution as `http_headers_from_env`. Concretely:
`auth_env="X"` behaves as an implicit `{"Authorization": {"env": "X", "prefix":
"Bearer "}}` entry inside `_resolve_http_headers()`, unless `http_headers_from_env`
already defines its own `Authorization` entry (that one wins).

**No public config keys, saved-connection format, or CLI flow changed.**
`headers`, `auth_env`, and `http_headers_from_env` all keep behaving exactly as
documented and tested today. The only observable difference: a rotated
`auth_env` token is now picked up on the next request without restarting the
tool, since resolution happens fresh per call instead of once at `__init__`
(the static `.headers` snapshot is untouched, so anything reading that
attribute directly still sees the value captured at construction time).

## Verification

- 61 existing tests across `test_mcp_contract_hardening.py`,
  `test_native_remote_tools.py`, and `test_mcp_auto_loader_gi_config.py` pass
  unchanged
- Two new tests added: token rotation is picked up on the next
  `_resolve_http_headers()` call, and an explicit `http_headers_from_env`
  `Authorization` entry takes precedence over a legacy `auth_env`
- `ruff check` / `ruff format --check` clean at the CI-pinned version (0.15.22)