### PR TITLE
fix(mcpb): declare openpyxl for bundled Excel tools

### DIFF
--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "rcsb-api>=1.4.0",
     "scipy>=1.7.0",
     "pandas>=2.2.3",
+    "openpyxl>=3.1.0", # Read .xlsx bulk downloads (CellMarker, dataset tools)
     "setuptools>=70.0.0",
     "pdfplumber>=0.11.0",
     "playwright>=1.55.0",

--- a/tests/unit/test_packaging_dependencies.py
+++ b/tests/unit/test_packaging_dependencies.py
@@ -47,13 +47,6 @@ FORBIDDEN_DISTRIBUTIONS = {
     "fitz": "pymupdf",
 }
 
-# mcpb/pyproject.toml documents itself as a mirror of the root dependency list.
-# Anything intentionally left out of the bundle belongs here with a reason.
-KNOWN_MCPB_OMISSIONS = {
-    # Not currently bundled; tracked separately from the pymupdf migration.
-    "openpyxl",
-}
-
 # Dependencies the bundle declares on purpose that the root list leaves to an
 # extra. The bundle is a sealed Claude Desktop runtime: the end user cannot
 # install an extra into it, so anything optional upstream must be unconditional
@@ -131,11 +124,11 @@ def test_mcpb_dependencies_mirror_root():
     root = set(root_requirements)
     mcpb = set(mcpb_requirements)
 
-    missing = root - mcpb - KNOWN_MCPB_OMISSIONS
+    missing = root - mcpb
     assert not missing, (
         f"mcpb/pyproject.toml is missing dependencies present in the root "
-        f"pyproject.toml: {sorted(missing)}. Add them, or record them in "
-        f"KNOWN_MCPB_OMISSIONS with a reason."
+        f"pyproject.toml: {sorted(missing)}. Add them to the bundle dependency "
+        f"list."
     )
 
     extra = mcpb - root - KNOWN_MCPB_ADDITIONS


### PR DESCRIPTION
## Summary

- declare `openpyxl` directly in the standalone MCPB dependency list
- remove the packaging-test exception so MCPB continues mirroring root runtime dependencies

## Why

The MCPB bundle includes tools that call `pandas.read_excel()`, while its
standalone project metadata omitted the required Excel engine. `openpyxl`
currently arrives transitively through an unrelated MarkItDown extra, making
these tools dependent on an implementation detail of another package.

The root ToolUniverse package already declares `openpyxl>=3.1.0` directly.
Mirroring that requirement makes the sealed Claude Desktop runtime explicit
and prevents future dependency changes from breaking XLSX-backed tools.

## Validation

- [x] `pytest tests/unit/test_packaging_dependencies.py` — 6 passed, 1 optional PyMuPDF test skipped
- [x] `ruff check tests/unit/test_packaging_dependencies.py`
- [x] `ruff format --check tests/unit/test_packaging_dependencies.py`
- [x] `git diff --check`
- [x] built the MCPB wheel and confirmed `Requires-Dist: openpyxl>=3.1.0`

## Checklist

- [x] Described the user-facing dependency problem
- [x] No tool metadata or generated SDK files changed
- [x] No credentials, cached responses, or generated artifacts committed
