### PR TITLE
fix: preserve Ensembl reverse-strand region coordinates

### DIFF
--- a/src/tooluniverse/ensembl_sequence_tool.py
+++ b/src/tooluniverse/ensembl_sequence_tool.py
@@ -9,6 +9,8 @@ API: https://rest.ensembl.org/
 No authentication required. Free public access.
 """
 
+import re
+
 import requests
 from typing import Dict, Any
 from .base_tool import BaseTool
@@ -86,8 +88,10 @@ class EnsemblSequenceTool(BaseTool):
                 "error": "region parameter is required (e.g., '17:7668421..7668520:1' or '17:7668421-7668520')",
             }
 
-        # Normalize region format: accept both 17:start-end and 17:start..end
-        region = region.replace("-", "..")
+        # Normalize only the coordinate separator. A global replacement also
+        # changes the documented reverse strand suffix (`:-1`) and any
+        # hyphens that belong to a contig name.
+        region = re.sub(r"(?<=:)(\d+)-(\d+)(?=:[^:]+$|$)", r"\1..\2", region)
 
         # Add strand if not present
         if region.count(":") < 2 and ".." in region:

--- a/tests/unit/test_ensembl_region_separator.py
+++ b/tests/unit/test_ensembl_region_separator.py
@@ -1,0 +1,49 @@
+"""Regression tests for Ensembl region-coordinate normalization."""
+
+from unittest.mock import patch
+
+from tooluniverse.ensembl_sequence_tool import EnsemblSequenceTool
+
+
+def _tool():
+    return EnsemblSequenceTool({"fields": {"endpoint": "region_sequence"}})
+
+
+def _response():
+    response = type("Response", (), {})()
+    response.raise_for_status = lambda: None
+    response.json = lambda: {"seq": "ACTG", "molecule": "dna", "id": "17:1..4"}
+    return response
+
+
+def test_region_sequence_preserves_reverse_strand_with_canonical_separator():
+    with patch(
+        "tooluniverse.ensembl_sequence_tool.requests.get", return_value=_response()
+    ) as get:
+        result = _tool().run({"region": "17:7668421..7668520:-1"})
+
+    assert result["status"] == "success"
+    assert result["data"]["region"] == "17:7668421..7668520:-1"
+    assert get.call_args.args[0].endswith("/17:7668421..7668520:-1")
+
+
+def test_region_sequence_converts_hyphen_coordinate_separator_on_forward_strand():
+    with patch(
+        "tooluniverse.ensembl_sequence_tool.requests.get", return_value=_response()
+    ) as get:
+        result = _tool().run({"region": "17:7668421-7668520"})
+
+    assert result["status"] == "success"
+    assert result["data"]["region"] == "17:7668421..7668520:1"
+    assert get.call_args.args[0].endswith("/17:7668421..7668520:1")
+
+
+def test_region_sequence_preserves_hyphenated_contig_name():
+    with patch(
+        "tooluniverse.ensembl_sequence_tool.requests.get", return_value=_response()
+    ) as get:
+        result = _tool().run({"region": "contig-name:100-200:-1"})
+
+    assert result["status"] == "success"
+    assert result["data"]["region"] == "contig-name:100..200:-1"
+    assert get.call_args.args[0].endswith("/contig-name:100..200:-1")


### PR DESCRIPTION
## Summary
- normalize only a hyphen used between region start and end coordinates
- preserve canonical `..` regions, reverse strand `-1`, and hyphens in contig names
- add regressions for canonical reverse, shorthand forward, and hyphenated-contig paths

## Why
The region endpoint documents `X:start..end:-1` as a valid reverse-strand request. The current global `replace('-', '..')` changes `:-1` into `:..1`, producing an invalid path. It also changes hyphens that are part of contig names.

## Validation
- `uv run --no-project --with-editable . --with pytest pytest tests/unit/test_ensembl_region_separator.py -q --disable-warnings -o addopts=`: 3 passed, 8 warnings
- `git diff --check && uv run --no-project --with ruff ruff check --select F,E9 src/tooluniverse/ensembl_sequence_tool.py tests/unit/test_ensembl_region_separator.py`: passed

Static validation was limited to Ruff F/E9; the full repository lint profile was not established as passing.