### PR TITLE
fix: preserve encoded DuckDuckGo redirect targets

### DIFF
--- a/src/tooluniverse/web_search_tool.py
+++ b/src/tooluniverse/web_search_tool.py
@@ -8,7 +8,7 @@ import sys
 import time
 from html import unescape
 from typing import Any, Dict, List, Optional, Tuple
-from urllib.parse import parse_qs, unquote, urlparse
+from urllib.parse import parse_qs, urlparse
 
 import requests
 
@@ -448,7 +448,10 @@ print(json.dumps(results))
                 query_map = parse_qs(parsed.query)
                 uddg_values = query_map.get("uddg")
                 if uddg_values:
-                    parsed_href = unquote(uddg_values[0])
+                    # parse_qs already percent-decodes query values. Decoding a
+                    # second time corrupts destinations that intentionally
+                    # contain escaped reserved characters (for example %2B).
+                    parsed_href = uddg_values[0]
 
             clean_title = unescape(re.sub(r"<[^>]+>", "", raw_title)).strip()
             raw_snippet = snippets[index - 1] if index - 1 < len(snippets) else ""

--- a/tests/tools/test_web_search_tool.py
+++ b/tests/tools/test_web_search_tool.py
@@ -142,6 +142,30 @@ def test_web_search_falls_back_to_http_provider(monkeypatch):
 
 
 @pytest.mark.unit
+def test_duckduckgo_redirect_preserves_percent_encoded_destination_query(monkeypatch):
+    """parse_qs decodes uddg once; a second decode changes the destination."""
+    tool = _new_tool()
+
+    class FakeResponse:
+        text = (
+            '<a class="result__a" '
+            'href="/l/?uddg=https%3A%2F%2Fexample.org%2Fsearch%3Fq%3Da%252Bb">'
+            "Result</a>"
+        )
+
+        def raise_for_status(self):
+            return None
+
+    monkeypatch.setattr(
+        web_search_tool.requests, "get", lambda *args, **kwargs: FakeResponse()
+    )
+
+    results = tool._search_with_duckduckgo_html("query", max_results=1)
+
+    assert results[0]["url"] == "https://example.org/search?q=a%2Bb"
+
+
+@pytest.mark.unit
 def test_parallel_search_uses_mcp_and_normalizes_structured_results(monkeypatch):
     calls = {}
 


### PR DESCRIPTION
## Summary
- preserve the already-decoded `uddg` redirect target from DuckDuckGo HTML
- add a regression test for destination query strings containing encoded `+`

## Why
`parse_qs()` decodes `uddg` once. Decoding it again changes reserved characters in valid destination URLs, so search callers can receive a different query than the search engine linked.

## Validation
- `uv run --no-project --with-editable . --with pytest pytest tests/tools/test_web_search_tool.py -q --disable-warnings -o addopts=`: 33 passed, 32 warnings
- `git diff --check && uv run --no-project --with ruff ruff check --select F,E9 src/tooluniverse/web_search_tool.py tests/tools/test_web_search_tool.py`: passed

Static validation was limited to Ruff F/E9; the full repository lint profile was not established as passing.