### PR TITLE
fix: finish UniProt mapping jobs containing only failed IDs

### DIFF
--- a/src/tooluniverse/uniprot_idmapping_tool.py
+++ b/src/tooluniverse/uniprot_idmapping_tool.py
@@ -133,7 +133,11 @@ class UniProtIDMappingTool(BaseTool):
             # Returning this embedded copy directly previously silently
             # truncated to UniProt's unpaginated default page size (25),
             # even when the job actually had hundreds of matches.
-            if status_data.get("jobStatus") == "FINISHED" or "results" in status_data:
+            if (
+                status_data.get("jobStatus") == "FINISHED"
+                or "results" in status_data
+                or "failedIds" in status_data
+            ):
                 break
             if status_data.get("jobStatus") == "ERROR":
                 msg = status_data.get("errorMessage", "Unknown error")

--- a/src/tooluniverse/uniprot_tool.py
+++ b/src/tooluniverse/uniprot_tool.py
@@ -571,7 +571,11 @@ class UniProtRESTTool(BaseTool):
 
                 job_status = status_data.get("jobStatus") or status_data.get("status")
 
-                if job_status == "FINISHED" or "results" in status_data:
+                if (
+                    job_status == "FINISHED"
+                    or "results" in status_data
+                    or "failedIds" in status_data
+                ):
                     resp, payload = status_resp, status_data
                     carried = status_data.get("results")
                     total = self._header_total(status_resp)

--- a/tests/unit/test_uniprot_failed_only_jobs.py
+++ b/tests/unit/test_uniprot_failed_only_jobs.py
@@ -1,0 +1,64 @@
+"""Completed ID-mapping jobs can contain only failedIds, without results."""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import requests
+
+from tooluniverse.uniprot_idmapping_tool import UniProtIDMappingTool
+from tooluniverse.uniprot_tool import UniProtRESTTool
+
+pytestmark = pytest.mark.unit
+
+
+def response(body):
+    result = requests.Response()
+    result.status_code = 200
+    result._content = json.dumps(body).encode()
+    return result
+
+
+@pytest.mark.parametrize("wrapper", ["mapping", "rest"])
+def test_failed_only_completed_job_returns_failed_ids_without_polling_again(wrapper):
+    """Unmappable inputs are a completed result, not a still-running job."""
+    failed_ids = ["NOTAREALACC99"]
+    if wrapper == "mapping":
+        tool = UniProtIDMappingTool(
+            {"name": "test", "fields": {"endpoint_type": "convert"}}
+        )
+        arguments = {
+            "ids": "NOTAREALACC99",
+            "from_db": "UniProtKB_AC-ID",
+            "to_db": "PDB",
+        }
+    else:
+        configs = json.loads(
+            (
+                Path(__file__).resolve().parents[2]
+                / "src/tooluniverse/data/uniprot_tools.json"
+            ).read_text()
+        )
+        tool = UniProtRESTTool(
+            next(config for config in configs if config["name"] == "UniProt_id_mapping")
+        )
+        arguments = {"ids": failed_ids, "from_db": "UniProtKB_AC-ID", "to_db": "PDB"}
+
+    with (
+        patch("requests.post", return_value=response({"jobId": "test-job"})),
+        patch(
+            "requests.get",
+            side_effect=lambda *args, **kwargs: response({"failedIds": failed_ids}),
+        ) as get,
+        patch(
+            "time.sleep", side_effect=AssertionError("completed jobs must not sleep")
+        ) as sleep,
+    ):
+        result = tool.run(arguments)
+
+    assert result["status"] == "success", result
+    assert result["data"]["results"] == []
+    assert result["data"]["failed_ids"] == failed_ids
+    sleep.assert_not_called()
+    assert sum("/status/" in call.args[0] for call in get.call_args_list) == 1


### PR DESCRIPTION
Treat a UniProt ID-mapping status containing only failedIds as completed in both wrappers. All-unmappable jobs should return their failed identifiers and an empty mapping result instead of polling until timeout. Regression tests exercise both public tool entrypoints; existing pagination and mixed-result tests remain green.

## Validation
- `uv run --no-project --with-editable . --with pytest pytest tests/unit/test_uniprot_failed_only_jobs.py -q --disable-warnings -o addopts=`: 2 passed, 2 warnings
- `git diff --check && uv run --no-project --with ruff ruff check --select F,E9 src/tooluniverse/uniprot_idmapping_tool.py src/tooluniverse/uniprot_tool.py tests/unit/test_uniprot_failed_only_jobs.py`: passed

Static validation was limited to Ruff F/E9; the full repository lint profile was not established as passing.