### PR TITLE
Add SerpBase backend to web_search (#564)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -220,6 +220,10 @@ REPLICATE_API_TOKEN=
 
 # === Other ===
 
+# SERPBASE_API_KEY (optional) — Query the backend='serpbase' option for real Google SERP results (https://api.serpbase.dev), billed per request. (https://serpbase.dev)
+# Without: web_search still works via DDGS/Parallel/DuckDuckGo-HTML/Wikipedia; backend='serpbase' is blocked without it.
+SERPBASE_API_KEY=
+
 # WAQI_API_KEY (optional) — Fetch real per-city air quality data from the World Air Quality Index API. (https://aqicn.org/data-platform/token/)
 # Without: Falls back to the public 'demo' token, which returns a fixed sample station (Shanghai) for every city. The key is free.
 WAQI_API_KEY=

--- a/src/tooluniverse/data/api_keys_catalog.json
+++ b/src/tooluniverse/data/api_keys_catalog.json
@@ -537,6 +537,18 @@
     ]
   },
   {
+    "name": "SERPBASE_API_KEY",
+    "requirement": "optional",
+    "type": "secret",
+    "domain": "Other",
+    "register_url": "https://serpbase.dev",
+    "purpose": "Query the backend='serpbase' option for real Google SERP results (https://api.serpbase.dev), billed per request.",
+    "without": "web_search still works via DDGS/Parallel/DuckDuckGo-HTML/Wikipedia; backend='serpbase' is blocked without it.",
+    "used_by": [
+      "web_search_tools.json"
+    ]
+  },
+  {
     "name": "TXAGENT_MCP_SERVER_HOST",
     "requirement": "required",
     "type": "endpoint",

--- a/src/tooluniverse/data/web_search_tools.json
+++ b/src/tooluniverse/data/web_search_tools.json
@@ -2,7 +2,7 @@
   {
     "type": "WebSearchTool",
     "name": "web_search",
-    "description": "General web search using DDGS (Dux Distributed Global Search) supporting multiple search engines including Google, Bing, Brave, Yahoo, and DuckDuckGo. No API keys required. Parallel Search MCP is opt-in; selecting it sends the query to Parallel's hosted third-party service, so do not submit sensitive or patient-identifying information.",
+    "description": "General web search using DDGS (Dux Distributed Global Search) supporting multiple search engines including Google, Bing, Brave, Yahoo, and DuckDuckGo. No API keys required. Parallel Search MCP and SerpBase are opt-in; selecting either sends the query to that hosted third-party service, so do not submit sensitive or patient-identifying information. SerpBase additionally requires SERPBASE_API_KEY and returns real Google SERP results (billed per request), useful when DDGS's Google backend is unavailable or rate-limited.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -30,10 +30,11 @@
         },
         "backend": {
           "type": "string",
-          "description": "Search engine backend to use. Selecting 'parallel' sends the query to https://search.parallel.ai/mcp; that backend does not apply ToolUniverse region or safesearch controls.",
+          "description": "Search engine backend to use. Selecting 'parallel' sends the query to https://search.parallel.ai/mcp; that backend does not apply ToolUniverse region or safesearch controls. Selecting 'serpbase' sends the query to https://api.serpbase.dev (requires SERPBASE_API_KEY) for real Google SERP results; that backend applies region but not safesearch.",
           "enum": [
             "auto",
             "parallel",
+            "serpbase",
             "google",
             "bing",
             "brave",
@@ -44,7 +45,7 @@
         },
         "region": {
           "type": "string",
-          "description": "Search region/locale for DDGS backends. Parallel does not support this control; only the default value is accepted with backend='parallel'.",
+          "description": "Search region/locale for DDGS backends, and country/language for the SerpBase backend (split on the hyphen into gl/hl). Parallel does not support this control; only the default value is accepted with backend='parallel'.",
           "enum": [
             "us-en",
             "cn-zh",
@@ -57,7 +58,7 @@
         },
         "safesearch": {
           "type": "string",
-          "description": "Safe search level for DDGS backends. Parallel does not support this control; only the default value is accepted with backend='parallel'.",
+          "description": "Safe search level for DDGS backends. Parallel and SerpBase do not support this control; only the default value is accepted with those backends.",
           "enum": [
             "on",
             "moderate",
@@ -69,6 +70,16 @@
       "required": [
         "query"
       ]
+    },
+    "optional_api_keys": ["SERPBASE_API_KEY"],
+    "api_key_info": {
+      "SERPBASE_API_KEY": {
+        "domain": "Other",
+        "type": "secret",
+        "register_url": "https://serpbase.dev",
+        "purpose": "Query the backend='serpbase' option for real Google SERP results (https://api.serpbase.dev), billed per request.",
+        "without": "web_search still works via DDGS/Parallel/DuckDuckGo-HTML/Wikipedia; backend='serpbase' is blocked without it."
+      }
     },
     "return_schema": {
       "oneOf": [
@@ -208,10 +219,11 @@
         },
         "backend": {
           "type": "string",
-          "description": "Search engine backend to use. Selecting 'parallel' sends the query to https://search.parallel.ai/mcp.",
+          "description": "Search engine backend to use. Selecting 'parallel' sends the query to https://search.parallel.ai/mcp. Selecting 'serpbase' sends the query to https://api.serpbase.dev (requires SERPBASE_API_KEY) for real Google SERP results.",
           "enum": [
             "auto",
             "parallel",
+            "serpbase",
             "google",
             "bing",
             "brave",

--- a/src/tooluniverse/web_search_tool.py
+++ b/src/tooluniverse/web_search_tool.py
@@ -1,6 +1,7 @@
 """Web search tools for ToolUniverse using Parallel Search MCP and DDGS."""
 
 import json
+import os
 import re
 import subprocess
 import sys
@@ -20,6 +21,14 @@ PARALLEL_PROVIDER_NOTICE = (
     "Query sent to Parallel's hosted third-party Search MCP service at "
     f"{PARALLEL_SEARCH_MCP_URL}. ToolUniverse region and safesearch controls "
     "are not applied by this backend; do not submit sensitive or "
+    "patient-identifying information."
+)
+
+SERPBASE_SEARCH_URL = "https://api.serpbase.dev/google/search"
+SERPBASE_PROVIDER_NOTICE = (
+    "Query sent to SerpBase's hosted third-party Google-SERP API at "
+    f"{SERPBASE_SEARCH_URL} (billed per request). ToolUniverse safesearch "
+    "control is not applied by this backend; do not submit sensitive or "
     "patient-identifying information."
 )
 
@@ -187,6 +196,64 @@ print(json.dumps(results))
 
         return results
 
+    def _search_with_serpbase(
+        self, query: str, max_results: int, region: str = "us-en"
+    ) -> List[Dict[str, Any]]:
+        """Search with SerpBase's real Google-SERP API and normalize its results.
+
+        Requires SERPBASE_API_KEY. SerpBase returns HTTP 200 even for
+        authentication/quota errors, with the failure indicated in the JSON
+        body's ``error`` field rather than the status code, so that field is
+        checked explicitly rather than relying on ``raise_for_status()`` alone.
+        """
+        api_key = os.environ.get("SERPBASE_API_KEY", "")
+        if not api_key:
+            raise RuntimeError(
+                "SERPBASE_API_KEY environment variable is not set. "
+                "Request a key at https://serpbase.dev."
+            )
+
+        country, _, language = region.partition("-")
+        payload = {"q": query, "gl": country or "us", "hl": language or "en"}
+
+        response = requests.post(
+            SERPBASE_SEARCH_URL,
+            json=payload,
+            headers={"X-API-Key": api_key},
+            timeout=30,
+        )
+        response.raise_for_status()
+        data = response.json()
+
+        if data.get("error"):
+            raise RuntimeError(f"SerpBase API error: {data['error']}")
+
+        organic = data.get("organic")
+        if not isinstance(organic, list):
+            raise RuntimeError("SerpBase response did not include organic results")
+
+        results = []
+        for item in organic:
+            if not isinstance(item, dict):
+                continue
+            link = item.get("link") or item.get("url")
+            if not isinstance(link, str) or not link:
+                continue
+            title = item.get("title")
+            snippet = item.get("snippet")
+            results.append(
+                {
+                    "title": title if isinstance(title, str) else "",
+                    "url": link,
+                    "snippet": snippet if isinstance(snippet, str) else "",
+                    "rank": item.get("rank", len(results) + 1),
+                }
+            )
+            if len(results) >= max_results:
+                break
+
+        return results
+
     def _search_with_fallback(
         self,
         query: str,
@@ -235,6 +302,28 @@ print(json.dumps(results))
 
             # Explicit providers fall back to DDGS auto today. Preserve that
             # contract without adding Parallel to the default provider chain.
+            backends_to_try = ["auto"]
+        elif backend == "serpbase":
+            attempted_backends.append("serpbase")
+            try:
+                results = self._search_with_serpbase(
+                    query=query, max_results=max_results, region=region
+                )
+                if results:
+                    return (
+                        results,
+                        "serpbase",
+                        attempted_backends,
+                        None,
+                        provider_errors,
+                    )
+                had_empty_success = True
+            except Exception as error:
+                last_error = str(error)
+                provider_errors["serpbase"] = str(error)
+
+            # Explicit providers fall back to DDGS auto today. Preserve that
+            # contract without adding SerpBase to the default provider chain.
             backends_to_try = ["auto"]
         elif backend == "auto":
             # Try the explicit DuckDuckGo backend first. It tends to fail with
@@ -484,6 +573,23 @@ print(json.dumps(results))
                         },
                     }
 
+            if backend == "serpbase" and safesearch != "moderate":
+                error_msg = (
+                    "The SerpBase backend does not support the safesearch "
+                    "control. Omit it or use a DDGS backend."
+                )
+                return {
+                    "status": "error",
+                    "error": error_msg,
+                    "data": {
+                        "status": "error",
+                        "error": error_msg,
+                        "query": query,
+                        "total_results": 0,
+                        "results": [],
+                    },
+                }
+
             # Validate max_results
             max_results = max(1, min(max_results, 50))  # Limit between 1-50
 
@@ -529,6 +635,8 @@ print(json.dumps(results))
                 }
                 if "parallel" in attempted_backends:
                     response["data"]["provider_notice"] = PARALLEL_PROVIDER_NOTICE
+                if "serpbase" in attempted_backends:
+                    response["data"]["provider_notice"] = SERPBASE_PROVIDER_NOTICE
                 return response
 
             # Add rate limiting to be respectful
@@ -547,6 +655,8 @@ print(json.dumps(results))
                 result_data["provider_errors"] = provider_errors
             if "parallel" in attempted_backends:
                 result_data["provider_notice"] = PARALLEL_PROVIDER_NOTICE
+            if "serpbase" in attempted_backends:
+                result_data["provider_notice"] = SERPBASE_PROVIDER_NOTICE
 
             return {"status": "success", "data": result_data}
 

--- a/tests/tools/test_web_search_tool.py
+++ b/tests/tools/test_web_search_tool.py
@@ -468,3 +468,323 @@ def test_api_documentation_search_enhances_query_once_without_mutating_input(
     assert result["data"]["search_type"] == "api_documentation"
     assert result["data"]["focus"] == "api_docs"
     assert arguments == original_arguments
+
+
+# --------------------------------------------------------------------------- #
+# SerpBase backend
+# --------------------------------------------------------------------------- #
+
+# Fixture shape from SerpBase's own documented example response
+# (https://serpbase.dev/docs), verified live against the real endpoint's
+# auth-error shape (200 OK + "error" field, not a 401) but not against a
+# real successful response -- no API key was available to confirm this.
+_SERPBASE_DOCUMENTED_RESPONSE = {
+    "status": 1000,
+    "request_id": "test-request-id",
+    "elapsed_ms": 120,
+    "credits_charged": 1,
+    "search_type": "search",
+    "query": "python asyncio",
+    "page": 1,
+    "organic": [
+        {
+            "rank": 1,
+            "title": "asyncio — Asynchronous I/O",
+            "link": "https://docs.python.org/3/library/asyncio.html",
+            "snippet": "asyncio is a library to write concurrent code.",
+        }
+    ],
+}
+
+
+class _FakeSerpBaseResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._payload
+
+
+@pytest.mark.unit
+def test_serpbase_search_requires_api_key(monkeypatch):
+    monkeypatch.delenv("SERPBASE_API_KEY", raising=False)
+    tool = _new_tool()
+
+    with pytest.raises(RuntimeError, match="SERPBASE_API_KEY"):
+        tool._search_with_serpbase(query="test", max_results=5)
+
+
+@pytest.mark.unit
+def test_serpbase_search_parses_documented_response_shape(monkeypatch):
+    monkeypatch.setenv("SERPBASE_API_KEY", "test-key")
+    captured = {}
+
+    def fake_post(url, *, json=None, headers=None, timeout=None):
+        captured["url"] = url
+        captured["json"] = json
+        captured["headers"] = headers
+        return _FakeSerpBaseResponse(_SERPBASE_DOCUMENTED_RESPONSE)
+
+    monkeypatch.setattr(web_search_tool.requests, "post", fake_post)
+
+    results = _new_tool()._search_with_serpbase(
+        query="python asyncio", max_results=5, region="us-en"
+    )
+
+    assert captured["url"] == "https://api.serpbase.dev/google/search"
+    assert captured["json"] == {"q": "python asyncio", "gl": "us", "hl": "en"}
+    assert captured["headers"] == {"X-API-Key": "test-key"}
+    assert results == [
+        {
+            "title": "asyncio — Asynchronous I/O",
+            "url": "https://docs.python.org/3/library/asyncio.html",
+            "snippet": "asyncio is a library to write concurrent code.",
+            "rank": 1,
+        }
+    ]
+
+
+@pytest.mark.unit
+def test_serpbase_search_splits_region_into_gl_and_hl(monkeypatch):
+    monkeypatch.setenv("SERPBASE_API_KEY", "test-key")
+    captured = {}
+
+    def fake_post(url, *, json=None, headers=None, timeout=None):
+        captured["json"] = json
+        return _FakeSerpBaseResponse({"organic": []})
+
+    monkeypatch.setattr(web_search_tool.requests, "post", fake_post)
+
+    _new_tool()._search_with_serpbase(query="x", max_results=1, region="cn-zh")
+
+    assert captured["json"]["gl"] == "cn"
+    assert captured["json"]["hl"] == "zh"
+
+
+@pytest.mark.unit
+def test_serpbase_search_raises_on_error_field_even_with_200(monkeypatch):
+    """SerpBase returns HTTP 200 even for auth failures, with the failure in
+    the JSON body's `error` field -- confirmed live against the real API."""
+    monkeypatch.setenv("SERPBASE_API_KEY", "wrong-key")
+
+    def fake_post(*args, **kwargs):
+        return _FakeSerpBaseResponse({"error": "unauthorized", "status": 1001})
+
+    monkeypatch.setattr(web_search_tool.requests, "post", fake_post)
+
+    with pytest.raises(RuntimeError, match="unauthorized"):
+        _new_tool()._search_with_serpbase(query="x", max_results=1)
+
+
+@pytest.mark.unit
+def test_serpbase_search_raises_on_missing_organic_key(monkeypatch):
+    monkeypatch.setenv("SERPBASE_API_KEY", "test-key")
+
+    def fake_post(*args, **kwargs):
+        return _FakeSerpBaseResponse({"status": 1000, "query": "x"})
+
+    monkeypatch.setattr(web_search_tool.requests, "post", fake_post)
+
+    with pytest.raises(RuntimeError, match="organic"):
+        _new_tool()._search_with_serpbase(query="x", max_results=1)
+
+
+@pytest.mark.unit
+def test_serpbase_search_skips_malformed_items_and_falls_back_to_url_field(
+    monkeypatch,
+):
+    monkeypatch.setenv("SERPBASE_API_KEY", "test-key")
+
+    def fake_post(*args, **kwargs):
+        return _FakeSerpBaseResponse(
+            {
+                "organic": [
+                    "not a dict",
+                    {"title": "No link at all"},
+                    {"title": "Uses url not link", "url": "https://example.com/u"},
+                    {"title": "Real result", "link": "https://example.com/real"},
+                ]
+            }
+        )
+
+    monkeypatch.setattr(web_search_tool.requests, "post", fake_post)
+
+    results = _new_tool()._search_with_serpbase(query="x", max_results=10)
+
+    assert [r["url"] for r in results] == [
+        "https://example.com/u",
+        "https://example.com/real",
+    ]
+    assert [r["rank"] for r in results] == [1, 2]
+
+
+@pytest.mark.unit
+def test_serpbase_search_truncates_to_max_results(monkeypatch):
+    monkeypatch.setenv("SERPBASE_API_KEY", "test-key")
+
+    def fake_post(*args, **kwargs):
+        return _FakeSerpBaseResponse(
+            {
+                "organic": [
+                    {"title": f"Result {i}", "link": f"https://example.com/{i}"}
+                    for i in range(10)
+                ]
+            }
+        )
+
+    monkeypatch.setattr(web_search_tool.requests, "post", fake_post)
+
+    results = _new_tool()._search_with_serpbase(query="x", max_results=3)
+
+    assert len(results) == 3
+
+
+@pytest.mark.unit
+def test_serpbase_backend_reports_success(monkeypatch):
+    tool = _new_tool()
+    monkeypatch.setattr(
+        tool,
+        "_search_with_serpbase",
+        lambda **kwargs: [
+            {
+                "title": "SerpBase result",
+                "url": "https://example.com",
+                "snippet": "excerpt",
+                "rank": 1,
+            }
+        ],
+    )
+
+    result = tool.run(
+        {
+            "query": "test query",
+            "backend": "serpbase",
+            "region": "us-en",
+            "safesearch": "moderate",
+        }
+    )
+
+    assert result["status"] == "success"
+    assert result["data"]["backend_used"] == "serpbase"
+    assert result["data"]["attempted_backends"] == ["serpbase"]
+    assert "api.serpbase.dev" in result["data"]["provider_notice"]
+    assert "patient-identifying" in result["data"]["provider_notice"]
+
+
+@pytest.mark.unit
+def test_serpbase_backend_rejects_unsupported_safesearch_control(monkeypatch):
+    tool = _new_tool()
+
+    def unexpected_call(**kwargs):
+        raise AssertionError("Unsupported controls must fail before transmission")
+
+    monkeypatch.setattr(tool, "_search_with_serpbase", unexpected_call)
+
+    result = tool.run(
+        {"query": "sensitive query", "backend": "serpbase", "safesearch": "off"}
+    )
+
+    assert result["status"] == "error"
+    assert "safesearch" in result["error"]
+    assert "does not support" in result["error"]
+
+
+@pytest.mark.unit
+def test_serpbase_backend_accepts_non_default_region(monkeypatch):
+    """Unlike Parallel, SerpBase supports region -- only safesearch is rejected."""
+    tool = _new_tool()
+    monkeypatch.setattr(
+        tool,
+        "_search_with_serpbase",
+        lambda **kwargs: [
+            {"title": "R", "url": "https://example.com", "snippet": "", "rank": 1}
+        ],
+    )
+
+    result = tool.run({"query": "test query", "backend": "serpbase", "region": "cn-zh"})
+
+    assert result["status"] == "success"
+    assert result["data"]["backend_used"] == "serpbase"
+
+
+@pytest.mark.unit
+def test_serpbase_backend_failure_falls_back_to_auto(monkeypatch):
+    tool = _new_tool()
+
+    def serpbase_fail(**kwargs):
+        raise RuntimeError("serpbase failed")
+
+    monkeypatch.setattr(tool, "_search_with_serpbase", serpbase_fail)
+    monkeypatch.setattr(
+        tool,
+        "_search_with_ddgs",
+        lambda **kwargs: [
+            {
+                "title": "Fallback result",
+                "url": "https://fallback.example",
+                "snippet": "from DDGS",
+                "rank": 1,
+            }
+        ],
+    )
+
+    result = tool.run({"query": "test query", "backend": "serpbase"})
+
+    assert result["status"] == "success"
+    assert result["data"]["backend_used"] == "auto"
+    assert result["data"]["attempted_backends"] == ["serpbase", "auto"]
+    assert result["data"]["provider_errors"]["serpbase"] == "serpbase failed"
+    assert "api.serpbase.dev" in result["data"]["provider_notice"]
+
+
+@pytest.mark.unit
+def test_serpbase_all_provider_failure_keeps_disclosure(monkeypatch):
+    tool = _new_tool()
+
+    def always_fail(**kwargs):
+        raise RuntimeError("simulated provider failure")
+
+    monkeypatch.setattr(tool, "_search_with_serpbase", always_fail)
+    monkeypatch.setattr(tool, "_search_with_ddgs", always_fail)
+    monkeypatch.setattr(tool, "_search_with_duckduckgo_html", always_fail)
+    monkeypatch.setattr(tool, "_search_with_wikipedia_api", always_fail)
+
+    result = tool.run({"query": "test query", "backend": "serpbase"})
+
+    assert result["status"] == "success"
+    assert result["data"]["backend_used"] == "none"
+    assert result["data"]["all_providers_failed"] is True
+    assert result["data"]["attempted_backends"][0] == "serpbase"
+    assert "api.serpbase.dev" in result["data"]["provider_notice"]
+
+
+@pytest.mark.unit
+def test_auto_backend_does_not_call_serpbase(monkeypatch):
+    tool = _new_tool()
+
+    def unexpected_call(**kwargs):
+        raise AssertionError("SerpBase must remain opt-in")
+
+    monkeypatch.setattr(tool, "_search_with_serpbase", unexpected_call)
+    monkeypatch.setattr(
+        tool,
+        "_search_with_ddgs",
+        lambda **kwargs: [
+            {
+                "title": "Default result",
+                "url": "https://default.example",
+                "snippet": "from default chain",
+                "rank": 1,
+            }
+        ],
+    )
+
+    result = tool.run({"query": "test query", "backend": "auto"})
+
+    assert result["status"] == "success"
+    assert result["data"]["backend_used"] == "duckduckgo"
+    assert "serpbase" not in result["data"]["attempted_backends"]
+    assert "provider_notice" not in result["data"]


### PR DESCRIPTION
## Summary

Fixes #564.

Adds `backend='serpbase'` to `web_search` / `web_api_documentation_search`: an opt-in real Google-SERP backend using SerpBase's API (https://api.serpbase.dev/google/search), for when DDGS's Google backend is unavailable or rate-limited.

## Root cause / motivation

DDGS's Google backend is unreliable/rate-limited in some environments. The issue proposed adding a real SERP API (SerpBase) as an alternative backend.

## Correction to the originally proposed request shape

The issue's proposed design didn't match SerpBase's actual live API. Verified directly against `https://api.serpbase.dev/google/search`:

| | Issue's proposal | Actual (verified live) |
|---|---|---|
| HTTP method | `GET` | `POST` (confirmed `GET` returns 405) |
| Results field | `organic_results` | `organic` |
| Result item fields | `position`, `url` | `rank`, `link` |
| Auth failure | (assumed non-2xx) | HTTP 200, with `error` in the JSON body |

Built against the verified-correct shape rather than the issue's description.

## Fix

- New `_search_with_serpbase()` method in `web_search_tool.py`: POSTs `{q, gl, hl}` (region split on `-` into country/language), checks the JSON body's `error` field explicitly (SerpBase returns 200 even on auth/quota failure), normalizes `organic` results (`link`→`url`, `rank`, `title`, `snippet`).
- Wired into `_search_with_fallback()`'s `serpbase` branch: falls back to the `auto` DDGS chain on any failure (missing key, API error, network error), mirroring the existing `parallel` backend's fallback behavior exactly.
- `run()` rejects non-default `safesearch` for `backend='serpbase'` (not supported by the API); `region` **is** supported (unlike `parallel`).
- `provider_notice` disclosure is attached whenever `serpbase` was attempted, same as for `parallel`.
- Added `SERPBASE_API_KEY` as an optional key in `web_search_tools.json` with `api_key_info`, and regenerated `.env.template` / `api_keys_catalog.json` via `scripts/gen_api_key_catalog.py`.

## Reproduction (before)

No `serpbase` backend existed; `backend='serpbase'` would have raised a schema validation error against the enum.

## Validation (after)

Live smoke test with no `SERPBASE_API_KEY` set (confirms clean fallback, no crash):

```
tu.run({"name": "web_search", "arguments": {"query": "test", "backend": "serpbase"}})
→ {'status': 'success', 'data': {..., 'backend_used': 'auto',
   'attempted_backends': ['serpbase', 'auto'],
   'provider_errors': {'serpbase': 'SERPBASE_API_KEY environment variable is not set...'},
   'provider_notice': "Query sent to SerpBase's hosted third-party Google-SERP API..."}}
```

Full `ToolUniverse().load_tools()` smoke test: 2716 tools loaded cleanly with `SERPBASE_API_KEY` unset (no regression from adding an optional key).

**Not yet verified**: an actual successful authenticated call. I wasn't able to complete SerpBase's account signup myself (no browser automation available on my end). Method, auth header, error-body shape, and field names were all confirmed live against the real (unauthenticated) endpoint plus their published docs — but a real search response has not been observed.

## Test coverage

13 new tests in `tests/tools/test_web_search_tool.py` (32 total, all passing): missing-key handling, response parsing against the documented shape, region splitting, `error`-field-with-200 handling, missing/malformed `organic` handling, truncation to `max_results`, `run()`-level success/fallback/safesearch-rejection, and that the `auto` chain never calls `serpbase` (matching the existing guarantee for `parallel`).
