### PR TITLE
Fix: raise timeout for two live-API ComposeTool integration tests

### DIFF
--- a/tests/integration/test_compose_tool.py
+++ b/tests/integration/test_compose_tool.py
@@ -252,6 +252,7 @@ def test_config_file_tools(tooluni):
         engine.close()
 
 
+@pytest.mark.timeout(180)
 def test_external_file_tools(tooluni):
     """
     Test additional ComposeTool functionality
@@ -260,6 +261,13 @@ def test_external_file_tools(tooluni):
     1. Additional composite tools from configuration
     2. Testing ProteinFunctionAnalyzer and LiteratureMetaAnalyzer
     3. Demonstrate complex biomedical analysis workflows
+
+    Runs every loaded ComposeTool (not just the two named above), each of
+    which may make a live external API call, so total runtime scales with
+    however many compose tools exist in the repo -- it grows over time and
+    the global 60s default (pytest.ini) has repeatedly been too tight for it
+    under CI's parallel (-n auto) load, where several workers can be
+    contending for the same rate-limited external services at once.
     """
     print("\nTesting additional composite tools")
     print("=" * 40)
@@ -330,6 +338,7 @@ def test_external_file_tools(tooluni):
         engine.close()
 
 
+@pytest.mark.timeout(180)
 def test_dependency_auto_loading(tooluni):
     """
     Test ComposeTool automatic dependency loading functionality
@@ -339,6 +348,10 @@ def test_dependency_auto_loading(tooluni):
     2. Auto-loading of missing tool categories
     3. Error handling for unavailable tools
     4. Configuration options for dependency behavior
+
+    Calls the live EuropePMC API through call_tool(); see
+    test_external_file_tools above for why this needs more than the
+    pytest.ini default under CI's parallel load.
     """
     print("\nTesting automatic dependency loading functionality")
     print("=" * 40)


### PR DESCRIPTION
## Problem

\`test_external_file_tools\` and \`test_dependency_auto_loading\` in
\`tests/integration/test_compose_tool.py\` make real external API calls --
the first runs every loaded ComposeTool (including ones that call live
biomedical APIs), the second calls EuropePMC through \`call_tool\`. Both ran
under \`pytest.ini\`'s global 60s default.

Three unrelated PRs (#529, #548, #550 -- a packaging change, an LLM
provider addition, and an MCP loader addition) all hit this same timeout
in CI this week, on two different tests within the same file, across
otherwise-passing runs. Confirmed unrelated to any of their diffs.

## Root cause

\`test_external_file_tools\` iterates every ComposeTool loaded from
\`compose_tools.json\`, so its total runtime scales with however many
compose tools exist -- it only grows as the repo grows. Under CI's
parallel (\`-n auto\`) execution, several workers can also end up
contending for the same rate-limited external service at once.

Measured locally: the two tests together take **71.8s wall-clock** against
a combined 120s budget (60s x 2), with only ~2s of that being actual CPU
time -- almost all of it is waiting on network I/O.

## Fix

Gave both tests a **180s** per-test timeout via \`@pytest.mark.timeout\`,
well clear of the observed worst case.

Considered marking both \`@pytest.mark.network\` instead --
\`pytest.ini\`'s default \`addopts\` already excludes that marker from the
main \`Run core tests\` CI job. But the only other job that runs
(\`workflow_dispatch\`-only) doesn't execute \`tests/integration/\` at all,
so that would have silently dropped both tests from CI coverage entirely
rather than fixing the flakiness.

## Validation

- both tests pass individually and together, sequentially and under
  \`-n 4\` parallel execution
- \`ruff check\` clean on the modified file
- no other test in the file touches live APIs or needed the same treatment