### PR TITLE
fix: retain biomedical query terms in guideline searches

### DIFF
--- a/src/tooluniverse/unified_guideline_tools.py
+++ b/src/tooluniverse/unified_guideline_tools.py
@@ -61,8 +61,17 @@ def _extract_meaningful_terms(query):
     if not isinstance(query, str):
         return []
 
-    # Keep alphabetic tokens with length >= 3
-    tokens = re.findall(r"[a-zA-Z]{3,}", query.lower())
+    # Keep connected biomedical identifiers as one token (COVID-19,
+    # HLA-B*57:01, IL-6) as well as Unicode terms.  Splitting at punctuation
+    # turns the numeric suffix into a broad substring filter (e.g. "2019"),
+    # which admits unrelated literature.  Numeric-only fragments are never
+    # useful evidence concepts, so discard them.
+    tokens = re.findall(r"[^\W_]+(?:[-*:/][^\W_]+)*", query.lower())
+    tokens = [
+        token
+        for token in tokens
+        if len(token) >= 2 and any(character.isalpha() for character in token)
+    ]
     stop_terms = {
         "management",
         "care",

--- a/tests/unit/test_guideline_query_terms.py
+++ b/tests/unit/test_guideline_query_terms.py
@@ -1,0 +1,58 @@
+"""Keep biomedical query terms intact for guideline relevance filtering."""
+
+import pytest
+
+from tooluniverse.unified_guideline_tools import _extract_meaningful_terms
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize(
+    ("query", "expected"),
+    [
+        ("H1N1", ["h1n1"]),
+        ("医疗", ["医疗"]),
+        ("COVID-19", ["covid-19"]),
+        ("HLA-B*57:01", ["hla-b*57:01"]),
+        ("IL-6", ["il-6"]),
+    ],
+)
+def test_meaningful_terms_support_alphanumeric_and_unicode_biomedical_queries(
+    query, expected
+):
+    assert _extract_meaningful_terms(query) == expected
+
+
+def test_pubmed_guideline_filter_does_not_admit_numeric_suffix_matches():
+    from unittest.mock import MagicMock, patch
+
+    from tooluniverse.unified_guideline_tools import PubMedGuidelinesTool
+
+    tool = PubMedGuidelinesTool({"name": "PubMed_Guidelines_Search"})
+    search = MagicMock()
+    search.json.return_value = {"esearchresult": {"idlist": ["1", "2"], "count": "2"}}
+    summary = MagicMock()
+    summary.json.return_value = {
+        "result": {
+            "1": {
+                "title": "COVID-19 clinical guideline",
+                "authors": [],
+                "pubtype": ["Guideline"],
+            },
+            "2": {
+                "title": "Health service report for 2019",
+                "authors": [],
+                "pubtype": ["Guideline"],
+            },
+        }
+    }
+    abstract = MagicMock()
+    abstract.text = ""
+
+    with (
+        patch.object(tool.session, "get", side_effect=[search, summary, abstract]),
+        patch("tooluniverse.unified_guideline_tools.time.sleep"),
+    ):
+        result = tool.run({"query": "COVID-19"})
+
+    assert [row["pmid"] for row in result["data"]] == ["1"]


### PR DESCRIPTION
## Summary

Retain Unicode and connected biomedical query terms in the guideline post-filter. Previously H1N1 and Chinese terms could disappear, disabling relevance filtering. Preserve identifiers such as COVID-19 and HLA-B*57:01 as complete terms and exclude numeric-only fragments.

## Validation

- [ ] Full touched-file `ruff check`: pre-existing diagnostics remain; no full-profile pass is claimed.
- [x] Relevant tests: 20 passed, 15 warnings.
- [x] Generated SDK/tool files: not applicable; tool metadata was not changed.
- [x] New tests isolate network requests with synthetic mocks.
- Targeted Ruff F/E9 and new-test formatting checks passed; `git diff --check` passed.

Commands:
```sh
uv run --no-project --with-editable . --with pytest pytest tests/unit/test_guideline_query_terms.py tests/unit/test_pubmed_guidelines_total.py tests/unit/test_who_guidelines_query_specific.py -q --disable-warnings -o addopts=
```

## Checklist

- [x] User-facing problem described above.
- [x] Existing schema/public API is retained; no separate documentation change is required for this correction.
- [x] Added regression tests for the affected behavior.
- [x] No credentials, cached API responses, or generated artifacts committed.

A public PubMed regression rejects a guideline that matches only 2019 for a COVID-19 query. This does not change upstream query syntax or ranking.
