### PR TITLE
Fix: validate Host/Origin in ToolGraphWebUI, same gap as #531 (#557)

### DIFF
--- a/src/tooluniverse/tool_graph_web_ui.py
+++ b/src/tooluniverse/tool_graph_web_ui.py
@@ -11,6 +11,8 @@ from flask import Flask, render_template, jsonify, request
 import pickle
 from typing import Dict, Any, List, Optional
 
+from .server_security import is_loopback_authority, is_loopback_host, is_loopback_origin
+
 
 class ToolGraphWebUI:
     """Web interface for visualizing tool composition graphs."""
@@ -19,12 +21,37 @@ class ToolGraphWebUI:
         self.app = Flask(__name__, template_folder="templates", static_folder="static")
         self.graph_data: Optional[Dict[str, Any]] = None
         self.graph_data_path = graph_data_path
+        # The bind host run() will actually use; loopback until told otherwise,
+        # so the request guard below defaults to protecting the common case.
+        self._bind_host = "127.0.0.1"
 
         self._setup_routes()
         self._load_graph_data()
 
     def _setup_routes(self):
         """Setup Flask routes."""
+
+        @self.app.before_request
+        def _guard_host_and_origin():
+            """Reject requests whose Host/Origin do not name loopback, on loopback binds.
+
+            A server bound to 127.0.0.1 is not automatically safe from remote
+            callers: DNS rebinding lets a malicious webpage resolve its own origin
+            to the loopback address and become an in-browser client of this
+            server, with a Host header naming the attacker's domain rather than
+            "localhost" — reaching routes like POST /api/load_graph (which
+            deserializes a caller-supplied pickle path) with no authentication.
+            Skipped once bound to a non-loopback interface, which
+            enforce_bind_security already gates on a Bearer token.
+            """
+            if not is_loopback_host(self._bind_host):
+                return None
+            if not is_loopback_authority(request.host):
+                return jsonify({"error": "Misdirected Request"}), 421
+            origin = request.headers.get("Origin")
+            if origin and not is_loopback_origin(origin):
+                return jsonify({"error": "Forbidden Origin"}), 403
+            return None
 
         @self.app.route("/")
         def index():
@@ -245,8 +272,9 @@ class ToolGraphWebUI:
         never be enabled on a network-reachable bind. Binding to a non-loopback
         host without TOOLUNIVERSE_API_TOKEN is refused.
         """
-        from .server_security import enforce_bind_security, is_loopback_host
+        from .server_security import enforce_bind_security
 
+        self._bind_host = host
         enforce_bind_security(host)
         if debug and not is_loopback_host(host):
             raise RuntimeError(

--- a/tests/unit/test_dns_rebinding_guard.py
+++ b/tests/unit/test_dns_rebinding_guard.py
@@ -8,7 +8,7 @@ matching Origin header. The prior bind-time-only guard
 (``enforce_bind_security``) did not defend against this because it only ever
 inspects the *configured bind address*, never the *inbound request*.
 
-Covers three independent wirings of the same fix:
+Covers four independent wirings of the same fix:
 
 1. ``server_security.is_loopback_authority`` / ``is_loopback_origin`` — the
    request-time helpers.
@@ -17,6 +17,11 @@ Covers three independent wirings of the same fix:
 3. FastMCP-based servers (the main SMCP server and every standalone
    ``remote/*`` MCP tool server) opting in to FastMCP's own
    ``host_origin_protection="auto"`` via ``run()`` / ``run_fastmcp_server``.
+4. ``ToolGraphWebUI``'s Flask ``before_request`` hook, which reuses the same
+   helpers directly (Flask has no FastMCP-equivalent built-in) — found while
+   verifying the fix for #531 and tracked separately as #557, since
+   ``POST /api/load_graph`` deserializes a caller-supplied pickle path and was
+   reachable with a spoofed Host/Origin exactly like the original report.
 """
 
 import pytest
@@ -210,3 +215,71 @@ def test_smcp_run_stdio_does_not_set_host_origin_protection(monkeypatch):
     server.run(transport="stdio")
 
     assert "host_origin_protection" not in captured
+
+
+# --------------------------------------------------------------------------- #
+# ToolGraphWebUI: Flask before_request guard (#557)
+# --------------------------------------------------------------------------- #
+
+
+def _graph_ui_client():
+    pytest.importorskip("flask")
+    from tooluniverse.tool_graph_web_ui import ToolGraphWebUI
+
+    ui = ToolGraphWebUI(graph_data_path=None)
+    return ui, ui.app.test_client()
+
+
+def test_graph_ui_rejects_dns_rebinding_host():
+    """Default-constructed UI defaults to loopback (matching run()'s default),
+    so the guard is active without needing to actually start the server."""
+    _, client = _graph_ui_client()
+    resp = client.get("/api/stats", headers={"Host": "evil.example"})
+    assert resp.status_code == 421
+
+
+def test_graph_ui_allows_loopback_host():
+    _, client = _graph_ui_client()
+    resp = client.get("/api/stats")
+    assert resp.status_code == 404  # no graph loaded; guard let it through
+
+
+def test_graph_ui_rejects_cross_origin_browser_request():
+    _, client = _graph_ui_client()
+    resp = client.get("/api/stats", headers={"Origin": "http://evil.example"})
+    assert resp.status_code == 403
+
+
+def test_graph_ui_allows_loopback_origin():
+    _, client = _graph_ui_client()
+    resp = client.get("/api/stats", headers={"Origin": "http://127.0.0.1:5000"})
+    assert resp.status_code == 404
+
+
+def test_graph_ui_dangerous_load_graph_endpoint_is_also_guarded():
+    """POST /api/load_graph deserializes a caller-supplied pickle path — the
+    endpoint the original finding centered on."""
+    _, client = _graph_ui_client()
+    resp = client.post(
+        "/api/load_graph",
+        json={"path": "/tmp/anything.pkl"},
+        headers={"Host": "evil.example"},
+    )
+    assert resp.status_code == 421
+
+
+def test_graph_ui_skipped_on_explicit_non_loopback_bind():
+    ui, client = _graph_ui_client()
+    ui._bind_host = "0.0.0.0"  # what run() would set for an explicit remote bind
+    resp = client.get("/api/stats", headers={"Host": "evil.example"})
+    assert resp.status_code == 404  # guard is a no-op; not what rejected it
+
+
+def test_graph_ui_run_sets_bind_host(monkeypatch):
+    pytest.importorskip("flask")
+    from tooluniverse.tool_graph_web_ui import ToolGraphWebUI
+
+    ui = ToolGraphWebUI(graph_data_path=None)
+    monkeypatch.setattr(ui.app, "run", lambda **kw: None)  # don't actually bind
+    ui.run(host="127.0.0.1", port=5000)
+    assert ui._bind_host == "127.0.0.1"


### PR DESCRIPTION
## Summary

Fixes #557: `ToolGraphWebUI` (the Flask-based tool-graph visualization server) has the same DNS-rebinding gap #531 fixed for the SMCP and HTTP API servers.

Built on top of #556 (issue #531's fix, now merged) — reuses the `is_loopback_authority`/`is_loopback_origin` helpers introduced there. Rebased cleanly onto `main` now that #556 is in.

## Root cause

`ToolGraphWebUI.run()` already calls `enforce_bind_security(host)` — the same bind-time guard used by `http_api_server.py` and `smcp.py` — but nothing validated the `Host`/`Origin` headers on the actual inbound request. Exactly like #531: a server bound to loopback is not automatically safe from a remote browser, because DNS rebinding lets a malicious webpage resolve its own origin to `127.0.0.1` and reach the server with a spoofed `Host` header.

This matters more here than it might look at first: `POST /api/load_graph` accepts a caller-supplied file path and calls `pickle.load()` on it if the path ends in `.pkl`. Untrusted pickle deserialization is a well-known code-execution primitive — so a DNS-rebinding attacker reaching this endpoint isn't just an information-disclosure risk, it's a path to code execution if the attacker can get any file planted at a predictable path on the victim's machine.

Found while verifying the #531 fix, not part of the original advisory's scope.

## Impact

- `tool_graph_web_ui.py` ships inside the published `tooluniverse` wheel — confirmed by actually building the wheel and inspecting its contents, not just checking the packaging config. This is live in every install.
- It is not wired into any CLI entry point, script, or automatic startup path anywhere in the codebase — a caller has to explicitly `from tooluniverse.tool_graph_web_ui import ToolGraphWebUI` and call `.run()`. Exposure is opt-in, but real for anyone who does.

## Fix

Added a Flask `before_request` hook (`_guard_host_and_origin`) mirroring `http_api_server.py`'s `guard_host_and_origin` middleware, reusing the same helpers from `server_security.py`. `ToolGraphWebUI` now tracks its configured bind host (`self._bind_host`, set by `run()`, defaulting to `127.0.0.1` to match `run()`'s own default) so the guard can tell whether it's protecting a loopback bind or an explicit non-loopback one — skipped for the latter, which `enforce_bind_security` already gates on a Bearer token.

## Reproduction (before)

```python
# Real Flask dev server, real socket, real requests library:
requests.post(
    "http://127.0.0.1:PORT/api/load_graph",
    json={"path": "/tmp/anything.pkl"},
    headers={"Host": "evil.example", "Origin": "http://evil.example"},
)
# -> 400 "Invalid graph path" (reached the actual pickle-loading logic; only
#    failed because the path didn't exist — a real path would have proceeded)
```

## Validation (after)

Same request now returns `421 Misdirected Request` before the handler runs at all. Verified live with a real `uvicorn`-equivalent (Flask dev server) instance, real socket, real `requests` calls — both the exploit path and legitimate loopback traffic (via `127.0.0.1` and `localhost`).

## Test coverage

Extended `tests/unit/test_dns_rebinding_guard.py` (7 new tests, 35 total in the file):
- Rejects a spoofed `Host`, rejects a cross-origin browser request, allows loopback `Host`/`Origin`.
- Specifically confirms `POST /api/load_graph` (the dangerous endpoint) is guarded, not just the read-only routes.
- Confirms the guard is skipped for an explicit non-loopback bind.
- Confirms `run()` actually records the bind host the guard checks against.
