### PR TITLE
fix: validate DailyMed Set IDs before XML requests

### DIFF
--- a/src/tooluniverse/dailymed_tool.py
+++ b/src/tooluniverse/dailymed_tool.py
@@ -110,6 +110,10 @@ class GetSPLBySetIDTool(BaseTool):
         self.resource = tool_config.get("fields", {}).get("resource")
 
     def run(self, arguments):
+        setid = arguments.get("setid")
+        if not setid or not str(setid).strip():
+            return {"status": "error", "error": "setid parameter is required"}
+
         if self.resource in ("media", "history"):
             return self._get_resource(arguments)
         return self._get_full_spl(arguments)

--- a/tests/unit/test_drug_safety_clinical_depth.py
+++ b/tests/unit/test_drug_safety_clinical_depth.py
@@ -468,6 +468,18 @@ class TestDailyMedSPLHistory(unittest.TestCase):
         self.assertEqual(result["status"], "success")
         self.assertIn("xml", result)
 
+    def test_full_spl_missing_setid_is_a_local_validation_error(self):
+        """The XML path must not issue a request for a missing Set ID."""
+        from tooluniverse.dailymed_tool import GetSPLBySetIDTool
+
+        tool = GetSPLBySetIDTool({})
+        with patch("tooluniverse.dailymed_tool.requests.get") as get:
+            result = tool.run({})
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("setid parameter is required", result["error"])
+        get.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

DailyMed's full SPL XML branch issued `/spls/None.xml` before reaching the Set ID guard used by its JSON sub-resources. Validate missing or blank Set IDs before dispatching either branch, returning the existing structured input error without an HTTP request. This covers direct/raw tool calls; the generated schema already requires `setid`.

## Validation

- [ ] Full `ruff check` for touched files: existing legacy diagnostics remain; no full-file lint pass is claimed.
- [x] Relevant tests: 28 passed, 11 warnings (`test_drug_safety_clinical_depth.py`, `test_dailymed_search_spls_limit_alias.py`, `test_dailymed_null_and_headers.py`).
- [x] SDK/tool metadata regeneration: not applicable; the existing required parameter schema is unchanged.
- [x] HTTP calls are mocked; regression asserts that missing Set ID makes no request.
- `git diff --check`: passed.

## Checklist

- [x] User-facing problem and affected call path described above.
- [x] No docs/schema change needed: existing required `setid` contract is enforced consistently.
- [x] Added a regression for the full XML resource path.
- [x] No credentials, cached API responses, or generated artifacts committed.
