### PR TITLE
fix: preserve all sections of guideline abstracts

### DIFF
--- a/src/tooluniverse/unified_guideline_tools.py
+++ b/src/tooluniverse/unified_guideline_tools.py
@@ -4,7 +4,6 @@ Unified Guideline Tools
 Consolidated clinical guidelines search tools from multiple sources.
 """
 
-import html
 import requests
 import time
 import re
@@ -87,6 +86,16 @@ def _extract_meaningful_terms(query):
     }
     meaningful = [token for token in tokens if token not in stop_terms]
     return meaningful if meaningful else tokens
+
+
+def _abstract_text_from_sections(element: ET.Element) -> str:
+    """Flatten every structured abstract section, preserving inline text."""
+    sections = element.findall(".//AbstractText")
+    return " ".join(
+        "".join(section.itertext()).strip()
+        for section in sections
+        if "".join(section.itertext()).strip()
+    )
 
 
 @register_tool()
@@ -390,28 +399,28 @@ class PubMedGuidelinesTool(BaseTool):
             )
             abstract_response.raise_for_status()
 
-            # Parse abstracts from XML
-            import re
-
+            # Parse abstracts from XML.  PubMed commonly splits a structured
+            # abstract into several AbstractText nodes (Background, Methods,
+            # Results, Conclusions); treating the first match as the complete
+            # abstract drops the evidence callers need to assess a guideline.
             abstracts = {}
-            xml_text = abstract_response.text
-            # Extract abstracts for each PMID
+            if abstract_response.text.strip():
+                try:
+                    abstract_root = ET.fromstring(abstract_response.text)
+                    records = abstract_root.findall(".//PubmedArticle")
+                    records.extend(abstract_root.findall(".//PubmedBookArticle"))
+                    for record in records:
+                        pmid = record.findtext(".//PMID")
+                        if pmid:
+                            abstracts[pmid] = _abstract_text_from_sections(record)
+                except ET.ParseError as e:
+                    return {
+                        "status": "error",
+                        "error": f"Failed to parse PubMed abstract XML: {e}",
+                        "source": "PubMed",
+                    }
             for pmid in pmids:
-                # Find abstract text for this PMID
-                pmid_pattern = rf"<PMID[^>]*>{pmid}</PMID>.*?<AbstractText[^>]*>(.*?)</AbstractText>"
-                abstract_match = re.search(pmid_pattern, xml_text, re.DOTALL)
-                if abstract_match:
-                    # Clean HTML tags from abstract
-                    abstract = re.sub(r"<[^>]+>", "", abstract_match.group(1))
-                    # Fix-R7B-2/R7E-1: this regex-based extraction never
-                    # actually parses the XML, so entity references like
-                    # "&#x2265;" (confirmed present verbatim in PubMed's raw
-                    # efetch XML for "&#x2265;" / "&#xe7;" etc.) were left
-                    # undecoded, unlike PubMed_search_articles which uses a
-                    # real XML parser that resolves them automatically.
-                    abstracts[pmid] = html.unescape(abstract).strip()
-                else:
-                    abstracts[pmid] = ""
+                abstracts.setdefault(pmid, "")
 
             # Process results
             results = []
@@ -658,10 +667,12 @@ class EuropePMCGuidelinesTool(BaseTool):
 
             root = ET.fromstring(response.content)
 
-            # Find abstract text
-            abstract_elem = root.find(".//AbstractText")
-            if abstract_elem is not None:
-                return abstract_elem.text or ""
+            # PubMed structured abstracts may have multiple sections and
+            # inline markup; retain each section instead of the first node's
+            # direct text only.
+            abstract = _abstract_text_from_sections(root)
+            if abstract:
+                return abstract
 
             # Try alternative path
             abstract_elem = root.find(".//abstract")
@@ -670,6 +681,8 @@ class EuropePMCGuidelinesTool(BaseTool):
 
             return ""
 
+        except ET.ParseError as e:
+            raise ValueError(f"Failed to parse Europe PMC abstract XML: {e}") from e
         except Exception as e:
             return f"Error fetching abstract: {str(e)}"
 

--- a/tests/unit/test_guideline_multi_section_abstracts.py
+++ b/tests/unit/test_guideline_multi_section_abstracts.py
@@ -1,0 +1,83 @@
+"""Keep every section of structured abstracts used in guideline results."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.unified_guideline_tools import (
+    EuropePMCGuidelinesTool,
+    PubMedGuidelinesTool,
+)
+
+pytestmark = pytest.mark.unit
+
+
+_MULTI_SECTION_XML = (
+    "<PubmedArticleSet><PubmedArticle><MedlineCitation><PMID>123</PMID>"
+    "<Article><Abstract>"
+    '<AbstractText Label="BACKGROUND">Background <i>evidence</i>.</AbstractText>'
+    '<AbstractText Label="RESULTS">Results &amp; conclusions.</AbstractText>'
+    "</Abstract></Article></MedlineCitation></PubmedArticle></PubmedArticleSet>"
+)
+
+
+def test_pubmed_guideline_result_keeps_all_abstract_sections():
+    tool = PubMedGuidelinesTool({"name": "PubMed_Guidelines_Search"})
+    search = MagicMock()
+    search.json.return_value = {"esearchresult": {"idlist": ["123"], "count": "1"}}
+    summary = MagicMock()
+    summary.json.return_value = {
+        "result": {
+            "123": {
+                "title": "Evidence guideline for testing",
+                "authors": [],
+                "pubtype": ["Guideline"],
+                "source": "J Test",
+                "pubdate": "2026",
+                "elocationid": "",
+            }
+        }
+    }
+    abstract = MagicMock()
+    abstract.text = _MULTI_SECTION_XML
+
+    with (
+        patch.object(tool.session, "get", side_effect=[search, summary, abstract]),
+        patch("tooluniverse.unified_guideline_tools.time.sleep"),
+    ):
+        result = tool.run({"query": "evidence testing"})
+
+    assert (
+        result["data"][0]["abstract"] == "Background evidence. Results & conclusions."
+    )
+
+
+def test_europepmc_abstract_fetch_keeps_all_sections_and_inline_text():
+    tool = EuropePMCGuidelinesTool({"name": "EuropePMC_Guidelines_Search"})
+    response = MagicMock()
+    response.content = _MULTI_SECTION_XML.encode()
+    response.raise_for_status.return_value = None
+
+    with patch.object(tool.session, "get", return_value=response):
+        abstract = tool._get_europepmc_abstract("123")
+
+    assert abstract == "Background evidence. Results & conclusions."
+
+
+def test_pubmed_malformed_abstract_xml_returns_a_visible_error():
+    tool = PubMedGuidelinesTool({"name": "PubMed_Guidelines_Search"})
+    search = MagicMock()
+    search.json.return_value = {"esearchresult": {"idlist": ["123"], "count": "1"}}
+    summary = MagicMock()
+    summary.json.return_value = {"result": {"123": {}}}
+    abstract = MagicMock()
+    abstract.text = "<PubmedArticle><AbstractText>unterminated"
+
+    with (
+        patch.object(tool.session, "get", side_effect=[search, summary, abstract]),
+        patch("tooluniverse.unified_guideline_tools.time.sleep"),
+    ):
+        result = tool.run({"query": "evidence"})
+
+    assert result["status"] == "error"
+    assert "parse PubMed abstract XML" in result["error"]

--- a/tests/unit/test_pubmed_guidelines_book_records.py
+++ b/tests/unit/test_pubmed_guidelines_book_records.py
@@ -34,7 +34,7 @@ _SUMMARY_JSON = {
 _ABSTRACT_XML = (
     "<PubmedArticleSet><PubmedArticle><MedlineCitation><PMID>34787987</PMID>"
     "<Article><Abstract><AbstractText>Guidance on managing lead exposure."
-    "</AbstractText></Article></MedlineCitation></PubmedArticle></PubmedArticleSet>"
+    "</AbstractText></Abstract></Article></MedlineCitation></PubmedArticle></PubmedArticleSet>"
 )
 
 

--- a/tests/unit/test_pubmed_guidelines_entity_decoding.py
+++ b/tests/unit/test_pubmed_guidelines_entity_decoding.py
@@ -31,7 +31,7 @@ _ABSTRACT_XML = (
     "<PubmedArticleSet><PubmedArticle><MedlineCitation><PMID>123</PMID>"
     "<Article><Abstract><AbstractText>"
     "Criteria include NEWS/NEWS2 &#x2265; 5 and Shock Index &#x2265; 0.7."
-    "</AbstractText></Article></MedlineCitation></PubmedArticle></PubmedArticleSet>"
+    "</AbstractText></Abstract></Article></MedlineCitation></PubmedArticle></PubmedArticleSet>"
 )
 
 

--- a/tests/unit/test_pubmed_guidelines_envelope.py
+++ b/tests/unit/test_pubmed_guidelines_envelope.py
@@ -31,10 +31,14 @@ def _search_returning(pmids, count):
             **{p: {"title": "A guideline", "pubdate": "2026"} for p in pmids},
         }
     }
-    abstracts = "".join(
-        f"<PubmedArticle><PMID>{p}</PMID>"
-        f"<AbstractText>A guideline abstract</AbstractText></PubmedArticle>"
-        for p in pmids
+    abstracts = (
+        "<PubmedArticleSet>"
+        + "".join(
+            f"<PubmedArticle><PMID>{p}</PMID>"
+            f"<AbstractText>A guideline abstract</AbstractText></PubmedArticle>"
+            for p in pmids
+        )
+        + "</PubmedArticleSet>"
     )
 
     def fake_get(url, **kwargs):

--- a/tests/unit/test_pubmed_guidelines_total.py
+++ b/tests/unit/test_pubmed_guidelines_total.py
@@ -47,10 +47,14 @@ def _xml(text):
     return r
 
 
-ABSTRACTS = "".join(
-    f"<PubmedArticle><PMID>{pmid}</PMID>"
-    f"<AbstractText>Abstract {pmid}</AbstractText></PubmedArticle>"
-    for pmid in ("1", "2")
+ABSTRACTS = (
+    "<PubmedArticleSet>"
+    + "".join(
+        f"<PubmedArticle><PMID>{pmid}</PMID>"
+        f"<AbstractText>Abstract {pmid}</AbstractText></PubmedArticle>"
+        for pmid in ("1", "2")
+    )
+    + "</PubmedArticleSet>"
 )
 
 


### PR DESCRIPTION
## Summary

Preserve every AbstractText section and nested inline text for PubMed and Europe PMC guideline abstracts. The old paths could omit Results/Conclusions while still returning successful evidence. Use one shared XML flattening helper, retain entity decoding, and repair two incomplete synthetic XML fixtures.

## Validation

- [ ] Full touched-file `ruff check`: pre-existing diagnostics remain; no full-profile pass is claimed.
- [x] Relevant tests: 6 passed, 8 warnings.
- [x] Generated SDK/tool files: not applicable; tool metadata was not changed.
- [x] New tests isolate network requests with synthetic mocks.
- Targeted Ruff F/E9 and new-test formatting checks passed; `git diff --check` passed.

Commands:
```sh
uv run --no-project --with-editable . --with pytest pytest tests/unit/test_guideline_multi_section_abstracts.py tests/unit/test_pubmed_guidelines_entity_decoding.py tests/unit/test_pubmed_guidelines_book_records.py -q --disable-warnings -o addopts=
```

## Checklist

- [x] User-facing problem described above.
- [x] Existing schema/public API is retained; no separate documentation change is required for this correction.
- [x] Added regression tests for the affected behavior.
- [x] No credentials, cached API responses, or generated artifacts committed.

Nonempty malformed PubMed XML now produces a visible parse error. A valid response without an abstract can still have an empty abstract; no regex recovery is used.
