### PR TITLE
Fix: validate Host/Origin headers to close a DNS-rebinding gap (#531)

### DIFF
--- a/src/tooluniverse/http_api_server.py
+++ b/src/tooluniverse/http_api_server.py
@@ -35,7 +35,14 @@ from pydantic import BaseModel, Field
 
 from .execute_function import ToolUniverse
 from .logging_config import get_logger
-from .server_security import enforce_bind_security, get_api_token, token_matches
+from .server_security import (
+    enforce_bind_security,
+    get_api_token,
+    is_loopback_authority,
+    is_loopback_host,
+    is_loopback_origin,
+    token_matches,
+)
 
 logger = get_logger("HTTPAPIServer")
 
@@ -219,6 +226,38 @@ async def require_bearer_token(request, call_next):
                     "error": "Unauthorized: a valid Bearer token is required",
                     "error_type": "AuthenticationError",
                 },
+            )
+    return await call_next(request)
+
+
+@app.middleware("http")
+async def guard_host_and_origin(request, call_next):
+    """Reject requests whose Host/Origin do not name loopback, on loopback binds.
+
+    A server bound to 127.0.0.1 is not automatically safe from remote callers:
+    DNS rebinding lets a malicious webpage resolve its own origin to the
+    loopback address and become an in-browser client of this server, with a
+    ``Host`` header naming the attacker's domain rather than "localhost" and
+    (when the request is a fetch/XHR) an ``Origin`` header to match. This closes
+    that gap independent of whether a Bearer token is configured.
+
+    Skipped once the server is actually bound to a non-loopback interface:
+    that's an explicit operator opt-in that ``enforce_bind_security`` already
+    gates on a Bearer token, and the Host/Origin a legitimate remote caller
+    sends there is not expected to be loopback.
+    """
+    server = request.scope.get("server")
+    if server and is_loopback_host(server[0]):
+        if not is_loopback_authority(request.headers.get("host", "")):
+            return JSONResponse(
+                status_code=421,
+                content={"success": False, "error": "Misdirected Request"},
+            )
+        origin = request.headers.get("origin")
+        if origin and not is_loopback_origin(origin):
+            return JSONResponse(
+                status_code=403,
+                content={"success": False, "error": "Forbidden Origin"},
             )
     return await call_next(request)
 

--- a/src/tooluniverse/server_security.py
+++ b/src/tooluniverse/server_security.py
@@ -5,7 +5,7 @@ HTTP via several entry points: the FastAPI app (``http_api_server``) and the
 FastMCP-based SMCP server (``smcp``). None of these should be reachable over the
 network without authentication.
 
-This module centralizes two controls used by every server entry point:
+This module centralizes three controls used by every server entry point:
 
 1. A Bearer token, read from the ``TOOLUNIVERSE_API_TOKEN`` environment variable.
    When set, callers must present ``Authorization: Bearer <token>`` on every
@@ -17,6 +17,15 @@ This module centralizes two controls used by every server entry point:
    bind address is loopback (``127.0.0.1``); operators must opt in to remote
    exposure *and* set a token to do so.
 
+   Binding to loopback is not, by itself, safe from remote browsers: a
+   malicious webpage can use DNS rebinding to resolve its own origin to
+   127.0.0.1 and become an in-browser client of a loopback-bound server, with
+   a ``Host``/``Origin`` naming the attacker's domain rather than
+   "localhost". :func:`is_loopback_authority` and :func:`is_loopback_origin`
+   let a request-time middleware reject that traffic even when no Bearer
+   token is configured; FastMCP-based servers get the same protection by
+   passing ``host_origin_protection="auto"`` (see :func:`run_fastmcp_server`).
+
 3. Fail-closed FastMCP helpers used by standalone remote-tool servers. When a
    token is configured but FastMCP authentication cannot be initialized, server
    construction raises instead of silently exposing an unauthenticated service.
@@ -25,6 +34,7 @@ This module centralizes two controls used by every server entry point:
 import hmac
 import ipaddress
 import os
+from urllib.parse import urlsplit
 
 API_TOKEN_ENV = "TOOLUNIVERSE_API_TOKEN"
 
@@ -54,6 +64,34 @@ def is_loopback_host(host):
         # A non-literal hostname other than "localhost": treat as remotely
         # reachable so we fail closed rather than open.
         return False
+
+
+def is_loopback_authority(authority):
+    """Return ``True`` if a ``Host``-style ``host[:port]`` value names loopback.
+
+    Used on the request path (not just at bind time): a DNS-rebinding
+    attacker's ``Host`` header carries whatever hostname was resolved to the
+    loopback address (e.g. ``evil.example``), not a loopback literal, so this
+    rejects it even though the connection itself landed on 127.0.0.1.
+    """
+    if not authority or not isinstance(authority, str):
+        return False
+    try:
+        hostname = urlsplit(f"//{authority}").hostname
+    except ValueError:
+        return False
+    return is_loopback_host(hostname)
+
+
+def is_loopback_origin(origin_header):
+    """Return ``True`` if a browser ``Origin`` header names a loopback address."""
+    if not origin_header or not isinstance(origin_header, str):
+        return False
+    try:
+        hostname = urlsplit(origin_header).hostname
+    except ValueError:
+        return False
+    return is_loopback_host(hostname)
 
 
 def token_matches(provided_header, expected_token):
@@ -121,6 +159,13 @@ def run_fastmcp_server(
     transport="streamable-http",
     **kwargs,
 ):
-    """Run a standalone FastMCP server after enforcing the network bind guard."""
+    """Run a standalone FastMCP server after enforcing the network bind guard.
+
+    Defaults FastMCP's own ``host_origin_protection`` to ``"auto"`` so a
+    loopback-bound server also validates the request's Host/Origin headers,
+    closing the DNS-rebinding gap a bind-time-only guard leaves open (see the
+    module docstring). Callers can still override it explicitly.
+    """
     enforce_bind_security(host)
+    kwargs.setdefault("host_origin_protection", "auto")
     return server.run(transport=transport, host=host, port=port, **kwargs)

--- a/src/tooluniverse/smcp.py
+++ b/src/tooluniverse/smcp.py
@@ -1468,6 +1468,13 @@ class SMCP(FastMCP):
 
             enforce_bind_security(host)
 
+            # Binding to loopback is not, by itself, safe from remote browsers:
+            # DNS rebinding lets a malicious webpage resolve its own origin to
+            # 127.0.0.1 and reach this MCP endpoint as an in-browser client,
+            # with no Bearer token required. FastMCP validates Host/Origin
+            # itself once told to; ToolUniverse just needs to opt in.
+            kwargs.setdefault("host_origin_protection", "auto")
+
         # Build server URL based on transport
         if transport == "streamable-http" or transport == "http":
             self._server_url = f"http://{host}:{port}/mcp"

--- a/tests/unit/test_dns_rebinding_guard.py
+++ b/tests/unit/test_dns_rebinding_guard.py
@@ -1,0 +1,212 @@
+"""Regression tests for the DNS-rebinding advisory (GHSA-vx97-q3mm-h3r9).
+
+A server bound to loopback is not, by itself, safe from remote browsers: DNS
+rebinding lets a malicious webpage resolve its own origin to 127.0.0.1 and
+become an in-browser client of a loopback-bound server, with a Host header
+naming the attacker's domain (not "localhost") and, for fetch/XHR calls, a
+matching Origin header. The prior bind-time-only guard
+(``enforce_bind_security``) did not defend against this because it only ever
+inspects the *configured bind address*, never the *inbound request*.
+
+Covers three independent wirings of the same fix:
+
+1. ``server_security.is_loopback_authority`` / ``is_loopback_origin`` — the
+   request-time helpers.
+2. The FastAPI app's ``guard_host_and_origin`` middleware, which rejects a
+   loopback-bound request whose Host/Origin do not name loopback.
+3. FastMCP-based servers (the main SMCP server and every standalone
+   ``remote/*`` MCP tool server) opting in to FastMCP's own
+   ``host_origin_protection="auto"`` via ``run()`` / ``run_fastmcp_server``.
+"""
+
+import pytest
+
+from tooluniverse import server_security as ss
+
+
+@pytest.fixture(autouse=True)
+def _clear_token(monkeypatch):
+    monkeypatch.delenv(ss.API_TOKEN_ENV, raising=False)
+    yield
+
+
+# --------------------------------------------------------------------------- #
+# server_security helpers
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "authority,loopback",
+    [
+        ("127.0.0.1", True),
+        ("127.0.0.1:7000", True),
+        ("localhost", True),
+        ("localhost:7000", True),
+        ("[::1]:7000", True),
+        ("evil.example", False),
+        ("evil.example:7000", False),
+        ("0.0.0.0", False),
+        ("", False),
+        (None, False),
+    ],
+)
+def test_is_loopback_authority(authority, loopback):
+    assert ss.is_loopback_authority(authority) is loopback
+
+
+@pytest.mark.parametrize(
+    "origin,loopback",
+    [
+        ("http://127.0.0.1:7000", True),
+        ("http://localhost:7000", True),
+        ("http://[::1]:7000", True),
+        ("http://evil.example", False),
+        ("https://evil.example", False),
+        ("null", False),
+        ("", False),
+        (None, False),
+    ],
+)
+def test_is_loopback_origin(origin, loopback):
+    assert ss.is_loopback_origin(origin) is loopback
+
+
+def test_run_fastmcp_server_defaults_host_origin_protection(monkeypatch):
+    captured = {}
+
+    class _FakeServer:
+        def run(self, **kwargs):
+            captured.update(kwargs)
+
+    ss.run_fastmcp_server(_FakeServer(), host="127.0.0.1", port=9000)
+
+    assert captured["host_origin_protection"] == "auto"
+    assert captured["transport"] == "streamable-http"
+
+
+def test_run_fastmcp_server_respects_explicit_override(monkeypatch):
+    captured = {}
+
+    class _FakeServer:
+        def run(self, **kwargs):
+            captured.update(kwargs)
+
+    ss.run_fastmcp_server(
+        _FakeServer(), host="127.0.0.1", port=9000, host_origin_protection=False
+    )
+
+    assert captured["host_origin_protection"] is False
+
+
+# --------------------------------------------------------------------------- #
+# FastAPI app: guard_host_and_origin middleware
+# --------------------------------------------------------------------------- #
+
+
+def _client(base_url="http://127.0.0.1"):
+    fastapi_testclient = pytest.importorskip("fastapi.testclient")
+    from tooluniverse import http_api_server
+
+    return fastapi_testclient.TestClient(http_api_server.app, base_url=base_url)
+
+
+def test_guard_rejects_dns_rebinding_host():
+    """A loopback-bound server must reject a Host naming the attacker's domain."""
+    client = _client()
+    resp = client.get("/health", headers={"Host": "evil.example"})
+    assert resp.status_code == 421
+
+
+def test_guard_allows_loopback_host():
+    client = _client()
+    resp = client.get("/health")
+    assert resp.status_code == 200
+
+
+def test_guard_rejects_cross_origin_browser_request():
+    client = _client()
+    resp = client.get("/health", headers={"Origin": "http://evil.example"})
+    assert resp.status_code == 403
+
+
+def test_guard_allows_loopback_origin():
+    client = _client()
+    resp = client.get("/health", headers={"Origin": "http://127.0.0.1:7000"})
+    assert resp.status_code == 200
+
+
+def test_guard_skipped_on_explicit_non_loopback_bind():
+    """An operator who opted into a non-loopback bind (token required to get
+    here at all) is not subject to the loopback Host/Origin allowlist — that
+    guard exists to protect the *default* loopback trust boundary, not to
+    constrain a deliberately-exposed deployment."""
+    client = _client(base_url="http://testserver")
+    resp = client.get("/health", headers={"Host": "evil.example"})
+    assert resp.status_code == 200
+
+
+# --------------------------------------------------------------------------- #
+# SMCP.run(): opts in to FastMCP's own host/origin guard
+# --------------------------------------------------------------------------- #
+
+
+def test_smcp_run_defaults_host_origin_protection_to_auto(monkeypatch):
+    from fastmcp import FastMCP
+
+    from tooluniverse.smcp import SMCP
+
+    captured = {}
+
+    def fake_parent_run(self, *args, **kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(FastMCP, "run", fake_parent_run)
+
+    server = object.__new__(SMCP)
+    server._tooluniverse_banner_shown = True  # skip the banner thread
+    server.run(transport="streamable-http", host="127.0.0.1", port=7000)
+
+    assert captured["host_origin_protection"] == "auto"
+
+
+def test_smcp_run_respects_explicit_host_origin_protection(monkeypatch):
+    from fastmcp import FastMCP
+
+    from tooluniverse.smcp import SMCP
+
+    captured = {}
+
+    def fake_parent_run(self, *args, **kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(FastMCP, "run", fake_parent_run)
+
+    server = object.__new__(SMCP)
+    server._tooluniverse_banner_shown = True
+    server.run(
+        transport="http",
+        host="127.0.0.1",
+        port=7000,
+        host_origin_protection=False,
+    )
+
+    assert captured["host_origin_protection"] is False
+
+
+def test_smcp_run_stdio_does_not_set_host_origin_protection(monkeypatch):
+    from fastmcp import FastMCP
+
+    from tooluniverse.smcp import SMCP
+
+    captured = {}
+
+    def fake_parent_run(self, *args, **kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(FastMCP, "run", fake_parent_run)
+
+    server = object.__new__(SMCP)
+    server._tooluniverse_banner_shown = True
+    server.run(transport="stdio")
+
+    assert "host_origin_protection" not in captured


### PR DESCRIPTION
## Summary

Fixes #531 (the still-open half; the first reported vulnerability, RCE via `python_code_executor` / non-loopback exposure, was already fixed in PR #251 and is covered by `tests/unit/test_security_advisory_fixes.py`).

Addresses GHSA-vx97-q3mm-h3r9 (CVSS 9.6, critical): DNS rebinding lets a malicious webpage invoke MCP tools through ToolUniverse's Streamable HTTP MCP server with no authentication, even on the default loopback bind.

## Root cause

`enforce_bind_security()` and the FastAPI Bearer-token middleware only ever inspect the *configured bind address* (refusing to bind non-loopback without a token). Neither inspects the *inbound request*. A server bound to `127.0.0.1` was assumed safe from remote callers on that basis, but DNS rebinding breaks that assumption: a malicious webpage can register a domain that first resolves normally, then rebinds to `127.0.0.1` after the browser's same-origin check has passed. The browser then sends requests carrying a `Host` header naming the attacker's domain (not `localhost`) to what is actually the local ToolUniverse server. Since no Bearer token is required when none is configured (the common/default case), and neither server path validated Host/Origin, this let a webpage call any exposed tool — including `python_code_executor` — without authentication.

FastMCP (the library backing the SMCP Streamable HTTP server) already ships a `host_origin_protection` option that validates Host/Origin per-request, but ToolUniverse never passed it, so it defaulted to disabled.

## Fix

- `server_security.py`: two new helpers, `is_loopback_authority` (validates a `Host`-style value) and `is_loopback_origin` (validates a browser `Origin` header). `run_fastmcp_server` — the shared entry point used by the main SMCP server and every standalone `remote/*` MCP tool server — now defaults `host_origin_protection` to `"auto"`.
- `smcp.py`: `SMCP.run()` sets the same default for the main server's `http`/`sse`/`streamable-http` transports, so every FastMCP-based path opts in.
- `http_api_server.py`: new `guard_host_and_origin` ASGI middleware applies the same check to the FastAPI app (which doesn't go through FastMCP), rejecting a request with `421 Misdirected Request` (bad `Host`) or `403 Forbidden Origin` (bad `Origin`) when the server is bound to loopback. The check is skipped once an operator has explicitly opted into a non-loopback bind, which already requires a token — that's a deliberate exposure, not the loopback trust boundary this guard protects.

## Reproduction (before)

```python
from fastapi.testclient import TestClient
from tooluniverse import http_api_server

client = TestClient(http_api_server.app, base_url="http://127.0.0.1")
resp = client.get("/health", headers={"Host": "evil.example", "Origin": "http://evil.example"})
print(resp.status_code)  # 200 — reachable with no authentication at all
```

## Validation (after)

Same request now returns `421` (bad Host) before the request handler runs at all; a request with a good Host but bad `Origin` returns `403`. Legitimate loopback traffic (default TestClient-against-127.0.0.1 requests, no spoofed headers) is unaffected.

## Test coverage

`tests/unit/test_dns_rebinding_guard.py` (new, 28 tests):
- `is_loopback_authority` / `is_loopback_origin` unit cases (IPv4, IPv6, `localhost`, ports, non-loopback names, `null` origin).
- `guard_host_and_origin` middleware: rejects spoofed Host, rejects cross-origin browser request, allows loopback Host/Origin, and confirms the guard is skipped for an explicit non-loopback bind.
- `run_fastmcp_server` defaults `host_origin_protection` to `"auto"` and respects an explicit override.
- `SMCP.run()` sets the same default for `streamable-http`/`http`, respects an explicit override, and leaves `stdio` untouched.
