### PR TITLE
USPTO downloader: OCR fallback per-page, not whole-document

### DIFF
--- a/src/tooluniverse/remote/uspto_downloader/uspto_downloader_tool.py
+++ b/src/tooluniverse/remote/uspto_downloader/uspto_downloader_tool.py
@@ -227,25 +227,36 @@ class USPTOPatentDocumentDownloader(USPTOOpenDataPortalTool):
         return result
 
     def _run_provider(self, arguments):
-        def ocr_pdf_bytes(pdf_bytes, dpi=300):
-            print("Running OCR on PDF bytes...")
+        def extract_pdf_text(pdf_bytes, dpi=300):
+            """Extract each page's embedded text, OCR-ing only pages that
+            have none (e.g. a scanned page inside an otherwise text PDF)."""
             doc = _pdf_backend().open(stream=pdf_bytes, filetype="pdf")
             try:
                 if doc.page_count > _MAX_PDF_PAGES:
                     raise ValueError("USPTO PDF exceeds the page limit.")
-                if doc.page_count > _MAX_OCR_PAGES:
-                    raise ValueError("USPTO image-only PDF exceeds the OCR page limit.")
 
-                reader = _ocr_reader().Reader(["en"], gpu=False)
+                reader = None
+                ocr_page_count = 0
+                total_ocr_pixels = 0
                 pages_text = []
-                total_pixels = 0
                 for page in doc:
+                    page_text = page.get_text().strip()
+                    if page_text:
+                        pages_text.append(page_text)
+                        continue
+
+                    ocr_page_count += 1
+                    if ocr_page_count > _MAX_OCR_PAGES:
+                        raise ValueError("USPTO PDF exceeds the OCR page limit.")
+                    if reader is None:
+                        reader = _ocr_reader().Reader(["en"], gpu=False)
+
                     pix = page.get_pixmap(dpi=dpi, alpha=False)
                     pixels = pix.width * pix.height
-                    total_pixels += pixels
+                    total_ocr_pixels += pixels
                     if (
                         pixels > _MAX_OCR_PIXELS_PER_PAGE
-                        or total_pixels > _MAX_OCR_TOTAL_PIXELS
+                        or total_ocr_pixels > _MAX_OCR_TOTAL_PIXELS
                     ):
                         raise ValueError("USPTO PDF exceeds the OCR image limit.")
                     img = Image.frombytes("RGB", [pix.width, pix.height], pix.samples)
@@ -310,19 +321,7 @@ class USPTOPatentDocumentDownloader(USPTOOpenDataPortalTool):
                 pdf_bytes = _download_uspto_document(
                     pdf_opt.get("downloadUrl"), self.headers
                 )
-                pdf_doc = _pdf_backend().open(stream=pdf_bytes, filetype="pdf")
-                try:
-                    if pdf_doc.page_count > _MAX_PDF_PAGES:
-                        raise ValueError("USPTO PDF exceeds the page limit.")
-                    plain_text, extraction_truncated = _bounded_join_text(
-                        page.get_text() for page in pdf_doc
-                    )
-                finally:
-                    pdf_doc.close()
-
-                if plain_text == "":
-                    # If no text was extracted, try to extract text from images
-                    plain_text, extraction_truncated = ocr_pdf_bytes(pdf_bytes)
+                plain_text, extraction_truncated = extract_pdf_text(pdf_bytes)
 
             if plain_text:
                 # if plain text is longer than current result, it is probably a better text extraction

--- a/tests/unit/test_uspto_downloader_tool.py
+++ b/tests/unit/test_uspto_downloader_tool.py
@@ -111,3 +111,122 @@ def test_run_reports_missing_docx_dependency_without_crashing():
     assert result["error"] == "USPTO document extraction dependency is not installed."
     assert "python-docx" in result["hint"]
     assert "pip install tooluniverse[ocr]" in result["hint"]
+
+
+class _FakePixmap:
+    def __init__(self, width=2, height=2):
+        self.width = width
+        self.height = height
+        self.samples = bytes([255, 255, 255] * (width * height))
+
+
+class _FakePage:
+    def __init__(self, text):
+        self._text = text
+
+    def get_text(self):
+        return self._text
+
+    def get_pixmap(self, dpi=300, alpha=False):
+        return _FakePixmap()
+
+
+class _FakePdfDoc:
+    def __init__(self, pages):
+        self._pages = pages
+        self.page_count = len(pages)
+
+    def __iter__(self):
+        return iter(self._pages)
+
+    def close(self):
+        pass
+
+
+class _FakeFitz:
+    def __init__(self, pages):
+        self._pages = pages
+
+    def open(self, stream, filetype):
+        return _FakePdfDoc(self._pages)
+
+
+class _FakeOcrReader:
+    def __init__(self, calls):
+        self._calls = calls
+
+    def readtext(self, image_bytes, detail=0):
+        self._calls.append(image_bytes)
+        return ["OCR RESULT"]
+
+
+class _FakeEasyocr:
+    def __init__(self, calls):
+        self._calls = calls
+
+    def Reader(self, langs, gpu=False):
+        return _FakeOcrReader(self._calls)
+
+
+def _pdf_metadata():
+    return _metadata(
+        [{"mimeTypeIdentifier": "PDF", "downloadUrl": "https://uspto.gov/x.pdf"}]
+    )
+
+
+def test_run_ocrs_only_pdf_pages_without_embedded_text():
+    """A page with no embedded text (e.g. a scanned page mixed into an
+    otherwise text-based PDF) is OCR'd; pages with real text are not."""
+    tool = _tool()
+    pages = [_FakePage("Real embedded text"), _FakePage("   "), _FakePage("More text")]
+    ocr_calls = []
+
+    with (
+        patch.object(mod.USPTOOpenDataPortalTool, "run", return_value=_pdf_metadata()),
+        patch.object(mod, "_download_uspto_document", return_value=b"%PDF-1.4 fake"),
+        patch.object(mod, "_pdf_backend", return_value=_FakeFitz(pages)),
+        patch.object(mod, "_ocr_reader", return_value=_FakeEasyocr(ocr_calls)),
+    ):
+        result = tool.run({"applicationNumberText": "19053071"})
+
+    assert "Real embedded text" in result["result"]
+    assert "More text" in result["result"]
+    assert "OCR RESULT" in result["result"]
+    assert len(ocr_calls) == 1
+
+
+def test_run_does_not_ocr_a_text_heavy_document_that_needs_no_ocr():
+    """A large document made entirely of text pages must not be blocked by
+    the OCR page-count budget, since no page actually needs OCR."""
+    tool = _tool()
+    pages = [_FakePage(f"page {i} text") for i in range(mod._MAX_OCR_PAGES + 50)]
+    ocr_calls = []
+
+    with (
+        patch.object(mod.USPTOOpenDataPortalTool, "run", return_value=_pdf_metadata()),
+        patch.object(mod, "_download_uspto_document", return_value=b"%PDF-1.4 fake"),
+        patch.object(mod, "_pdf_backend", return_value=_FakeFitz(pages)),
+        patch.object(mod, "_ocr_reader", return_value=_FakeEasyocr(ocr_calls)),
+    ):
+        result = tool.run({"applicationNumberText": "19053071"})
+
+    assert "error" not in result
+    assert ocr_calls == []
+
+
+def test_run_still_enforces_ocr_page_limit_when_pages_actually_need_ocr():
+    """The OCR budget still applies, counted over pages that lack embedded
+    text (not the document's total page count)."""
+    tool = _tool()
+    pages = [_FakePage("") for _ in range(mod._MAX_OCR_PAGES + 1)]
+    ocr_calls = []
+
+    with (
+        patch.object(mod.USPTOOpenDataPortalTool, "run", return_value=_pdf_metadata()),
+        patch.object(mod, "_download_uspto_document", return_value=b"%PDF-1.4 fake"),
+        patch.object(mod, "_pdf_backend", return_value=_FakeFitz(pages)),
+        patch.object(mod, "_ocr_reader", return_value=_FakeEasyocr(ocr_calls)),
+    ):
+        result = tool.run({"applicationNumberText": "19053071"})
+
+    assert result["error"] == "USPTO document retrieval failed on the provider."


### PR DESCRIPTION
## Summary

- OCR-fallback for scanned PDF pages in the USPTO downloader now runs **per page** instead of only when the *entire* document extracts to zero embedded text
- Pages with embedded text are used as-is; only pages with none are OCR'd
- The OCR page/pixel budgets (`_MAX_OCR_PAGES`, `_MAX_OCR_PIXELS_PER_PAGE`, `_MAX_OCR_TOTAL_PIXELS`) now apply to the pages actually OCR'd, not the document's total page count

## Context

Follow-up to #523 (closed as superseded by #546, which independently shipped a hardened, CPU-only rewrite of this same tool covering renaming/auth/fallback/retry). The one remaining gap between #523 and main's version was OCR granularity — main only OCR'd a PDF if the whole document had zero extractable text, and skipped OCR entirely for any document over the page budget regardless of whether OCR was actually needed. This PR fixes just that, on top of main's current implementation.

## Validation

- `pytest tests/unit/test_uspto_downloader_tool.py tests/tools/test_uspto_tool.py -q --no-cov` — 19 passed, including 3 new tests covering: a mixed text/scanned-page document only OCRs the scanned page, a large text-only document is not blocked by the OCR page budget, and the budget still applies when pages actually need OCR
- `ruff check` / `ruff format --check` clean (pre-existing lint findings in this file, unrelated to this change, left as-is)

Note: like the rest of this file, OCR/PDF behavior can't be exercised end-to-end without the optional `easyocr`/`pymupdf` dependencies and a live USPTO API key; the tests above mock the PDF/OCR backends directly.