### PR TITLE
feat: add Folklore Clinical Variant Interpretation MCP loader

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -110,6 +110,10 @@ FDA_API_KEY=
 # Without: Falls back to a shared, rate-limited DEMO_KEY without it.
 FDC_API_KEY=
 
+# FOLKLORE_MCP_URL (required) — Endpoint URL for the opt-in Folklore Clinical Variant Interpretation MCP connection. (https://folklore.helena.bio/integrations)
+# Without: Leave blank to keep this third-party MCP connection disabled. The public read-only endpoint is https://api.helena.bio/folklore/v1/mcp and requires no authentication.
+FOLKLORE_MCP_URL=
+
 # ICD_CLIENT_ID (optional) — WHO ICD-11 API client ID (OAuth) for disease classification lookups. (https://icd.who.int/icdapi)
 # Without: ICD-11 tools are blocked without it (paired with the client secret).
 ICD_CLIENT_ID=

--- a/src/tooluniverse/data/api_keys_catalog.json
+++ b/src/tooluniverse/data/api_keys_catalog.json
@@ -254,6 +254,18 @@
     ]
   },
   {
+    "name": "FOLKLORE_MCP_URL",
+    "requirement": "required",
+    "type": "endpoint",
+    "domain": "Clinical & Safety",
+    "register_url": "https://folklore.helena.bio/integrations",
+    "purpose": "Endpoint URL for the opt-in Folklore Clinical Variant Interpretation MCP connection.",
+    "without": "Leave blank to keep this third-party MCP connection disabled. The public read-only endpoint is https://api.helena.bio/folklore/v1/mcp and requires no authentication.",
+    "used_by": [
+      "mcp_auto_loader_folklore.json"
+    ]
+  },
+  {
     "name": "GEMINI_API_KEY",
     "requirement": "optional",
     "type": "secret",

--- a/src/tooluniverse/data/mcp_auto_loader_folklore.json
+++ b/src/tooluniverse/data/mcp_auto_loader_folklore.json
@@ -1,0 +1,113 @@
+[
+  {
+    "name": "mcp_auto_loader_folklore",
+    "description": "Opt-in connection to Folklore Clinical Variant Interpretation MCP, published by Helena Bioinformatics. Discovers four reviewed, read-only tools for public GRCh38 germline variant evidence and source-linked literature. The service accepts no patient, phenotype, family, segregation, or private case data. Results require qualified professional review and are not diagnoses or treatment recommendations.",
+    "type": "MCPAutoLoaderTool",
+    "tool_prefix": "folklore_",
+    "server_url": "${FOLKLORE_MCP_URL}",
+    "transport": "http",
+    "timeout": 30,
+    "strict_tool_contracts": true,
+    "normalize_mcp_result": true,
+    "require_structured_content": true,
+    "mcp_structured_error_field": "adapter_error",
+    "selected_tools": [
+      "search_variant_evidence",
+      "search_variant_literature",
+      "get_publication_details",
+      "search_literature_corpus"
+    ],
+    "tool_contracts": [
+      {
+        "name": "search_variant_evidence",
+        "title": "Classify a germline variant with Folklore",
+        "description": "Resolve one public GRCh38 germline nuclear SNV or simple indel smaller than 50 bp. Returns normalized identity, automated ACMG/AMP decision support, evidence, provenance, and explicit limitations. Do not send patient or case context. Results require qualified professional review and are not diagnoses or treatment recommendations. Never select a candidate when the result is ambiguous.",
+        "contract_sha256": "7a537fea79ae459ada1ef188e0b84147b35aead716295b423a0d8c7173e5d42f",
+        "annotations": {
+          "readOnlyHint": true,
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": false
+        }
+      },
+      {
+        "name": "search_variant_literature",
+        "title": "Find literature for a germline variant",
+        "description": "Resolve one public GRCh38 germline variant and retrieve source-linked publications from Folklore's PubMed-derived genetics corpus. Exact variant mentions precede broader gene associations. Associations do not establish causality, pathogenicity, or a diagnosis and do not change the ACMG/AMP classification.",
+        "contract_sha256": "999ec1ddb4ea413fe8a22df866086e0fa94f5e5f8027e6fbb6a1faabb38174d8",
+        "annotations": {
+          "readOnlyHint": true,
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": false
+        }
+      },
+      {
+        "name": "get_publication_details",
+        "title": "Get details for a PubMed publication",
+        "description": "Retrieve one complete public bibliographic record by PMID from Folklore's PubMed-derived genetics corpus, including abstract, authors, publication metadata, gene and variant mentions, retraction status, and source links. This read-only literature evidence contains no patient context.",
+        "contract_sha256": "7f91cb6ac7c93b9a59116ab81aa74620b9eff248a66a29da2c0e3847c4f9017b",
+        "annotations": {
+          "readOnlyHint": true,
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": false
+        }
+      },
+      {
+        "name": "search_literature_corpus",
+        "title": "Search the Folklore Literature Corpus",
+        "description": "Search source-linked scientific literature by natural-language question or exact PMID, DOI, PMCID, gene, variant, phenotype, HPO, or OMIM query. Include every known publication identifier when comparing papers. Results are evidence candidates for professional review, not diagnoses, causality claims, or treatment recommendations.",
+        "contract_sha256": "3f48a079fcef31724f35ac5cd22051f208194eba9fab38b0a90de9b478d70186",
+        "annotations": {
+          "readOnlyHint": true,
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": false
+        }
+      }
+    ],
+    "required_api_keys": [
+      "FOLKLORE_MCP_URL"
+    ],
+    "api_key_info": {
+      "FOLKLORE_MCP_URL": {
+        "domain": "Clinical & Safety",
+        "type": "endpoint",
+        "register_url": "https://folklore.helena.bio/integrations",
+        "purpose": "Endpoint URL for the opt-in Folklore Clinical Variant Interpretation MCP connection.",
+        "without": "Leave blank to keep this third-party MCP connection disabled. The public read-only endpoint is https://api.helena.bio/folklore/v1/mcp and requires no authentication."
+      }
+    },
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "operation": {
+          "type": "string",
+          "enum": [
+            "discover",
+            "generate_configs",
+            "call_tool"
+          ],
+          "description": "Discover reviewed tools, generate proxy configurations, or call one reviewed tool."
+        },
+        "tool_name": {
+          "type": "string",
+          "description": "Reviewed MCP tool name, required when operation is call_tool."
+        },
+        "tool_arguments": {
+          "type": "object",
+          "description": "Public variant-level or literature arguments for the selected tool. Never include patient or private case data."
+        }
+      },
+      "required": [
+        "operation"
+      ]
+    },
+    "return_schema": {
+      "type": "object",
+      "description": "Reviewed Folklore Clinical Variant Interpretation MCP discovery data or structured tool result.",
+      "additionalProperties": true
+    }
+  }
+]

--- a/src/tooluniverse/data/mcp_auto_loader_folklore.json
+++ b/src/tooluniverse/data/mcp_auto_loader_folklore.json
@@ -58,7 +58,7 @@
         "name": "search_literature_corpus",
         "title": "Search the Folklore Literature Corpus",
         "description": "Search source-linked scientific literature by natural-language question or exact PMID, DOI, PMCID, gene, variant, phenotype, HPO, or OMIM query. Include every known publication identifier when comparing papers. Results are evidence candidates for professional review, not diagnoses, causality claims, or treatment recommendations.",
-        "contract_sha256": "1bcff02b31b1b92ac225b3869e01089fa82f3cc3395c4659a327fd90373ed05d",
+        "contract_sha256": "6e09be489f4d1a5d25652df12ca0ec0924d8fc27f4c940e31528dd1ea22d776e",
         "annotations": {
           "readOnlyHint": true,
           "destructiveHint": false,

--- a/src/tooluniverse/data/mcp_auto_loader_folklore.json
+++ b/src/tooluniverse/data/mcp_auto_loader_folklore.json
@@ -20,8 +20,8 @@
     "tool_contracts": [
       {
         "name": "search_variant_evidence",
-        "title": "Classify a germline variant with Folklore",
-        "description": "Resolve one public GRCh38 germline nuclear SNV or simple indel smaller than 50 bp. Returns normalized identity, automated ACMG/AMP decision support, evidence, provenance, and explicit limitations. Do not send patient or case context. Results require qualified professional review and are not diagnoses or treatment recommendations. Never select a candidate when the result is ambiguous.",
+        "title": "Classify or interpret a germline variant under ACMG/AMP",
+        "description": "Use when a user asks to classify or interpret pathogenicity, review a VUS, check available ClinVar assertions or population-frequency evidence, or resolve a variant notation. Resolve one public GRCh38 germline nuclear SNV or simple indel smaller than 50 bp. Returns normalized identity, automated ACMG/AMP decision support, evidence, provenance and explicit limitations. Do not send patient or case context. Results require qualified professional review and are not diagnoses or treatment recommendations. Never select a candidate when the result is ambiguous.",
         "contract_sha256": "7a537fea79ae459ada1ef188e0b84147b35aead716295b423a0d8c7173e5d42f",
         "annotations": {
           "readOnlyHint": true,
@@ -58,7 +58,7 @@
         "name": "search_literature_corpus",
         "title": "Search the Folklore Literature Corpus",
         "description": "Search source-linked scientific literature by natural-language question or exact PMID, DOI, PMCID, gene, variant, phenotype, HPO, or OMIM query. Include every known publication identifier when comparing papers. Results are evidence candidates for professional review, not diagnoses, causality claims, or treatment recommendations.",
-        "contract_sha256": "3f48a079fcef31724f35ac5cd22051f208194eba9fab38b0a90de9b478d70186",
+        "contract_sha256": "1bcff02b31b1b92ac225b3869e01089fa82f3cc3395c4659a327fd90373ed05d",
         "annotations": {
           "readOnlyHint": true,
           "destructiveHint": false,

--- a/src/tooluniverse/default_config.py
+++ b/src/tooluniverse/default_config.py
@@ -354,6 +354,9 @@ default_tool_files = {
         current_dir, "data", "mcp_auto_loader_esm.json"
     ),
     "mcp_auto_loader_gi": os.path.join(current_dir, "data", "mcp_auto_loader_gi.json"),
+    "mcp_auto_loader_folklore": os.path.join(
+        current_dir, "data", "mcp_auto_loader_folklore.json"
+    ),
     "cryoet": os.path.join(current_dir, "data", "cryoet_tools.json"),
     "esm": os.path.join(current_dir, "data", "esm_tools.json"),
     "structure_annotation": os.path.join(

--- a/tests/integration/test_mcp_auto_loader_folklore_live.py
+++ b/tests/integration/test_mcp_auto_loader_folklore_live.py
@@ -29,7 +29,13 @@ async def test_folklore_reviewed_tools_match_live_contract_and_return_boundaries
         "search_variant_evidence",
         {
             "assembly": "GRCh38",
-            "query": "chr17:43045705:A:G",
+            # BRCA1 is minus-strand; the reference genome's plus-strand base at
+            # this position is T, not A (A is T's complement). The previous
+            # A:G here was written in BRCA1's gene-strand orientation, so the
+            # server correctly rejected it (reference_mismatch) rather than
+            # resolving it -- this always returned invalid_request instead of
+            # exercising the resolved path this test claims to cover.
+            "query": "chr17:43045705:T:C",
         },
     )
     structured = response["structuredContent"]

--- a/tests/integration/test_mcp_auto_loader_folklore_live.py
+++ b/tests/integration/test_mcp_auto_loader_folklore_live.py
@@ -1,0 +1,57 @@
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+from tooluniverse.default_config import default_tool_files
+from tooluniverse.mcp_client_tool import MCPAutoLoaderTool
+
+PUBLIC_ENDPOINT = "https://api.helena.bio/folklore/v1/mcp"
+
+
+@pytest.mark.integration
+@pytest.mark.network
+@pytest.mark.mcp
+@pytest.mark.asyncio
+async def test_folklore_reviewed_tools_match_live_contract_and_return_boundaries():
+    config_path = Path(default_tool_files["mcp_auto_loader_folklore"])
+    config = copy.deepcopy(json.loads(config_path.read_text())[0])
+    config["server_url"] = PUBLIC_ENDPOINT
+
+    loader = MCPAutoLoaderTool(config)
+    tools = await loader.discover_tools()
+
+    assert list(tools) == config["selected_tools"]
+    assert all(tool["annotations"]["readOnlyHint"] for tool in tools.values())
+
+    response = await loader.call_tool(
+        "search_variant_evidence",
+        {
+            "assembly": "GRCh38",
+            "query": "chr17:43045705:A:G",
+        },
+    )
+    structured = response["structuredContent"]
+
+    assert structured["contract_version"] == "1"
+    assert structured["adapter_error"] is None
+    assert structured["result"]["status"] in {
+        "resolved",
+        "ambiguous",
+        "not_found",
+        "invalid_request",
+        "unsupported",
+        "resolution_unavailable",
+    }
+    assert structured["usage_boundary"] == {
+        "result_type": "automated_variant_level_classification",
+        "review_required": True,
+        "patient_context_evaluated": False,
+        "intended_use": "professional_variant_review",
+        "not_for": [
+            "patient_diagnosis",
+            "treatment_decision",
+            "standalone_clinical_reporting",
+        ],
+    }

--- a/tests/unit/test_mcp_auto_loader_folklore_config.py
+++ b/tests/unit/test_mcp_auto_loader_folklore_config.py
@@ -1,0 +1,79 @@
+import json
+from pathlib import Path
+
+from tooluniverse.default_config import default_tool_files
+
+EXPECTED_TOOLS = {
+    "search_variant_evidence",
+    "search_variant_literature",
+    "get_publication_details",
+    "search_literature_corpus",
+}
+
+EXPECTED_CONTRACT_HASHES = {
+    "search_variant_evidence": (
+        "7a537fea79ae459ada1ef188e0b84147b35aead716295b423a0d8c7173e5d42f"
+    ),
+    "search_variant_literature": (
+        "999ec1ddb4ea413fe8a22df866086e0fa94f5e5f8027e6fbb6a1faabb38174d8"
+    ),
+    "get_publication_details": (
+        "7f91cb6ac7c93b9a59116ab81aa74620b9eff248a66a29da2c0e3847c4f9017b"
+    ),
+    "search_literature_corpus": (
+        "3f48a079fcef31724f35ac5cd22051f208194eba9fab38b0a90de9b478d70186"
+    ),
+}
+
+
+def test_folklore_loader_is_opt_in_allowlisted_and_contract_pinned():
+    config_path = Path(default_tool_files["mcp_auto_loader_folklore"])
+    config = json.loads(config_path.read_text())[0]
+
+    assert config["server_url"] == "${FOLKLORE_MCP_URL}"
+    assert config["required_api_keys"] == ["FOLKLORE_MCP_URL"]
+    assert config["tool_prefix"] == "folklore_"
+    assert config["timeout"] == 30
+    assert set(config["selected_tools"]) == EXPECTED_TOOLS
+    assert len(config["selected_tools"]) == len(EXPECTED_TOOLS)
+    assert config["strict_tool_contracts"] is True
+    assert config["normalize_mcp_result"] is True
+    assert config["require_structured_content"] is True
+    assert config["mcp_structured_error_field"] == "adapter_error"
+    assert "authentication" in config["api_key_info"]["FOLKLORE_MCP_URL"]["without"]
+
+    contracts = {contract["name"]: contract for contract in config["tool_contracts"]}
+    assert set(contracts) == EXPECTED_TOOLS
+    assert {
+        name: contract["contract_sha256"] for name, contract in contracts.items()
+    } == EXPECTED_CONTRACT_HASHES
+    assert all(
+        contract["annotations"]["readOnlyHint"] for contract in contracts.values()
+    )
+    assert all(
+        not contract["annotations"]["destructiveHint"]
+        for contract in contracts.values()
+    )
+    assert "professional review" in contracts["search_variant_evidence"]["description"]
+    assert "do not change" in contracts["search_variant_literature"]["description"]
+    assert "no patient context" in contracts["get_publication_details"]["description"]
+    assert "professional review" in contracts["search_literature_corpus"]["description"]
+
+
+def test_folklore_loader_copy_preserves_clinical_and_data_boundaries():
+    config_path = Path(default_tool_files["mcp_auto_loader_folklore"])
+    config = json.loads(config_path.read_text())[0]
+    copy = " ".join(
+        [config["description"]]
+        + [contract["description"] for contract in config["tool_contracts"]]
+        + [
+            config["parameter"]["properties"]["tool_arguments"]["description"],
+        ]
+    ).lower()
+
+    assert "helena bioinformatics" in copy
+    assert "patient" in copy
+    assert "private case" in copy
+    assert "not diagnoses" in copy
+    assert "treatment recommendation" in copy
+    assert "ambiguous" in copy

--- a/tests/unit/test_mcp_auto_loader_folklore_config.py
+++ b/tests/unit/test_mcp_auto_loader_folklore_config.py
@@ -21,7 +21,7 @@ EXPECTED_CONTRACT_HASHES = {
         "7f91cb6ac7c93b9a59116ab81aa74620b9eff248a66a29da2c0e3847c4f9017b"
     ),
     "search_literature_corpus": (
-        "1bcff02b31b1b92ac225b3869e01089fa82f3cc3395c4659a327fd90373ed05d"
+        "6e09be489f4d1a5d25652df12ca0ec0924d8fc27f4c940e31528dd1ea22d776e"
     ),
 }
 

--- a/tests/unit/test_mcp_auto_loader_folklore_config.py
+++ b/tests/unit/test_mcp_auto_loader_folklore_config.py
@@ -21,7 +21,7 @@ EXPECTED_CONTRACT_HASHES = {
         "7f91cb6ac7c93b9a59116ab81aa74620b9eff248a66a29da2c0e3847c4f9017b"
     ),
     "search_literature_corpus": (
-        "3f48a079fcef31724f35ac5cd22051f208194eba9fab38b0a90de9b478d70186"
+        "1bcff02b31b1b92ac225b3869e01089fa82f3cc3395c4659a327fd90373ed05d"
     ),
 }
 
@@ -55,6 +55,17 @@ def test_folklore_loader_is_opt_in_allowlisted_and_contract_pinned():
         for contract in contracts.values()
     )
     assert "professional review" in contracts["search_variant_evidence"]["description"]
+    assert contracts["search_variant_evidence"]["title"] == (
+        "Classify or interpret a germline variant under ACMG/AMP"
+    )
+    for trigger in (
+        "pathogenicity",
+        "VUS",
+        "ClinVar assertions",
+        "population-frequency evidence",
+        "resolve a variant notation",
+    ):
+        assert trigger in contracts["search_variant_evidence"]["description"]
     assert "do not change" in contracts["search_variant_literature"]["description"]
     assert "no patient context" in contracts["get_publication_details"]["description"]
     assert "professional review" in contracts["search_literature_corpus"]["description"]


### PR DESCRIPTION
## Summary

- add an opt-in ToolUniverse profile for Folklore Clinical Variant Interpretation MCP, published by Helena Bioinformatics
- allowlist and contract-pin its four read-only variant-evidence and literature tools
- normalize structured MCP results and fail closed if a reviewed input or output schema changes
- add generated endpoint metadata, isolated configuration tests, and an opt-in live contract test

## Why

ToolUniverse already supports reviewed remote MCP profiles and scientific tool composition. This contribution lets an agent add source-linked public variant evidence and literature to those workflows without copying clinical resolver, evidence-aggregation, or ACMG/AMP logic into ToolUniverse.

The connection remains explicit. Users enable it by setting:

```text
FOLKLORE_MCP_URL=https://api.helena.bio/folklore/v1/mcp
```

The discovered tools receive a `folklore_` prefix to avoid collisions:

- `folklore_search_variant_evidence`
- `folklore_search_variant_literature`
- `folklore_get_publication_details`
- `folklore_search_literature_corpus`

No authentication header or credential is required.

## Safety boundary

Folklore Clinical Variant Interpretation MCP accepts one public GRCh38 germline nuclear SNV or simple indel smaller than 50 bp for variant-level queries. It does not accept patient, phenotype, family, segregation, or private case data. It does not support automatic selection of an ambiguous candidate.

Results provide automated ACMG/AMP decision support and source-linked evidence for qualified professional review. They are not diagnoses, treatment recommendations, or standalone clinical reports. Literature associations do not establish causality or change the returned ACMG/AMP classification.

The public Apache-2.0 adapter and contract are available at https://github.com/helena-bioinformatics/folklore-mcp. The connector instructions are at https://folklore.helena.bio/integrations.

## Validation

- [x] `ruff check` passed for the touched Python tests
- [x] relevant configuration and reviewed-MCP hardening tests passed: 14 tests
- [x] the opt-in live network test passed against the public endpoint
- [x] contract hashes were reproduced from the live public `tools/list` response
- [x] generated endpoint catalog and `.env.template` are synchronized
- [x] the live test is marked `network`, so default CI does not depend on an external service

## Checklist

- [x] Linked the relevant user-facing problem in this description
- [x] Updated endpoint metadata for the new opt-in connection
- [x] Added isolated configuration and live contract tests
- [x] Kept network tests out of default CI
- [x] Avoided credentials, cached responses, private data, and large generated artifacts

Disclosure: I am submitting this contribution on behalf of Helena Bioinformatics, the publisher of Folklore Clinical Variant Interpretation MCP.
