### PR TITLE
Docs: cross-reference the Codex and Antigravity plugin skills from setup-tooluniverse

### DIFF
--- a/plugin/skills/setup-tooluniverse/SKILL.md
+++ b/plugin/skills/setup-tooluniverse/SKILL.md
@@ -155,16 +155,27 @@ Read https://aiscientist.tools/setup.md and set up ToolUniverse for me.
 
 The agent handles config, keys, skills, and validation. No terminal, no JSON.
 
-**Path B — Claude Code users: one-liner, no config file at all.**
+**Path B — Claude Code or Codex users: one-liner, no config file at all.**
 
+Claude Code:
 ```bash
 claude plugin marketplace add mims-harvard/ToolUniverse
 claude plugin install tooluniverse@tooluniverse
 ```
+See the `tooluniverse-claude-code-plugin` skill's "Recommended: turn on
+auto-update" step so future releases apply without manual `claude plugin update`.
 
-Installs MCP server + 115 skills + slash commands in one step. Then see the
-`tooluniverse-claude-code-plugin` skill's "Recommended: turn on auto-update"
-step so future releases apply without manual `claude plugin update`.
+Codex:
+```bash
+codex plugin marketplace add mims-harvard/ToolUniverse
+codex plugin add tooluniverse -m tooluniverse
+```
+See the `tooluniverse-codex-plugin` skill for verification, updates, and
+troubleshooting.
+
+Both install the MCP server plus 100+ skills in one step. Google Antigravity
+users: see the `tooluniverse-antigravity-plugin` skill instead — its install
+flow differs (`agy plugin install`, not a marketplace add).
 
 ### Manual config (fallback)
 

--- a/plugins/tooluniverse/skills/setup-tooluniverse/SKILL.md
+++ b/plugins/tooluniverse/skills/setup-tooluniverse/SKILL.md
@@ -156,16 +156,27 @@ Read https://aiscientist.tools/setup.md and set up ToolUniverse for me.
 
 The agent handles config, keys, skills, and validation. No terminal, no JSON.
 
-**Path B — Claude Code users: one-liner, no config file at all.**
+**Path B — Claude Code or Codex users: one-liner, no config file at all.**
 
+Claude Code:
 ```bash
 claude plugin marketplace add mims-harvard/ToolUniverse
 claude plugin install tooluniverse@tooluniverse
 ```
+See the `tooluniverse-claude-code-plugin` skill's "Recommended: turn on
+auto-update" step so future releases apply without manual `claude plugin update`.
 
-Installs MCP server + 115 skills + slash commands in one step. Then see the
-`tooluniverse-claude-code-plugin` skill's "Recommended: turn on auto-update"
-step so future releases apply without manual `claude plugin update`.
+Codex:
+```bash
+codex plugin marketplace add mims-harvard/ToolUniverse
+codex plugin add tooluniverse -m tooluniverse
+```
+See the `tooluniverse-codex-plugin` skill for verification, updates, and
+troubleshooting.
+
+Both install the MCP server plus 100+ skills in one step. Google Antigravity
+users: see the `tooluniverse-antigravity-plugin` skill instead — its install
+flow differs (`agy plugin install`, not a marketplace add).
 
 ### Manual config (fallback)
 

--- a/skills/setup-tooluniverse/SKILL.md
+++ b/skills/setup-tooluniverse/SKILL.md
@@ -155,16 +155,27 @@ Read https://aiscientist.tools/setup.md and set up ToolUniverse for me.
 
 The agent handles config, keys, skills, and validation. No terminal, no JSON.
 
-**Path B — Claude Code users: one-liner, no config file at all.**
+**Path B — Claude Code or Codex users: one-liner, no config file at all.**
 
+Claude Code:
 ```bash
 claude plugin marketplace add mims-harvard/ToolUniverse
 claude plugin install tooluniverse@tooluniverse
 ```
+See the `tooluniverse-claude-code-plugin` skill's "Recommended: turn on
+auto-update" step so future releases apply without manual `claude plugin update`.
 
-Installs MCP server + 115 skills + slash commands in one step. Then see the
-`tooluniverse-claude-code-plugin` skill's "Recommended: turn on auto-update"
-step so future releases apply without manual `claude plugin update`.
+Codex:
+```bash
+codex plugin marketplace add mims-harvard/ToolUniverse
+codex plugin add tooluniverse -m tooluniverse
+```
+See the `tooluniverse-codex-plugin` skill for verification, updates, and
+troubleshooting.
+
+Both install the MCP server plus 100+ skills in one step. Google Antigravity
+users: see the `tooluniverse-antigravity-plugin` skill instead — its install
+flow differs (`agy plugin install`, not a marketplace add).
 
 ### Manual config (fallback)
 


### PR DESCRIPTION
## Summary

`setup-tooluniverse`'s "Path B" one-liner install section only ever named `tooluniverse-claude-code-plugin`, even though `tooluniverse-codex-plugin` and `tooluniverse-antigravity-plugin` already exist and give Codex/Antigravity users the same one-step "marketplace add + install" experience this skill otherwise only offers Claude Code users — everyone else got routed to the generic manual TOML/JSON config fallback instead.

## Fix

- Added the parallel `codex plugin marketplace add` / `codex plugin add` one-liner alongside Claude Code's.
- Added a pointer to `tooluniverse-antigravity-plugin` for Antigravity users (its install flow differs enough — `agy plugin install`, not a marketplace add — that it wasn't worth reproducing inline).
- Applied identically to all three packaged copies of the skill (`skills/`, `plugin/skills/`, `plugins/tooluniverse/skills/`), matching how it's distributed.

## Validation

- `tests/unit/test_codex_plugin.py` (covers the `plugins/tooluniverse/skills/` copy, including frontmatter/loadability checks) — all pass.
- Verified code fences are balanced in all three edited files.
- Confirmed the three copies are still identical in body (only frontmatter formatting differs, matching their existing convention).

No new tests added — this is a plain content fix to an existing skill file, not new logic to cover.
