### PR TITLE
Feature: add Consensus_search_papers tool (#562) — needs a real key to verify

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -76,6 +76,10 @@ HF_TOKEN=
 
 # === Literature & Patents ===
 
+# CONSENSUS_API_KEY (required) — Search 220M+ peer-reviewed papers via the Consensus API. (https://consensus.app/home/api)
+# Without: Consensus tools are blocked without it. Requires a paid Consensus account (Pro, Deep, or Teams plan).
+CONSENSUS_API_KEY=
+
 # NCBI_API_KEY (optional) — Search PubMed and fetch citation metrics (iCite) and PubTator annotations. (https://www.ncbi.nlm.nih.gov/account/)
 # Without: Works at 3 requests/sec without it; the key raises the limit to 10/sec.
 NCBI_API_KEY=

--- a/src/tooluniverse/consensus_tool.py
+++ b/src/tooluniverse/consensus_tool.py
@@ -1,0 +1,120 @@
+import os
+
+import requests
+
+from .base_tool import BaseTool
+from .http_utils import request_with_retry
+from .tool_registry import register_tool
+
+_BOOL_PARAMS = (
+    "human",
+    "controlled",
+    "exclude_preprints",
+    "medical_mode",
+    "open_access",
+    "include_semantic_score",
+    "include_full_text_chunks",
+)
+_PASSTHROUGH_PARAMS = (
+    "year_min",
+    "year_max",
+    "month_min",
+    "month_max",
+    "study_types",
+    "sample_size_min",
+    "sjr_min",
+    "sjr_max",
+    "citation_min",
+    "domain",
+    "country",
+    "journal_name",
+    "publisher_name",
+    "page",
+)
+
+
+@register_tool("ConsensusTool")
+class ConsensusTool(BaseTool):
+    """
+    Search 220M+ peer-reviewed papers via the Consensus API.
+
+    API key is required and read from the CONSENSUS_API_KEY environment
+    variable. Request one at: https://consensus.app/home/api
+    """
+
+    def __init__(self, tool_config, base_url="https://api.consensus.app/v1/search"):
+        super().__init__(tool_config)
+        self.base_url = base_url
+        self.session = requests.Session()
+        self.session.headers.update({"Accept": "application/json"})
+
+    def run(self, arguments):
+        query = arguments.get("query")
+        if not query:
+            return {"status": "error", "error": "`query` parameter is required."}
+
+        api_key = os.environ.get("CONSENSUS_API_KEY", "")
+        if not api_key:
+            return {
+                "status": "error",
+                "error": (
+                    "CONSENSUS_API_KEY environment variable is not set. "
+                    "Request a key at https://consensus.app/home/api."
+                ),
+            }
+
+        params = {"query": query}
+        for name in _BOOL_PARAMS:
+            value = arguments.get(name)
+            if value is not None:
+                params[name] = "true" if value else "false"
+        for name in _PASSTHROUGH_PARAMS:
+            value = arguments.get(name)
+            if value is not None:
+                params[name] = value
+
+        try:
+            response = request_with_retry(
+                self.session,
+                "GET",
+                self.base_url,
+                params=params,
+                headers={"x-api-key": api_key},
+                timeout=30,
+            )
+        except requests.RequestException as exc:
+            return {"status": "error", "error": f"Request failed: {exc}"}
+
+        if response.status_code == 401:
+            return {
+                "status": "error",
+                "error": "Consensus rejected the API key (401 Not authenticated).",
+            }
+        if response.status_code != 200:
+            return {
+                "status": "error",
+                "error": f"Consensus API returned {response.status_code}: {response.reason}",
+                "retryable": response.status_code in (429, 500, 502, 503, 504),
+            }
+
+        try:
+            payload = response.json()
+        except ValueError:
+            return {
+                "status": "error",
+                "error": "Consensus API returned a non-JSON response.",
+            }
+
+        results = payload.get("results", [])
+        return {
+            "status": "success",
+            "data": results,
+            "metadata": {
+                "query": query,
+                "returned": len(results),
+                "page": payload.get("page"),
+                "page_size": payload.get("page_size"),
+                "is_end": payload.get("is_end"),
+                "next_page": payload.get("next_page"),
+            },
+        }

--- a/src/tooluniverse/data/api_keys_catalog.json
+++ b/src/tooluniverse/data/api_keys_catalog.json
@@ -180,6 +180,18 @@
     ]
   },
   {
+    "name": "CONSENSUS_API_KEY",
+    "requirement": "required",
+    "type": "secret",
+    "domain": "Literature & Patents",
+    "register_url": "https://consensus.app/home/api",
+    "purpose": "Search 220M+ peer-reviewed papers via the Consensus API.",
+    "without": "Consensus tools are blocked without it. Requires a paid Consensus account (Pro, Deep, or Teams plan).",
+    "used_by": [
+      "consensus_tools.json"
+    ]
+  },
+  {
     "name": "DISGENET_API_KEY",
     "requirement": "required",
     "type": "secret",

--- a/src/tooluniverse/data/consensus_tools.json
+++ b/src/tooluniverse/data/consensus_tools.json
@@ -1,0 +1,166 @@
+[
+  {
+    "type": "ConsensusTool",
+    "name": "Consensus_search_papers",
+    "description": "Search 220M+ peer-reviewed papers via the Consensus API (https://consensus.app), returning ranked papers with an AI-generated one-line takeaway per paper plus study-design metadata (study type, sample size, journal quality) for evidence triage rather than raw retrieval. Complements PubMed/Europe PMC/OpenAlex: broader than biomedical-only sources, and surfaces a synthesized 'what does this paper conclude' takeaway instead of just an abstract. Requires CONSENSUS_API_KEY (paid Consensus account: https://consensus.app/home/api).",
+    "required_api_keys": ["CONSENSUS_API_KEY"],
+    "api_key_info": {
+      "CONSENSUS_API_KEY": {
+        "domain": "Literature & Patents",
+        "type": "secret",
+        "register_url": "https://consensus.app/home/api",
+        "purpose": "Search 220M+ peer-reviewed papers via the Consensus API.",
+        "without": "Consensus tools are blocked without it. Requires a paid Consensus account (Pro, Deep, or Teams plan)."
+      }
+    },
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "query": {
+          "type": "string",
+          "description": "Natural-language research question, e.g. 'Does creatine improve cognition?'"
+        },
+        "year_min": {
+          "type": "integer",
+          "description": "Minimum publication year."
+        },
+        "year_max": {
+          "type": "integer",
+          "description": "Maximum publication year."
+        },
+        "month_min": {
+          "type": "integer",
+          "description": "Minimum publication month (1-12), used with year_min."
+        },
+        "month_max": {
+          "type": "integer",
+          "description": "Maximum publication month (1-12), used with year_max."
+        },
+        "study_types": {
+          "type": "string",
+          "description": "Comma-separated study designs to filter by, e.g. 'rct,meta-analysis,systematic review,cohort study'."
+        },
+        "human": {
+          "type": "boolean",
+          "description": "Restrict to human studies only."
+        },
+        "controlled": {
+          "type": "boolean",
+          "description": "Restrict to controlled studies only."
+        },
+        "sample_size_min": {
+          "type": "integer",
+          "description": "Minimum study sample size."
+        },
+        "exclude_preprints": {
+          "type": "boolean",
+          "description": "Exclude preprints from results."
+        },
+        "sjr_min": {
+          "type": "integer",
+          "description": "Minimum SJR journal-quality quartile (1 = top quartile)."
+        },
+        "sjr_max": {
+          "type": "integer",
+          "description": "Maximum SJR journal-quality quartile (1 = top quartile)."
+        },
+        "citation_min": {
+          "type": "integer",
+          "description": "Minimum citation count."
+        },
+        "medical_mode": {
+          "type": "boolean",
+          "description": "Restrict to top medical journals and clinical guidelines (~8M docs)."
+        },
+        "domain": {
+          "type": "string",
+          "description": "Subject area filter, e.g. 'med', 'bio', 'cs', 'psych', 'econ'."
+        },
+        "country": {
+          "type": "string",
+          "description": "Filter by study country."
+        },
+        "journal_name": {
+          "type": "string",
+          "description": "Filter by exact journal name."
+        },
+        "publisher_name": {
+          "type": "string",
+          "description": "Filter by publisher name."
+        },
+        "open_access": {
+          "type": "boolean",
+          "description": "Restrict to open-access papers only."
+        },
+        "include_semantic_score": {
+          "type": "boolean",
+          "description": "Include a relevance (semantic similarity) score per result."
+        },
+        "include_full_text_chunks": {
+          "type": "boolean",
+          "description": "Include query-relevant full-text excerpts per result, where available."
+        },
+        "page": {
+          "type": "integer",
+          "description": "Zero-indexed page number for pagination; see the returned next_page/is_end fields."
+        }
+      },
+      "required": ["query"]
+    },
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "description": "Search results with pagination metadata.",
+          "properties": {
+            "status": {"type": "string", "enum": ["success"]},
+            "data": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "title": {"type": "string"},
+                  "authors": {"type": "array", "items": {"type": "string"}},
+                  "publish_year": {"type": "integer"},
+                  "doi": {"type": ["string", "null"]},
+                  "journal_name": {"type": ["string", "null"]},
+                  "citation_count": {"type": ["integer", "null"]},
+                  "study_type": {"type": ["string", "null"]},
+                  "sample_size": {"type": ["integer", "null"]},
+                  "sjr_best_quartile": {"type": ["integer", "null"]},
+                  "takeaway": {"type": ["string", "null"]},
+                  "abstract": {"type": ["string", "null"]},
+                  "url": {"type": "string"}
+                }
+              }
+            },
+            "metadata": {
+              "type": "object",
+              "properties": {
+                "query": {"type": "string"},
+                "returned": {"type": "integer"},
+                "page": {"type": ["integer", "null"]},
+                "page_size": {"type": ["integer", "null"]},
+                "is_end": {"type": ["boolean", "null"]},
+                "next_page": {"type": ["integer", "null"]}
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "description": "Error response.",
+          "properties": {
+            "status": {"type": "string", "enum": ["error"]},
+            "error": {"type": "string"}
+          }
+        }
+      ]
+    },
+    "test_examples": [
+      {
+        "query": "Does creatine improve cognition?"
+      }
+    ]
+  }
+]

--- a/src/tooluniverse/default_config.py
+++ b/src/tooluniverse/default_config.py
@@ -34,6 +34,7 @@ default_tool_files = {
     "semantic_scholar": os.path.join(
         current_dir, "data", "semantic_scholar_tools.json"
     ),
+    "consensus": os.path.join(current_dir, "data", "consensus_tools.json"),
     "pubtator": os.path.join(current_dir, "data", "pubtator_tools.json"),
     "EFO": os.path.join(current_dir, "data", "efo_tools.json"),
     "Enrichr": os.path.join(current_dir, "data", "enrichr_tools.json"),

--- a/tests/tools/test_consensus_tool.py
+++ b/tests/tools/test_consensus_tool.py
@@ -1,0 +1,177 @@
+"""Unit tests for the Consensus search tool.
+
+No real CONSENSUS_API_KEY is available in this environment (Consensus
+requires a paid account), so these tests mock the HTTP layer rather than
+call the live API, matching the established convention for API-key-gated
+tools (see test_semantic_scholar_tool_resilience.py). The fixture response
+shape is copied from Consensus's own published API documentation
+(https://github.com/Consensus-NLP/consensus-api), not invented, but it has
+not been verified against a real live response and should be re-checked
+against a real key before this tool ships to real users.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.consensus_tool import ConsensusTool
+
+
+class _FakeResponse:
+    def __init__(self, status_code=200, payload=None, reason=""):
+        self.status_code = status_code
+        self._payload = payload if payload is not None else {}
+        self.reason = reason
+        self.headers = {}
+
+    def json(self):
+        return self._payload
+
+
+# Fixture shape from Consensus's own documented example response.
+_DOCUMENTED_RESPONSE = {
+    "results": [
+        {
+            "title": "The effects of creatine supplementation on cognitive performance",
+            "authors": ["Sandkühler, J.F."],
+            "publish_year": 2023,
+            "doi": "10.1186/s12916-023-03146-5",
+            "journal_name": "BMC Medicine",
+            "citation_count": 47,
+            "study_type": "rct",
+            "sample_size": 123,
+            "sjr_best_quartile": 1,
+            "takeaway": "Creatine supplementation showed small positive effects on cognitive performance.",
+            "abstract": "...",
+            "url": "https://consensus.app/papers/example",
+        }
+    ],
+    "page": 0,
+    "page_size": 20,
+    "is_end": False,
+    "next_page": 1,
+}
+
+
+@pytest.mark.unit
+def test_requires_query():
+    tool = ConsensusTool({"name": "Consensus_search_papers"})
+    result = tool.run({})
+    assert result["status"] == "error"
+    assert "query" in result["error"]
+
+
+@pytest.mark.unit
+def test_missing_api_key_returns_clear_error(monkeypatch):
+    monkeypatch.delenv("CONSENSUS_API_KEY", raising=False)
+    tool = ConsensusTool({"name": "Consensus_search_papers"})
+    result = tool.run({"query": "creatine cognition"})
+    assert result["status"] == "error"
+    assert "CONSENSUS_API_KEY" in result["error"]
+
+
+@pytest.mark.unit
+def test_successful_search_returns_documented_shape(monkeypatch):
+    monkeypatch.setenv("CONSENSUS_API_KEY", "test-key")
+    tool = ConsensusTool({"name": "Consensus_search_papers"})
+
+    captured = {}
+
+    def fake_request_with_retry(
+        session, method, url, *, params=None, headers=None, **kwargs
+    ):
+        captured["method"] = method
+        captured["url"] = url
+        captured["params"] = params
+        captured["headers"] = headers
+        return _FakeResponse(status_code=200, payload=_DOCUMENTED_RESPONSE)
+
+    monkeypatch.setattr(
+        "tooluniverse.consensus_tool.request_with_retry", fake_request_with_retry
+    )
+
+    result = tool.run({"query": "Does creatine improve cognition?"})
+
+    assert captured["method"] == "GET"
+    assert captured["url"] == "https://api.consensus.app/v1/search"
+    assert captured["params"]["query"] == "Does creatine improve cognition?"
+    assert captured["headers"]["x-api-key"] == "test-key"
+
+    assert result["status"] == "success"
+    assert result["data"] == _DOCUMENTED_RESPONSE["results"]
+    assert result["metadata"]["returned"] == 1
+    assert result["metadata"]["next_page"] == 1
+    assert result["metadata"]["is_end"] is False
+
+
+@pytest.mark.unit
+def test_boolean_and_passthrough_filters_are_forwarded(monkeypatch):
+    monkeypatch.setenv("CONSENSUS_API_KEY", "test-key")
+    tool = ConsensusTool({"name": "Consensus_search_papers"})
+
+    captured = {}
+
+    def fake_request_with_retry(session, method, url, *, params=None, **kwargs):
+        captured["params"] = params
+        return _FakeResponse(status_code=200, payload={"results": []})
+
+    monkeypatch.setattr(
+        "tooluniverse.consensus_tool.request_with_retry", fake_request_with_retry
+    )
+
+    tool.run(
+        {
+            "query": "x",
+            "human": True,
+            "exclude_preprints": False,
+            "year_min": 2015,
+            "study_types": "rct,meta-analysis",
+            "sjr_min": 1,
+        }
+    )
+
+    assert captured["params"]["human"] == "true"
+    assert captured["params"]["exclude_preprints"] == "false"
+    assert captured["params"]["year_min"] == 2015
+    assert captured["params"]["study_types"] == "rct,meta-analysis"
+    assert captured["params"]["sjr_min"] == 1
+    # Unset optional filters are omitted, not sent as null/None.
+    assert "domain" not in captured["params"]
+    assert "page" not in captured["params"]
+
+
+@pytest.mark.unit
+def test_unauthenticated_response_returns_clear_error(monkeypatch):
+    monkeypatch.setenv("CONSENSUS_API_KEY", "wrong-key")
+    tool = ConsensusTool({"name": "Consensus_search_papers"})
+
+    def fake_request_with_retry(*args, **kwargs):
+        return _FakeResponse(status_code=401, reason="Unauthorized")
+
+    monkeypatch.setattr(
+        "tooluniverse.consensus_tool.request_with_retry", fake_request_with_retry
+    )
+
+    result = tool.run({"query": "x"})
+    assert result["status"] == "error"
+    assert "401" in result["error"] or "authenticat" in result["error"].lower()
+
+
+@pytest.mark.unit
+def test_server_error_is_marked_retryable(monkeypatch):
+    monkeypatch.setenv("CONSENSUS_API_KEY", "test-key")
+    tool = ConsensusTool({"name": "Consensus_search_papers"})
+
+    def fake_request_with_retry(*args, **kwargs):
+        return _FakeResponse(status_code=503, reason="Service Unavailable")
+
+    monkeypatch.setattr(
+        "tooluniverse.consensus_tool.request_with_retry", fake_request_with_retry
+    )
+
+    result = tool.run({"query": "x"})
+    assert result["status"] == "error"
+    assert result["retryable"] is True


### PR DESCRIPTION
## Summary

Addresses #562: adds a native `Consensus_search_papers` tool wrapping Consensus's REST search API (`GET https://api.consensus.app/v1/search`), returning papers from their 220M+ peer-reviewed corpus with an AI-generated per-paper takeaway and study-design metadata (study type, sample size, journal quality) — evidence triage rather than raw retrieval, complementing PubMed/Europe PMC/OpenAlex.

## Scope decision: native API tool, not their MCP server

#562 offered two options. Consensus also publishes an official MCP server (`https://mcp.consensus.app/mcp`), which was the initially-approved scope to match how #563 (Exa) was registered. Confirmed live that it requires full OAuth 2.0 (`WWW-Authenticate: Bearer resource_metadata=".../oauth-protected-resource"`), which ToolUniverse's MCP client framework doesn't support at all — only static header/Bearer-token auth. Building OAuth support is a separate, larger infrastructure task, not specific to Consensus, so this PR wraps their plain REST API instead — the other option #562 itself offered. Confirmed live that the REST API needs only a static `x-api-key` header (`401` + `WWW-Authenticate: APIKey` on an unauthenticated probe), matching dozens of other API-key-gated tools already in ToolUniverse.

## ⚠️ Not verified against a real API call — needs a reviewer with a Consensus account

I don't have a Consensus API key (their API requires a paid Pro/Deep/Teams account) and didn't want to sign up for a paid third-party account to test this myself. Everything checkable **without** a real key has been checked carefully:

- Confirmed live (unauthenticated probes against `api.consensus.app`): the endpoint exists, the method is `GET` (not `POST` — that returns `405`), the header name is `x-api-key`, and the auth-failure shape is a clean `401`.
- Resolved a real ambiguity: Consensus has two endpoints, `/v1/quick_search` (deprecated, removal 2027-02-07) and `/v1/search` (current). Confirmed via their own docs (`llms.txt`) that `/v1/search` — what this PR uses — is the correct, current one.
- Cross-checked all 22 documented request parameters and the full response shape (`results`, `page`, `page_size`, `is_end`, `next_page`, and every per-paper field) against [Consensus's own published API reference](https://github.com/Consensus-NLP/consensus-api) — all present, none missing, none extra.
- Verified `request_with_retry`'s actual contract by reading its source (never raises on non-2xx, doesn't retry `401`) matches what this tool's error handling assumes.

**One genuine open question:** how Consensus expects boolean parameters (`human`, `controlled`, `exclude_preprints`, `medical_mode`, `open_access`, `include_semantic_score`, `include_full_text_chunks`) serialized in the query string. No example anywhere I could access shows a real boolean value. This tool sends literal `"true"`/`"false"` strings, which is the standard FastAPI/Pydantic convention (their `server: uvicorn` header strongly implies FastAPI) — reasonably confident, not certain.

**If you have a Consensus API key, testing this and confirming (or fixing) the boolean handling would be genuinely useful before merging.**

## Test coverage

`tests/tools/test_consensus_tool.py` mocks the HTTP layer using Consensus's own documented example response as the fixture (following the same convention as `test_semantic_scholar_tool_resilience.py`): missing-query error, missing-API-key error, successful parse, boolean/passthrough filter forwarding, `401` handling, retryable-status marking. All pass, but none of them touch the real network.

## How to test this yourself

```bash
# Install ToolUniverse from this branch instead of PyPI:
uv pip install "git+https://github.com/mims-harvard/ToolUniverse.git@feature/consensus-search-tool"

# Or via uvx directly, no separate install step:
CONSENSUS_API_KEY=your_real_key uvx --from "git+https://github.com/mims-harvard/ToolUniverse.git@feature/consensus-search-tool" tooluniverse
```

Or point an existing checkout at this branch and `pip install -e .`, then with `CONSENSUS_API_KEY` set:

```python
from tooluniverse import ToolUniverse
tu = ToolUniverse()
tu.load_tools(categories=["consensus"])
print(tu.run({"name": "Consensus_search_papers", "arguments": {"query": "Does creatine improve cognition?"}}))
```

If the boolean filters (`human`, `open_access`, etc.) don't behave as expected, that's exactly the thing I couldn't verify without a key — a report or a fix would be very welcome.
