### PR TITLE
Fix: make easyocr and python-docx optional imports in USPTO downloader (#521)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,13 @@ pdf = [
     # it in implicitly.
     "pymupdf>=1.24.3",
 ]
+ocr = [
+    # Scanned-PDF text extraction for the USPTO downloader. EasyOCR pulls in
+    # PyTorch, a very large addition none of the other 600+ tools need, so keep
+    # it opt-in like `pdf` and out of the aggregate `all` extra.
+    "easyocr>=1.7",
+    "python-docx>=1.1",
+]
 # LLM provider SDKs. Both are imported lazily inside the client constructors in
 # llm_clients.py (AzureOpenAIClient, OpenAICompatibleClient, OpenRouterClient,
 # VLLMClient, GeminiClient) and in database_setup/embedder.py — never at module

--- a/src/tooluniverse/extras.py
+++ b/src/tooluniverse/extras.py
@@ -29,6 +29,10 @@ EXTRA_PACKAGES: dict[str, dict[str, str]] = {
     "pdf": {
         "pymupdf": "pymupdf",
     },
+    "ocr": {
+        "easyocr": "easyocr",
+        "docx": "python-docx",
+    },
     "ml": {
         "admet_ai": "admet-ai",
         "sentence_transformers": "sentence-transformers",
@@ -84,7 +88,7 @@ EXTRA_PACKAGES: dict[str, dict[str, str]] = {
 
 # Extras NOT covered by ``tooluniverse[all]`` — worth telling users about,
 # because "all" reads like it means all.
-EXTRAS_NOT_IN_ALL = ("pdf", "singlecell", "smolagents", "client", "build")
+EXTRAS_NOT_IN_ALL = ("pdf", "ocr", "singlecell", "smolagents", "client", "build")
 
 
 def _is_importable(import_name: str) -> bool:

--- a/src/tooluniverse/remote/uspto_downloader/uspto_downloader_tool.py
+++ b/src/tooluniverse/remote/uspto_downloader/uspto_downloader_tool.py
@@ -1,18 +1,28 @@
-import requests
-import easyocr
 import re
 import zipfile
 from io import BytesIO
-from docx import Document
-from PIL import Image
 from urllib.parse import urljoin, urlparse
-from tooluniverse.uspto_tool import USPTOOpenDataPortalTool
+
+import requests
+from PIL import Image
+
 from tooluniverse.tool_registry import register_tool
+from tooluniverse.uspto_tool import USPTOOpenDataPortalTool
 
 try:
     import pymupdf as fitz
 except ImportError:  # PyMuPDF is an explicit, AGPL/commercial opt-in dependency.
     fitz = None
+
+try:
+    import easyocr
+except ImportError:  # EasyOCR pulls in PyTorch; explicit opt-in, not a base dep.
+    easyocr = None
+
+try:
+    from docx import Document
+except ImportError:  # python-docx is an explicit opt-in, not a base dependency.
+    Document = None
 
 
 _APPLICATION_NUMBER_PATTERN = re.compile(r"^[0-9]{8,16}$")
@@ -26,16 +36,47 @@ _MAX_OCR_PIXELS_PER_PAGE = 25_000_000
 _MAX_OCR_TOTAL_PIXELS = 250_000_000
 
 
-class _MissingPdfDependencyError(RuntimeError):
+class _MissingProviderDependencyError(RuntimeError):
+    """A required optional dependency for USPTO document extraction is missing."""
+
+
+class _MissingPdfDependencyError(_MissingProviderDependencyError):
+    pass
+
+
+class _MissingOcrDependencyError(_MissingProviderDependencyError):
+    pass
+
+
+class _MissingDocxDependencyError(_MissingProviderDependencyError):
     pass
 
 
 def _pdf_backend():
     if fitz is None:
         raise _MissingPdfDependencyError(
-            "PDF extraction requires the optional PyMuPDF dependency."
+            "PDF extraction requires the optional PyMuPDF dependency. "
+            "Install it with `pip install tooluniverse[pdf]`."
         )
     return fitz
+
+
+def _ocr_reader():
+    if easyocr is None:
+        raise _MissingOcrDependencyError(
+            "Scanned-PDF OCR requires the optional EasyOCR dependency. "
+            "Install it with `pip install tooluniverse[ocr]`."
+        )
+    return easyocr
+
+
+def _docx_backend():
+    if Document is None:
+        raise _MissingDocxDependencyError(
+            "MS_WORD document extraction requires the optional python-docx "
+            "dependency. Install it with `pip install tooluniverse[ocr]`."
+        )
+    return Document
 
 
 def _validate_uspto_download_url(url):
@@ -102,8 +143,13 @@ def _validate_docx_archive(document_bytes):
         with zipfile.ZipFile(BytesIO(document_bytes)) as archive:
             members = archive.infolist()
             if len(members) > _MAX_DOCX_MEMBERS:
-                raise ValueError("USPTO Word document contains too many archive members.")
-            if sum(member.file_size for member in members) > _MAX_DOCX_UNCOMPRESSED_BYTES:
+                raise ValueError(
+                    "USPTO Word document contains too many archive members."
+                )
+            if (
+                sum(member.file_size for member in members)
+                > _MAX_DOCX_UNCOMPRESSED_BYTES
+            ):
                 raise ValueError("USPTO Word document exceeds the expansion limit.")
             if any(member.flag_bits & 0x1 for member in members):
                 raise ValueError("USPTO Word document must not be encrypted.")
@@ -152,19 +198,18 @@ class USPTOPatentDocumentDownloader(USPTOOpenDataPortalTool):
         if not isinstance(arguments, dict):
             return {"error": "Arguments must be an object."}
         application_number = arguments.get("applicationNumberText")
-        if (
-            not isinstance(application_number, str)
-            or not _APPLICATION_NUMBER_PATTERN.fullmatch(application_number.strip())
-        ):
+        if not isinstance(
+            application_number, str
+        ) or not _APPLICATION_NUMBER_PATTERN.fullmatch(application_number.strip()):
             return {"error": "applicationNumberText must contain 8 to 16 digits."}
         try:
             result = self._run_provider(
                 {"applicationNumberText": application_number.strip()}
             )
-        except _MissingPdfDependencyError:
+        except _MissingProviderDependencyError as exc:
             return {
-                "error": "USPTO PDF extraction dependency is not installed.",
-                "hint": "Install the provider setup dependencies, including PyMuPDF, and retry.",
+                "error": "USPTO document extraction dependency is not installed.",
+                "hint": str(exc),
             }
         except (requests.RequestException, ValueError):
             return {"error": "USPTO document retrieval failed on the provider."}
@@ -191,7 +236,7 @@ class USPTOPatentDocumentDownloader(USPTOOpenDataPortalTool):
                 if doc.page_count > _MAX_OCR_PAGES:
                     raise ValueError("USPTO image-only PDF exceeds the OCR page limit.")
 
-                reader = easyocr.Reader(["en"], gpu=False)
+                reader = _ocr_reader().Reader(["en"], gpu=False)
                 pages_text = []
                 total_pixels = 0
                 for page in doc:
@@ -203,9 +248,7 @@ class USPTOPatentDocumentDownloader(USPTOOpenDataPortalTool):
                         or total_pixels > _MAX_OCR_TOTAL_PIXELS
                     ):
                         raise ValueError("USPTO PDF exceeds the OCR image limit.")
-                    img = Image.frombytes(
-                        "RGB", [pix.width, pix.height], pix.samples
-                    )
+                    img = Image.frombytes("RGB", [pix.width, pix.height], pix.samples)
                     img_bytes = BytesIO()
                     img.save(img_bytes, format="PNG")
                     results = reader.readtext(img_bytes.getvalue(), detail=0)
@@ -258,7 +301,7 @@ class USPTOPatentDocumentDownloader(USPTOOpenDataPortalTool):
                 )
                 _validate_docx_archive(document_bytes)
                 buf = BytesIO(document_bytes)
-                docx = Document(buf)
+                docx = _docx_backend()(buf)
                 plain_text, extraction_truncated = _bounded_join_text(
                     p.text for p in docx.paragraphs
                 )

--- a/tests/unit/test_uspto_downloader_tool.py
+++ b/tests/unit/test_uspto_downloader_tool.py
@@ -1,0 +1,113 @@
+"""Regression tests for issue #521: USPTOPatentDocumentDownloader imported
+easyocr and python-docx unconditionally at module scope, but neither is a
+declared dependency (root or MCPB). In an environment resolved from the
+declared dependencies alone — this test environment included — both imports
+failed, so importing this module raised ModuleNotFoundError instead of the
+tool merely failing (with a clear message) the first time OCR or MS_WORD
+extraction was actually needed.
+
+PyMuPDF was already handled this way (a soft import backed by
+``_pdf_backend()``); this fix applies the same pattern to EasyOCR and
+python-docx.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from tooluniverse.remote.uspto_downloader import uspto_downloader_tool as mod
+from tooluniverse.remote.uspto_downloader.uspto_downloader_tool import (
+    USPTOPatentDocumentDownloader,
+    _docx_backend,
+    _MissingDocxDependencyError,
+    _MissingOcrDependencyError,
+    _MissingPdfDependencyError,
+    _MissingProviderDependencyError,
+    _ocr_reader,
+    _pdf_backend,
+)
+
+
+def test_module_imports_without_optional_dependencies():
+    """None of pymupdf/easyocr/docx are installed in this environment; the
+    module must still import (this is the regression the issue reports)."""
+    assert mod.fitz is None
+    assert mod.easyocr is None
+    assert mod.Document is None
+
+
+@pytest.mark.parametrize(
+    "backend_fn,attr,exc_type",
+    [
+        (_pdf_backend, "fitz", _MissingPdfDependencyError),
+        (_ocr_reader, "easyocr", _MissingOcrDependencyError),
+        (_docx_backend, "Document", _MissingDocxDependencyError),
+    ],
+)
+def test_backend_raises_friendly_error_when_missing(backend_fn, attr, exc_type):
+    with patch.object(mod, attr, None), pytest.raises(exc_type) as exc_info:
+        backend_fn()
+    assert isinstance(exc_info.value, _MissingProviderDependencyError)
+    assert "pip install tooluniverse[" in str(exc_info.value)
+
+
+@pytest.fixture(autouse=True)
+def _uspto_api_key(monkeypatch):
+    monkeypatch.setenv("USPTO_API_KEY", "test-key")
+
+
+def _tool():
+    return USPTOPatentDocumentDownloader(
+        {"name": "uspto_patent_document_downloader", "document": "ABST"}
+    )
+
+
+def _metadata(download_option_bag):
+    return {
+        "data": {
+            "documentBag": [
+                {
+                    "documentCode": "ABST",
+                    "documentIdentifier": "doc-1",
+                    "downloadOptionBag": download_option_bag,
+                }
+            ]
+        }
+    }
+
+
+def test_run_reports_missing_pdf_dependency_without_crashing():
+    """A PDF-only document, with no PyMuPDF installed, must return a clear
+    error from run() — not raise ModuleNotFoundError out of the tool."""
+    tool = _tool()
+    metadata = _metadata(
+        [{"mimeTypeIdentifier": "PDF", "downloadUrl": "https://uspto.gov/x.pdf"}]
+    )
+    with (
+        patch.object(mod.USPTOOpenDataPortalTool, "run", return_value=metadata),
+        patch.object(mod, "_download_uspto_document", return_value=b"%PDF-1.4 fake"),
+    ):
+        result = tool.run({"applicationNumberText": "19053071"})
+
+    assert result["error"] == "USPTO document extraction dependency is not installed."
+    assert "PyMuPDF" in result["hint"]
+    assert "pip install tooluniverse[pdf]" in result["hint"]
+
+
+def test_run_reports_missing_docx_dependency_without_crashing():
+    """An MS_WORD-only document, with no python-docx installed, must return a
+    clear error from run() — not raise ModuleNotFoundError out of the tool."""
+    tool = _tool()
+    metadata = _metadata(
+        [{"mimeTypeIdentifier": "MS_WORD", "downloadUrl": "https://uspto.gov/x.docx"}]
+    )
+    with (
+        patch.object(mod.USPTOOpenDataPortalTool, "run", return_value=metadata),
+        patch.object(mod, "_download_uspto_document", return_value=b"fake docx bytes"),
+        patch.object(mod, "_validate_docx_archive", return_value=None),
+    ):
+        result = tool.run({"applicationNumberText": "19053071"})
+
+    assert result["error"] == "USPTO document extraction dependency is not installed."
+    assert "python-docx" in result["hint"]
+    assert "pip install tooluniverse[ocr]" in result["hint"]


### PR DESCRIPTION
## Summary

Fixes #521: `USPTOPatentDocumentDownloader` imported `easyocr` and `docx` (python-docx) unconditionally at module scope, but neither is declared anywhere (root `pyproject.toml` or the MCPB bundle).

## Root cause

In an environment resolved from the declared dependencies alone, `import easyocr` and `from docx import Document` at module top level fail with `ModuleNotFoundError`. Because the tool registry loads this module lazily (only when `USPTOPatentDocumentDownloader` is actually invoked), nothing surfaces at startup — the failure appears as an unhandled `ModuleNotFoundError` the first time a caller uses the tool, per the issue and @fbjk2000's follow-up (which found the same gap for `pymupdf` before the `fitz`→`pymupdf` fix in #516/#516 landed everywhere).

PyMuPDF already had the right pattern here: `try: import pymupdf as fitz / except ImportError: fitz = None`, with a `_pdf_backend()` accessor that raises a clear `RuntimeError` only when a caller actually needs PDF extraction and PyMuPDF isn't installed.

## Fix

Applied the identical pattern to the other two optional dependencies:
- `_ocr_reader()` guards `easyocr` (used only inside the scanned-PDF OCR path).
- `_docx_backend()` guards `Document` (used only inside the MS_WORD extraction path).
- All three failure modes now share a `_MissingProviderDependencyError` base, so `run()`'s existing exception handling catches all of them with one clear message + an actionable hint, instead of only PyMuPDF.
- Added an `ocr` extra to `pyproject.toml` (`pip install tooluniverse[ocr]`) declaring `easyocr` and `python-docx`, kept separate from the base dependency set for the same reason `pdf` (PyMuPDF) is opt-in: EasyOCR pulls in PyTorch, a large addition none of the other 600+ tools need.

**Not in scope:** this does not touch the MCPB bundle's dependency list (which deliberately omits PyMuPDF too, for AGPL-licensing reasons already documented at that call site) or PR #523's broader "separately deployed MCP service" redesign, which remains a draft blocked on a real-GPU EasyOCR validation step. This PR is a narrow, self-contained fix for the reported import-time crash on the code as it exists on `main` today.

## Reproduction (before)

```python
# In an environment with the declared dependencies only (no easyocr, no python-docx):
import tooluniverse.remote.uspto_downloader.uspto_downloader_tool  # ModuleNotFoundError: No module named 'easyocr'
```

## Validation (after)

```python
import tooluniverse.remote.uspto_downloader.uspto_downloader_tool as mod
assert mod.easyocr is None and mod.Document is None  # imports fine
# Actually invoking the tool against a document that needs OCR/MS_WORD now
# returns a clear error instead of crashing:
# {"error": "USPTO document extraction dependency is not installed.",
#  "hint": "... Install it with `pip install tooluniverse[ocr]`."}
```

## Test coverage

`tests/unit/test_uspto_downloader_tool.py` (new, 6 tests), run in this exact environment (none of pymupdf/easyocr/docx are installed here, which is exactly the reported condition):
- The module imports cleanly with all three optional deps absent.
- Each of `_pdf_backend()`/`_ocr_reader()`/`_docx_backend()` raises its typed error with an actionable `pip install` hint when the dependency is missing.
- `run()` end-to-end for a PDF-only document and an MS_WORD-only document, each confirming a clean `{"error": ..., "hint": ...}` response rather than a crash.
