### PR TITLE
Add Noodle Biomedical Literature Discovery MCP

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -110,6 +110,10 @@ FDA_API_KEY=
 # Without: Falls back to a shared, rate-limited DEMO_KEY without it.
 FDC_API_KEY=
 
+# NOODLE_MCP_URL (required) — Endpoint URL for the opt-in Noodle Biomedical Literature Discovery MCP connection. (https://noodle.helena.bio/integrations)
+# Without: Leave blank to keep this third-party MCP connection disabled. The public read-only endpoint is https://api.helena.bio/noodle/v1/mcp and requires no authentication.
+NOODLE_MCP_URL=
+
 # ICD_CLIENT_ID (optional) — WHO ICD-11 API client ID (OAuth) for disease classification lookups. (https://icd.who.int/icdapi)
 # Without: ICD-11 tools are blocked without it (paired with the client secret).
 ICD_CLIENT_ID=

--- a/src/tooluniverse/data/api_keys_catalog.json
+++ b/src/tooluniverse/data/api_keys_catalog.json
@@ -254,6 +254,18 @@
     ]
   },
   {
+    "name": "NOODLE_MCP_URL",
+    "requirement": "required",
+    "type": "endpoint",
+    "domain": "Literature & Evidence",
+    "register_url": "https://noodle.helena.bio/integrations",
+    "purpose": "Endpoint URL for the opt-in Noodle Biomedical Literature Discovery MCP connection.",
+    "without": "Leave blank to keep this third-party MCP connection disabled. The public read-only endpoint is https://api.helena.bio/noodle/v1/mcp and requires no authentication.",
+    "used_by": [
+      "mcp_auto_loader_noodle.json"
+    ]
+  },
+  {
     "name": "GEMINI_API_KEY",
     "requirement": "optional",
     "type": "secret",

--- a/src/tooluniverse/data/mcp_auto_loader_noodle.json
+++ b/src/tooluniverse/data/mcp_auto_loader_noodle.json
@@ -1,0 +1,101 @@
+[
+  {
+    "name": "mcp_auto_loader_noodle",
+    "description": "Opt-in connection to Noodle Biomedical Literature Discovery MCP, published by Helena Bioinformatics. Discovers six reviewed, read-only tools for PubMed-derived biomedical literature search, publication details, corpus metadata, and bounded citation or semantic graph traversal. Search rank, citation proximity, semantic similarity, and graph distance are discovery signals, not evidence of causality, scientific validity, diagnosis, or treatment.",
+    "type": "MCPAutoLoaderTool",
+    "tool_prefix": "noodle_",
+    "server_url": "${NOODLE_MCP_URL}",
+    "transport": "http",
+    "timeout": 30,
+    "strict_tool_contracts": true,
+    "normalize_mcp_result": true,
+    "require_structured_content": true,
+    "mcp_structured_error_field": "adapter_error",
+    "selected_tools": [
+      "search_biomedical_literature",
+      "get_publication_details",
+      "get_work_details",
+      "get_publication_neighborhood",
+      "get_work_neighborhood",
+      "get_corpus_summary"
+    ],
+    "tool_contracts": [
+      {
+        "name": "search_biomedical_literature",
+        "title": "Search biomedical literature",
+        "description": "Semantically search Noodle's public PubMed-derived biomedical corpus. Include a known PMID, DOI, or PMCID as an exact anchor when available. Results support literature discovery and professional review, not diagnosis or treatment.",
+        "contract_sha256": "7f9ccd9ddaa845f2e412116ef322b5dc571f767b75ee6b8c346e8e256913f368",
+        "annotations": {"readOnlyHint": true, "destructiveHint": false, "idempotentHint": true, "openWorldHint": false}
+      },
+      {
+        "name": "get_publication_details",
+        "title": "Get publication details by PMID",
+        "description": "Retrieve one source-linked public bibliographic record by PMID after search, including retraction status and available identifiers. Results support literature discovery and professional review, not diagnosis or treatment.",
+        "contract_sha256": "640e336c39dc047c7b56854f27d6acfe1293a130529ff633de5d0efb5e35fde0",
+        "annotations": {"readOnlyHint": true, "destructiveHint": false, "idempotentHint": true, "openWorldHint": false}
+      },
+      {
+        "name": "get_work_details",
+        "title": "Get publication details by work ID",
+        "description": "Retrieve one source-linked public bibliographic record by canonical Noodle work identifier. Results support literature discovery and professional review, not diagnosis or treatment.",
+        "contract_sha256": "6ae98c93cd0ba0878b2d1f7b07ee082f2a94fb0062ca7a92cfdaa25f4274a14d",
+        "annotations": {"readOnlyHint": true, "destructiveHint": false, "idempotentHint": true, "openWorldHint": false}
+      },
+      {
+        "name": "get_publication_neighborhood",
+        "title": "Explore a PMID literature neighborhood",
+        "description": "Retrieve one bounded citation and semantic neighborhood around a PMID. Preserve returned edge types and provenance; graph proximity and semantic similarity are discovery signals, not evidence of causality or scientific validity.",
+        "contract_sha256": "31cc91ee94d10ad4eb112b34ff0b36e14fdb3867c87f9da980e942c0918c3875",
+        "annotations": {"readOnlyHint": true, "destructiveHint": false, "idempotentHint": true, "openWorldHint": false}
+      },
+      {
+        "name": "get_work_neighborhood",
+        "title": "Explore a work literature neighborhood",
+        "description": "Retrieve one bounded citation and semantic neighborhood around a Noodle work identifier. Preserve returned edge types and provenance; graph proximity and semantic similarity are discovery signals, not evidence of causality or scientific validity.",
+        "contract_sha256": "7b0c25725c1c7c7ef848725923d59e59cdaa4231be999e3edf7b56cf312081bd",
+        "annotations": {"readOnlyHint": true, "destructiveHint": false, "idempotentHint": true, "openWorldHint": false}
+      },
+      {
+        "name": "get_corpus_summary",
+        "title": "Get corpus summary",
+        "description": "Return public corpus coverage, source, freshness, active graph metadata, and counts so an agent can state Noodle's current discovery boundary before interpreting search results.",
+        "contract_sha256": "cf03aed706e344baa94da5ff1aa1e7fc0827d23c6e10ec8ebb8e9cf43bf8a590",
+        "annotations": {"readOnlyHint": true, "destructiveHint": false, "idempotentHint": true, "openWorldHint": false}
+      }
+    ],
+    "required_api_keys": ["NOODLE_MCP_URL"],
+    "api_key_info": {
+      "NOODLE_MCP_URL": {
+        "domain": "Literature & Evidence",
+        "type": "endpoint",
+        "register_url": "https://noodle.helena.bio/integrations",
+        "purpose": "Endpoint URL for the opt-in Noodle Biomedical Literature Discovery MCP connection.",
+        "without": "Leave blank to keep this third-party MCP connection disabled. The public endpoint requires no authentication."
+      }
+    },
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "operation": {
+          "type": "string",
+          "enum": ["discover", "generate_configs", "call_tool"],
+          "description": "Discover reviewed tools, generate proxy configurations, or call one reviewed tool."
+        },
+        "tool_name": {
+          "type": "string",
+          "description": "Reviewed MCP tool name, required when operation is call_tool."
+        },
+        "tool_arguments": {
+          "type": "object",
+          "description": "Public literature-search, publication-identifier, graph-neighborhood, or corpus-summary arguments for the selected tool. Never include patient, private case, credential, or private uploaded content."
+        }
+      },
+      "required": ["operation"]
+    },
+    "return_schema": {
+      "type": "object",
+      "description": "Reviewed Noodle Biomedical Literature Discovery MCP discovery data or structured tool result.",
+      "additionalProperties": true
+    }
+  }
+]

--- a/src/tooluniverse/default_config.py
+++ b/src/tooluniverse/default_config.py
@@ -354,6 +354,9 @@ default_tool_files = {
         current_dir, "data", "mcp_auto_loader_esm.json"
     ),
     "mcp_auto_loader_gi": os.path.join(current_dir, "data", "mcp_auto_loader_gi.json"),
+    "mcp_auto_loader_noodle": os.path.join(
+        current_dir, "data", "mcp_auto_loader_noodle.json"
+    ),
     "cryoet": os.path.join(current_dir, "data", "cryoet_tools.json"),
     "esm": os.path.join(current_dir, "data", "esm_tools.json"),
     "structure_annotation": os.path.join(

--- a/tests/integration/test_mcp_auto_loader_noodle_live.py
+++ b/tests/integration/test_mcp_auto_loader_noodle_live.py
@@ -1,0 +1,34 @@
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+from tooluniverse.default_config import default_tool_files
+from tooluniverse.mcp_client_tool import MCPAutoLoaderTool
+
+
+PUBLIC_ENDPOINT = "https://api.helena.bio/noodle/v1/mcp"
+
+
+@pytest.mark.integration
+@pytest.mark.network
+@pytest.mark.mcp
+@pytest.mark.asyncio
+async def test_noodle_reviewed_tools_match_live_contract_and_return_boundaries():
+    config_path = Path(default_tool_files["mcp_auto_loader_noodle"])
+    config = copy.deepcopy(json.loads(config_path.read_text())[0])
+    config["server_url"] = PUBLIC_ENDPOINT
+
+    loader = MCPAutoLoaderTool(config)
+    tools = await loader.discover_tools()
+
+    assert list(tools) == config["selected_tools"]
+    assert all(tool["annotations"]["readOnlyHint"] for tool in tools.values())
+
+    response = await loader.call_tool("get_corpus_summary", {})
+    structured = response["structuredContent"]
+    assert structured["contract_version"] == "1.0"
+    assert structured["counts"]["unique_works"] > 0
+    assert structured["sources"]
+    assert "PubMed" in structured["scope"]

--- a/tests/unit/test_mcp_auto_loader_noodle_config.py
+++ b/tests/unit/test_mcp_auto_loader_noodle_config.py
@@ -1,0 +1,68 @@
+import json
+from pathlib import Path
+
+from tooluniverse.default_config import default_tool_files
+
+
+EXPECTED_HASHES = {
+    "search_biomedical_literature": (
+        "7f9ccd9ddaa845f2e412116ef322b5dc571f767b75ee6b8c346e8e256913f368"
+    ),
+    "get_publication_details": (
+        "640e336c39dc047c7b56854f27d6acfe1293a130529ff633de5d0efb5e35fde0"
+    ),
+    "get_work_details": (
+        "6ae98c93cd0ba0878b2d1f7b07ee082f2a94fb0062ca7a92cfdaa25f4274a14d"
+    ),
+    "get_publication_neighborhood": (
+        "31cc91ee94d10ad4eb112b34ff0b36e14fdb3867c87f9da980e942c0918c3875"
+    ),
+    "get_work_neighborhood": (
+        "7b0c25725c1c7c7ef848725923d59e59cdaa4231be999e3edf7b56cf312081bd"
+    ),
+    "get_corpus_summary": (
+        "cf03aed706e344baa94da5ff1aa1e7fc0827d23c6e10ec8ebb8e9cf43bf8a590"
+    ),
+}
+
+
+def test_noodle_loader_is_opt_in_allowlisted_and_contract_pinned():
+    config_path = Path(default_tool_files["mcp_auto_loader_noodle"])
+    config = json.loads(config_path.read_text())[0]
+    contracts = {item["name"]: item for item in config["tool_contracts"]}
+
+    assert config["server_url"] == "${NOODLE_MCP_URL}"
+    assert config["required_api_keys"] == ["NOODLE_MCP_URL"]
+    assert config["tool_prefix"] == "noodle_"
+    assert config["strict_tool_contracts"] is True
+    assert config["normalize_mcp_result"] is True
+    assert config["require_structured_content"] is True
+    assert config["selected_tools"] == list(EXPECTED_HASHES)
+    assert {
+        name: item["contract_sha256"] for name, item in contracts.items()
+    } == EXPECTED_HASHES
+    assert all(item["annotations"]["readOnlyHint"] for item in contracts.values())
+    assert all(not item["annotations"]["destructiveHint"] for item in contracts.values())
+
+
+def test_noodle_loader_copy_preserves_discovery_and_data_boundaries():
+    config_path = Path(default_tool_files["mcp_auto_loader_noodle"])
+    config = json.loads(config_path.read_text())[0]
+    copy = " ".join(
+        [config["description"]]
+        + [item["description"] for item in config["tool_contracts"]]
+        + [config["parameter"]["properties"]["tool_arguments"]["description"]]
+    ).lower()
+
+    for phrase in (
+        "helena bioinformatics",
+        "pubmed-derived",
+        "citation",
+        "semantic",
+        "provenance",
+        "not evidence of causality",
+        "not diagnosis",
+        "patient",
+        "private case",
+    ):
+        assert phrase in copy


### PR DESCRIPTION
## Summary

Adds **Noodle Biomedical Literature Discovery MCP** as an auto-loaded remote MCP service in ToolUniverse.

Noodle is Helena Bioinformatics' Apache-2.0 public, read-only MCP for source-linked biomedical literature discovery across a PubMed-derived corpus. It supports natural-language and identifier search, publication details, corpus coverage, and bounded citation/semantic graph traversal.

## Changes

- register the hosted Streamable HTTP endpoint in the default configuration;
- add the auto-loader metadata for all six scientific tools;
- document the optional `NOODLE_MCP_API_KEY` environment variable without requiring credentials for public access;
- add configuration validation and live contract tests;
- pin each tool's current contract hash for version 0.2.1.

## Validation

- all JSON files parse successfully;
- the loader exposes exactly six scientific tools;
- all six pinned contract hashes match the live `tools/list` response from `https://api.helena.bio/noodle/v1/mcp`;
- the public endpoint requires no account, API key, or OAuth.

Canonical source: https://github.com/helena-bioinformatics/noodle-mcp  
Product site: https://noodle.helena.bio  
Official MCP Registry identity: `io.github.helena-bioinformatics/noodle`

The full local pytest/ruff suite could not be run in the minimal bundled environment because those modules were not installed; syntax, JSON, diff, and live contract validation passed.