### PR TITLE
fix: honor zero result limits in OpenAlex guideline search

### DIFF
--- a/src/tooluniverse/unified_guideline_tools.py
+++ b/src/tooluniverse/unified_guideline_tools.py
@@ -1408,6 +1408,9 @@ class OpenAlexGuidelinesTool(BaseTool):
 
     def _search_openalex_guidelines(self, query, limit, year_from=None, year_to=None):
         """Search for clinical guidelines using OpenAlex API."""
+        if limit == 0:
+            return _guideline_envelope([], total=0, retrieved=0, source="OpenAlex")
+
         try:
             # Build search query to focus on guidelines
             search_query = (

--- a/tests/unit/test_openalex_guidelines_zero_limit.py
+++ b/tests/unit/test_openalex_guidelines_zero_limit.py
@@ -1,0 +1,21 @@
+"""A zero result limit must not return or fetch guideline records."""
+
+from unittest.mock import patch
+
+import pytest
+
+from tooluniverse.unified_guideline_tools import OpenAlexGuidelinesTool
+
+pytestmark = pytest.mark.unit
+
+
+def test_zero_limit_returns_an_empty_guideline_envelope_without_a_request():
+    tool = OpenAlexGuidelinesTool({"name": "OpenAlex_Guidelines_Search"})
+
+    with patch("tooluniverse.unified_guideline_tools.requests.get") as get:
+        result = tool.run({"query": "sepsis", "limit": 0})
+
+    get.assert_not_called()
+    assert result["status"] == "success"
+    assert result["data"] == []
+    assert result["metadata"]["returned"] == 0


### PR DESCRIPTION
## Summary

Honor a schema-valid limit of zero in OpenAlex guideline search. Return the existing empty result envelope before making a request, so this request cannot accidentally return the first record or send per_page=0 upstream.

## Validation

- [ ] Full touched-file `ruff check`: pre-existing diagnostics remain; no full-profile pass is claimed.
- [x] Relevant tests: 25 passed, 6 warnings.
- [x] Generated SDK/tool files: not applicable; tool metadata was not changed.
- [x] New tests isolate network requests with synthetic mocks.
- Targeted Ruff F/E9 and new-test formatting checks passed; `git diff --check` passed.

Commands:
```sh
uv run --no-project --with-editable . --with pytest pytest tests/unit/test_openalex_guidelines_zero_limit.py tests/unit/test_guideline_search_totals.py -q --disable-warnings -o addopts=
```

## Checklist

- [x] User-facing problem described above.
- [x] Existing schema/public API is retained; no separate documentation change is required for this correction.
- [x] Added regression tests for the affected behavior.
- [x] No credentials, cached API responses, or generated artifacts committed.

This is limited to zero-result behavior; it does not add new negative-limit policy or fetch a total-match count.
