### PR TITLE
Feature: register Exa's web-search MCP server (#563)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -76,6 +76,14 @@ HF_TOKEN=
 
 # === Literature & Patents ===
 
+# EXA_API_KEY (optional) — Raises Exa's rate limits for production use of the web-search MCP connection. (https://dashboard.exa.ai/)
+# Without: Works at Exa's free/casual rate limit without it.
+EXA_API_KEY=
+
+# EXA_MCP_URL (required) — Endpoint URL for the opt-in Exa web-search MCP connection. (https://exa.ai)
+# Without: Leave blank to keep this third-party MCP connection disabled. To enable, set this to https://mcp.exa.ai/mcp — the public endpoint requires no account for casual use.
+EXA_MCP_URL=
+
 # NCBI_API_KEY (optional) — Search PubMed and fetch citation metrics (iCite) and PubTator annotations. (https://www.ncbi.nlm.nih.gov/account/)
 # Without: Works at 3 requests/sec without it; the key raises the limit to 10/sec.
 NCBI_API_KEY=

--- a/src/tooluniverse/data/api_keys_catalog.json
+++ b/src/tooluniverse/data/api_keys_catalog.json
@@ -216,6 +216,30 @@
     ]
   },
   {
+    "name": "EXA_API_KEY",
+    "requirement": "optional",
+    "type": "secret",
+    "domain": "Literature & Patents",
+    "register_url": "https://dashboard.exa.ai/",
+    "purpose": "Raises Exa's rate limits for production use of the web-search MCP connection.",
+    "without": "Works at Exa's free/casual rate limit without it.",
+    "used_by": [
+      "mcp_auto_loader_exa.json"
+    ]
+  },
+  {
+    "name": "EXA_MCP_URL",
+    "requirement": "required",
+    "type": "endpoint",
+    "domain": "Literature & Patents",
+    "register_url": "https://exa.ai",
+    "purpose": "Endpoint URL for the opt-in Exa web-search MCP connection.",
+    "without": "Leave blank to keep this third-party MCP connection disabled. To enable, set this to https://mcp.exa.ai/mcp \u2014 the public endpoint requires no account for casual use.",
+    "used_by": [
+      "mcp_auto_loader_exa.json"
+    ]
+  },
+  {
     "name": "EXPERT_FEEDBACK_MCP_SERVER_URL",
     "requirement": "required",
     "type": "endpoint",

--- a/src/tooluniverse/data/mcp_auto_loader_exa.json
+++ b/src/tooluniverse/data/mcp_auto_loader_exa.json
@@ -1,0 +1,79 @@
+[
+  {
+    "name": "mcp_auto_loader_exa",
+    "description": "Opt-in connection to Exa's official web-search MCP server (https://mcp.exa.ai/mcp). Discovers two reviewed, read-only tools for neural/semantic web search and full-page content extraction over Exa's own web index — general internet retrieval, distinct from ToolUniverse's structured scientific-database tools. The hosted public server needs no API key for casual use; an optional key raises rate limits for production use.",
+    "type": "MCPAutoLoaderTool",
+    "tool_prefix": "exa_",
+    "server_url": "${EXA_MCP_URL}",
+    "transport": "http",
+    "timeout": 30,
+    "strict_tool_contracts": true,
+    "http_headers_from_env": {
+      "x-api-key": {
+        "env": "EXA_API_KEY"
+      }
+    },
+    "selected_tools": [
+      "web_search_exa",
+      "web_fetch_exa"
+    ],
+    "tool_contracts": [
+      {
+        "name": "web_search_exa",
+        "title": "Search the web (Exa)",
+        "description": "Neural/semantic web search over Exa's own index. Describe the ideal page in natural language rather than keywords (e.g. 'blog post comparing React and Vue performance'). Use category:people or category:company to focus results. Returns clean, ready-to-use content from top results; follow up with exa_web_fetch_exa if the returned content is insufficient.",
+        "contract_sha256": "3bd880d7e5c7f2110eaf5c1d08dee4b02cf95e27d6b944c7af5275c682e1ab64",
+        "annotations": {"readOnlyHint": true, "destructiveHint": false, "idempotentHint": true, "openWorldHint": true}
+      },
+      {
+        "name": "web_fetch_exa",
+        "title": "Fetch a webpage's content (Exa)",
+        "description": "Read one or more webpages' full content as clean markdown. Use after exa_web_search_exa when the search result content is insufficient, or to read any known URL directly. Batch multiple URLs in one call.",
+        "contract_sha256": "c52bc77073c7d3ba0fcc0f08e3bd2a0e90fd2327d50f64ad765e9549194e1dd0",
+        "annotations": {"readOnlyHint": true, "destructiveHint": false, "idempotentHint": true, "openWorldHint": true}
+      }
+    ],
+    "required_api_keys": ["EXA_MCP_URL"],
+    "optional_api_keys": ["EXA_API_KEY"],
+    "api_key_info": {
+      "EXA_MCP_URL": {
+        "domain": "Literature & Patents",
+        "type": "endpoint",
+        "register_url": "https://exa.ai",
+        "purpose": "Endpoint URL for the opt-in Exa web-search MCP connection.",
+        "without": "Leave blank to keep this third-party MCP connection disabled. To enable, set this to https://mcp.exa.ai/mcp — the public endpoint requires no account for casual use."
+      },
+      "EXA_API_KEY": {
+        "domain": "Literature & Patents",
+        "type": "secret",
+        "register_url": "https://dashboard.exa.ai/",
+        "purpose": "Raises Exa's rate limits for production use of the web-search MCP connection.",
+        "without": "Works at Exa's free/casual rate limit without it."
+      }
+    },
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "operation": {
+          "type": "string",
+          "enum": ["discover", "generate_configs", "call_tool"],
+          "description": "Discover reviewed tools, generate proxy configurations, or call one reviewed tool."
+        },
+        "tool_name": {
+          "type": "string",
+          "description": "Reviewed MCP tool name, required when operation is call_tool."
+        },
+        "tool_arguments": {
+          "type": "object",
+          "description": "Search query or URL-fetch arguments for the selected tool."
+        }
+      },
+      "required": ["operation"]
+    },
+    "return_schema": {
+      "type": "object",
+      "description": "Reviewed Exa web-search MCP discovery data or structured tool result.",
+      "additionalProperties": true
+    }
+  }
+]

--- a/src/tooluniverse/default_config.py
+++ b/src/tooluniverse/default_config.py
@@ -363,6 +363,9 @@ default_tool_files = {
     "mcp_auto_loader_noodle": os.path.join(
         current_dir, "data", "mcp_auto_loader_noodle.json"
     ),
+    "mcp_auto_loader_exa": os.path.join(
+        current_dir, "data", "mcp_auto_loader_exa.json"
+    ),
     "cryoet": os.path.join(current_dir, "data", "cryoet_tools.json"),
     "esm": os.path.join(current_dir, "data", "esm_tools.json"),
     "structure_annotation": os.path.join(

--- a/tests/integration/test_mcp_auto_loader_exa_live.py
+++ b/tests/integration/test_mcp_auto_loader_exa_live.py
@@ -1,0 +1,34 @@
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+from tooluniverse.default_config import default_tool_files
+from tooluniverse.mcp_client_tool import MCPAutoLoaderTool, _unwrap_mcp_tool_result
+
+PUBLIC_ENDPOINT = "https://mcp.exa.ai/mcp"
+
+
+@pytest.mark.integration
+@pytest.mark.network
+@pytest.mark.mcp
+@pytest.mark.asyncio
+async def test_exa_reviewed_tools_match_live_contract_and_return_readable_text():
+    config_path = Path(default_tool_files["mcp_auto_loader_exa"])
+    config = copy.deepcopy(json.loads(config_path.read_text())[0])
+    config["server_url"] = PUBLIC_ENDPOINT
+
+    loader = MCPAutoLoaderTool(config)
+    tools = await loader.discover_tools()
+
+    assert list(tools) == config["selected_tools"]
+    assert all(tool["annotations"]["readOnlyHint"] for tool in tools.values())
+
+    response = await loader.call_tool(
+        "web_search_exa", {"query": "CRISPR gene editing", "numResults": 1}
+    )
+    assert not response.get("isError")
+    result = _unwrap_mcp_tool_result(response)
+    assert isinstance(result, str)
+    assert "URL:" in result

--- a/tests/unit/test_mcp_auto_loader_exa_config.py
+++ b/tests/unit/test_mcp_auto_loader_exa_config.py
@@ -1,0 +1,51 @@
+import json
+from pathlib import Path
+
+from tooluniverse.default_config import default_tool_files
+
+EXPECTED_HASHES = {
+    "web_search_exa": (
+        "3bd880d7e5c7f2110eaf5c1d08dee4b02cf95e27d6b944c7af5275c682e1ab64"
+    ),
+    "web_fetch_exa": (
+        "c52bc77073c7d3ba0fcc0f08e3bd2a0e90fd2327d50f64ad765e9549194e1dd0"
+    ),
+}
+
+
+def test_exa_loader_is_opt_in_allowlisted_and_contract_pinned():
+    config_path = Path(default_tool_files["mcp_auto_loader_exa"])
+    config = json.loads(config_path.read_text())[0]
+    contracts = {item["name"]: item for item in config["tool_contracts"]}
+
+    assert config["server_url"] == "${EXA_MCP_URL}"
+    assert config["required_api_keys"] == ["EXA_MCP_URL"]
+    assert config["optional_api_keys"] == ["EXA_API_KEY"]
+    assert config["tool_prefix"] == "exa_"
+    assert config["strict_tool_contracts"] is True
+    assert config["selected_tools"] == list(EXPECTED_HASHES)
+    assert {
+        name: item["contract_sha256"] for name, item in contracts.items()
+    } == EXPECTED_HASHES
+    assert all(item["annotations"]["readOnlyHint"] for item in contracts.values())
+    assert all(
+        not item["annotations"]["destructiveHint"] for item in contracts.values()
+    )
+
+
+def test_exa_loader_does_not_require_structured_content():
+    """Exa's public MCP server returns plain-text content, not structuredContent
+    (verified live) — requiring it would make every call fail with 'did not
+    return required structuredContent'."""
+    config_path = Path(default_tool_files["mcp_auto_loader_exa"])
+    config = json.loads(config_path.read_text())[0]
+
+    assert config.get("normalize_mcp_result") is not True
+    assert config.get("require_structured_content") is not True
+
+
+def test_exa_loader_optional_api_key_lifts_rate_limit_via_header():
+    config_path = Path(default_tool_files["mcp_auto_loader_exa"])
+    config = json.loads(config_path.read_text())[0]
+
+    assert config["http_headers_from_env"]["x-api-key"]["env"] == "EXA_API_KEY"


### PR DESCRIPTION
## Summary

Fixes #563: registers an opt-in connection to Exa's official web-search MCP server (`https://mcp.exa.ai/mcp`), giving ToolUniverse a general web/open-internet retrieval channel — distinct from its existing structured scientific-database tools, as requested.

## Scope decision

Per the discussion on #563, this registers Exa's own MCP server rather than wrapping their full REST API natively.

## What it adds

Two tools, discovered live from Exa's server and gated behind `EXA_MCP_URL` (blank by default, so this connection stays opt-in):
- `exa_web_search_exa` — neural/semantic web search over Exa's own index
- `exa_web_fetch_exa` — full-page content extraction as clean markdown

An optional `EXA_API_KEY` lifts Exa's rate limit via an `x-api-key` header; the connection works without it.

## Implementation notes

Follows the established `mcp_auto_loader_*` pattern (Folklore, Noodle, Genomic Intelligence): tool schemas are discovered from the live server and pinned via `contract_sha256`, so an upstream schema change fails loudly instead of silently drifting.

One real difference from the existing templates, found by testing live rather than assuming: Exa's server returns plain-text content, not `structuredContent`. Copying `normalize_mcp_result`/`require_structured_content` from the Noodle config initially made every call fail with *"did not return required structuredContent"*. Dropped both, letting the existing `_unwrap_mcp_tool_result` plain-text fallback handle it.

## Validation

Fully verified live, end to end, against the real server — this is not just mocked:
- Discovery: both tools found, contract hashes matched (no drift)
- Real search call: returned real papers/pages for a live query
- Real fetch call: returned real page content

```python
from tooluniverse import ToolUniverse
tu = ToolUniverse()
tu.load_tools(categories=["mcp_auto_loader_exa"])  # with EXA_MCP_URL set
tu.run({"name": "exa_web_search_exa", "arguments": {"query": "CRISPR gene editing recent advances", "numResults": 1}})
# -> real Nature/Cell paper results, not a mock
```

## Test coverage

- `tests/unit/test_mcp_auto_loader_exa_config.py` — config shape, contract hashes, opt-in gating (no network)
- `tests/integration/test_mcp_auto_loader_exa_live.py` — live contract + real tool call (`network`/`integration`/`mcp` marked, excluded from the default test run like its siblings)

## How to test this yourself

```bash
# Install ToolUniverse from this branch instead of PyPI:
uv pip install "git+https://github.com/mims-harvard/ToolUniverse.git@feature/exa-mcp-integration"

# Or via uvx directly, no separate install step:
EXA_MCP_URL=https://mcp.exa.ai/mcp uvx --from "git+https://github.com/mims-harvard/ToolUniverse.git@feature/exa-mcp-integration" tooluniverse
```

Or point an existing checkout at this branch and `pip install -e .`, then set `EXA_MCP_URL=https://mcp.exa.ai/mcp` (and optionally `EXA_API_KEY`) before calling `exa_web_search_exa` / `exa_web_fetch_exa`.
