### PR TITLE
fix: validate ClinicalTrials.gov NCT identifiers before lookup

### DIFF
--- a/src/tooluniverse/clinicaltrials_tool.py
+++ b/src/tooluniverse/clinicaltrials_tool.py
@@ -9,6 +9,8 @@ API: https://clinicaltrials.gov/data-api/api
 No authentication required. Public access.
 """
 
+import re
+
 import requests
 from typing import Any
 
@@ -181,11 +183,16 @@ class CTGovAPITool(BaseRESTTool):
 
     def _get_study(self, arguments: dict) -> dict:
         """Get full details for a single study by NCT ID."""
-        nct_id = arguments.get("nct_id", "").strip()
+        nct_id = arguments.get("nct_id", "").strip().upper()
         if not nct_id:
             return {
                 "status": "error",
                 "error": "nct_id parameter is required (e.g., 'NCT04280705')",
+            }
+        if not re.fullmatch(r"NCT\d{8}", nct_id):
+            return {
+                "status": "error",
+                "error": "nct_id must be an NCT identifier (e.g., 'NCT04280705')",
             }
 
         url = f"{CLINICALTRIALS_BASE}/studies/{nct_id}"

--- a/src/tooluniverse/ctg_tool.py
+++ b/src/tooluniverse/ctg_tool.py
@@ -621,9 +621,14 @@ class ClinicalTrialsTool(RESTfulTool):
         """Get full details for a single study by NCT ID."""
         import requests
 
-        nct_id = arguments.get("nct_id")
+        nct_id = str(arguments.get("nct_id") or "").strip().upper()
         if not nct_id:
             return {"status": "error", "error": "nct_id is required"}
+        if not re.fullmatch(r"NCT\d{8}", nct_id):
+            return {
+                "status": "error",
+                "error": "nct_id must be an NCT identifier (e.g., 'NCT04280705')",
+            }
 
         resp = requests.get(
             f"{self._BASE_URL}/studies/{nct_id}",

--- a/tests/unit/test_ctgov_nct_id_validation.py
+++ b/tests/unit/test_ctgov_nct_id_validation.py
@@ -1,0 +1,61 @@
+"""Regression tests for ClinicalTrials.gov single-study identifier handling."""
+
+from unittest.mock import patch
+
+from tooluniverse.clinicaltrials_tool import CTGovAPITool
+from tooluniverse.ctg_tool import ClinicalTrialsTool
+
+
+def _tool():
+    return CTGovAPITool(
+        {"name": "ClinicalTrials_get_study", "fields": {"operation": "get_study"}}
+    )
+
+
+def test_get_study_rejects_path_like_nct_id_before_request():
+    """A path segment can otherwise reach a different ClinicalTrials endpoint."""
+    with patch("tooluniverse.clinicaltrials_tool.requests.get") as get:
+        result = _tool().run({"nct_id": "../stats/size"})
+
+    assert result == {
+        "status": "error",
+        "error": "nct_id must be an NCT identifier (e.g., 'NCT04280705')",
+    }
+    get.assert_not_called()
+
+
+def test_get_study_normalizes_lowercase_nct_id():
+    """Valid identifiers remain usable when an agent emits a lowercase prefix."""
+    response = {
+        "protocolSection": {
+            "identificationModule": {"nctId": "NCT04280705"},
+        }
+    }
+    with patch("tooluniverse.clinicaltrials_tool.requests.get") as get:
+        get.return_value.json.return_value = response
+        get.return_value.raise_for_status.return_value = None
+        result = _tool().run({"nct_id": "nct04280705"})
+
+    assert result["status"] == "success"
+    assert result["metadata"]["nct_id"] == "NCT04280705"
+    assert get.call_args.args[0].endswith("/NCT04280705")
+
+
+def test_ctg_get_study_rejects_path_like_nct_id_before_request():
+    """The sibling ClinicalTrials wrapper must keep the same URL boundary."""
+    tool = ClinicalTrialsTool(
+        {
+            "name": "ClinicalTrials_get_study",
+            "parameter": {"type": "object", "properties": {}},
+            "query_schema": {},
+            "fields": {"operation": "get_study"},
+        }
+    )
+    with patch("requests.get") as get:
+        result = tool._run_get_study({"nct_id": "../stats/size"})
+
+    assert result == {
+        "status": "error",
+        "error": "nct_id must be an NCT identifier (e.g., 'NCT04280705')",
+    }
+    get.assert_not_called()


### PR DESCRIPTION
## Summary
- validate the single-study `nct_id` in both ClinicalTrials.gov wrappers before constructing its path
- normalize a lowercase `nct` prefix in the REST wrapper
- add regressions for path-like input in both request paths and lowercase valid IDs

## Why
`../stats/size` is normalized by the HTTP client to the public stats endpoint. Its 200 response is then parsed as an empty study and returned as a false success. NCT identifiers are fixed-format registry identifiers, so rejecting non-NCT values preserves evidence provenance and prevents endpoint confusion.

## Validation
- `uv run --no-project --with-editable . --with pytest pytest tests/unit/test_ctgov_nct_id_validation.py tests/unit/test_ctg_tool.py tests/unit/test_upstream_total_keys.py -q --disable-warnings -o addopts=`: 25 passed, 28 warnings
- `git diff --check && uv run --no-project --with ruff ruff check --select F,E9 src/tooluniverse/clinicaltrials_tool.py src/tooluniverse/ctg_tool.py tests/unit/test_ctgov_nct_id_validation.py`: passed

Static validation was limited to Ruff F/E9; the full repository lint profile was not established as passing.